### PR TITLE
Fix a typo in the `Pipeline` class documentation.

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
@@ -39,7 +39,7 @@ import io.spine.server.storage.memory.InMemoryStorageFactory
  * A pipeline which processes the Protobuf files.
  *
  * A pipeline consists of the `Code Generation` context, which receives Protobuf compiler events,
- * and one ofr more [Renderer]s. A pipeline runs on a single source set.
+ * and one or more [Renderer]s. A pipeline runs on a single source set.
  *
  * The pipeline starts by building the `Code Generation` bounded context with the supplied
  * [Plugin]s. Then, the Protobuf compiler events are emitted and the subscribers in


### PR DESCRIPTION
Fix a small typo in the `Pipeline` class documentation: `orf` -> `of`.