### PR TITLE
Migrate to Spine v2.0

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -76,7 +76,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create" />
       <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -105,6 +105,9 @@
     <inspection_tool class="ClassIndependentOfModule" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassLoaderInstantiation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassMayBeInterface" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WEAK WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="ClassNamingConvention" enabled="true" level="INFO" enabled_by_default="true">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ spinePublishing {
 
 allprojects {
     group = "io.spine.protodata"
-    version = "0.0.8"
+    version = "0.0.9"
 
     repositories.applyStandard()
 }

--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package dart
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package dart
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,12 +30,13 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version     = "1.35.1"
-    const val core        = "io.grpc:grpc-core:${version}"
-    const val stub        = "io.grpc:grpc-stub:${version}"
-    const val okHttp      = "io.grpc:grpc-okhttp:${version}"
-    const val protobuf    = "io.grpc:grpc-protobuf:${version}"
-    const val netty       = "io.grpc:grpc-netty:${version}"
-    const val nettyShaded = "io.grpc:grpc-netty-shaded:${version}"
-    const val context     = "io.grpc:grpc-context:${version}"
+    const val version        = "1.38.0"
+    const val core           = "io.grpc:grpc-core:${version}"
+    const val stub           = "io.grpc:grpc-stub:${version}"
+    const val okHttp         = "io.grpc:grpc-okhttp:${version}"
+    const val protobuf       = "io.grpc:grpc-protobuf:${version}"
+    const val netty          = "io.grpc:grpc-netty:${version}"
+    const val nettyShaded    = "io.grpc:grpc-netty-shaded:${version}"
+    const val context        = "io.grpc:grpc-context:${version}"
+    const val protobufPlugin = "io.grpc:protoc-gen-grpc-java:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.0-RC"
+    const val version      = "1.5.0"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.15.7"
+    const val version    = "3.17.0"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
@@ -37,7 +37,7 @@ object Protobuf {
     const val compiler = "com.google.protobuf:protoc:${version}"
 
     object GradlePlugin {
-        const val version = "0.8.13"
+        const val version = "0.8.16"
         const val id = "com.google.protobuf"
         const val lib = "com.google.protobuf:protobuf-gradle-plugin:${version}"
     }

--- a/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
@@ -27,7 +27,7 @@
 package io.spine.protodata
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
-import io.spine.base.Production
+import io.spine.environment.Production
 import io.spine.logging.Logging
 import io.spine.protodata.events.CompilerEvents
 import io.spine.protodata.plugin.Plugin

--- a/compiler/src/main/kotlin/io/spine/protodata/ProtoSourceFileView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/ProtoSourceFileView.kt
@@ -38,19 +38,25 @@ internal class ProtoSourceFileView
     : View<FilePath, ProtobufSourceFile, ProtobufSourceFile.Builder>() {
 
     @Subscribe
-    internal fun on(@External e: FileEntered) = update {
-        filePath = e.file.path
-        file = e.file
+    internal fun on(@External e: FileEntered) {
+        update {
+            filePath = e.file.path
+            file = e.file
+        }
     }
 
     @Subscribe
-    internal fun on(@External e: FileOptionDiscovered) = update {
-        fileBuilder.addOption(e.option)
+    internal fun on(@External e: FileOptionDiscovered) {
+        update {
+            fileBuilder.addOption(e.option)
+        }
     }
 
     @Subscribe
-    internal fun on(@External e: TypeEntered) = update {
-        putType(e.type.typeUrl(), e.type)
+    internal fun on(@External e: TypeEntered) {
+        update {
+            putType(e.type.typeUrl(), e.type)
+        }
     }
 
     @Subscribe
@@ -86,8 +92,10 @@ internal class ProtoSourceFileView
     }
 
     @Subscribe
-    internal fun on(@External e: EnumEntered) = update {
-        putEnumType(e.type.typeUrl(), e.type)
+    internal fun on(@External e: EnumEntered) {
+        update {
+            putEnumType(e.type.typeUrl(), e.type)
+        }
     }
 
     @Subscribe
@@ -107,8 +115,10 @@ internal class ProtoSourceFileView
     }
 
     @Subscribe
-    internal fun on(@External e: ServiceEntered) = update {
-        putService(e.service.typeUrl(), e.service)
+    internal fun on(@External e: ServiceEntered) {
+        update {
+            putService(e.service.typeUrl(), e.service)
+        }
     }
 
     @Subscribe

--- a/compiler/src/main/kotlin/io/spine/protodata/QueryingClient.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/QueryingClient.kt
@@ -40,7 +40,7 @@ import java.util.*
 /**
  * A builder for queries to the entities defined on top of the Protobuf compiler events.
  */
-public class QueryingClient<T : EntityState>
+public class QueryingClient<T : EntityState<*>>
 internal constructor(
     private val context: BoundedContext,
     private val type: Class<T>,
@@ -101,7 +101,7 @@ internal constructor(
  *
  * The observer persists the [found result][foundResult] as a list of messages.
  */
-private class Observer<T : EntityState>(
+private class Observer<T : EntityState<*>>(
     private val type: Class<T>
 ) : StreamObserver<QueryResponse> {
 

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -101,7 +101,7 @@ public abstract class Policy<E : EventMessage> : AbstractEventReactor(), Logging
      * This method is targeted for Java API users. If you use Kotlin, see the no-param overload for
      * prettier code.
      */
-    protected fun <P : EntityState> select(type: Class<P>): QueryingClient<P> {
+    protected fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> {
         return QueryingClient(context!!, type, javaClass.name)
     }
 
@@ -110,7 +110,7 @@ public abstract class Policy<E : EventMessage> : AbstractEventReactor(), Logging
      *
      * Users may create their own views and submit them via a [io.spine.protodata.plugin.Plugin].
      */
-    protected inline fun <reified P : EntityState> select(): QueryingClient<P> {
+    protected inline fun <reified P : EntityState<*>> select(): QueryingClient<P> {
         val cls = P::class.java
         return select(cls)
     }

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/View.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/View.kt
@@ -27,13 +27,13 @@
 package io.spine.protodata.plugin
 
 import io.spine.base.EntityState
-import io.spine.protobuf.ValidatingBuilder
 import io.spine.server.DefaultRepository
 import io.spine.server.projection.Projection
 import io.spine.server.projection.ProjectionRepository
 import io.spine.server.projection.model.ProjectionClass
 import io.spine.server.route.EventRoute
 import io.spine.server.route.EventRouting
+import io.spine.validate.ValidatingBuilder
 
 /**
  * A view on the Protobuf sources.
@@ -76,7 +76,7 @@ import io.spine.server.route.EventRouting
  * @param M the type of the view's state; must be a Protobuf message
  * @param B the type of the view's state builder; must match `<M>`
  */
-public open class View<I, M : EntityState, B : ValidatingBuilder<M>> : Projection<I, M, B>()
+public open class View<I, M : EntityState<I>, B : ValidatingBuilder<M>> : Projection<I, M, B>()
 
 /**
  * A repository responsible for a certain type of [View]s.
@@ -90,14 +90,14 @@ public open class View<I, M : EntityState, B : ValidatingBuilder<M>> : Projectio
  * If no customization is required from a `ViewRepository`, users should prefer
  * [ViewRepository.default] to creating custom repository types.
  */
-public open class ViewRepository<I, V : View<I, S, *>, S : EntityState>
+public open class ViewRepository<I, V : View<I, S, *>, S : EntityState<I>>
     : ProjectionRepository<I, V, S>() {
 
     internal companion object {
 
         @Suppress("UNCHECKED_CAST")
         fun default(cls: Class<out View<*, *, *>>): ViewRepository<*, *, *> {
-            val cast = cls as Class<View<Any, EntityState, *>>
+            val cast = cls as Class<View<Any, EntityState<Any>, *>>
             return DefaultViewRepository(cast)
         }
     }
@@ -115,10 +115,10 @@ public open class ViewRepository<I, V : View<I, S, *>, S : EntityState>
  * should use `DefaultViewRepository` by calling [ViewRepository.default].
  */
 internal class DefaultViewRepository(
-    private val cls: Class<View<Any, EntityState, *>>
-) : ViewRepository<Any, View<Any, EntityState, *>, EntityState>(), DefaultRepository {
+    private val cls: Class<View<Any, EntityState<Any>, *>>
+) : ViewRepository<Any, View<Any, EntityState<Any>, *>, EntityState<Any>>(), DefaultRepository {
 
-    override fun entityModelClass(): ProjectionClass<View<Any, EntityState, *>> =
+    override fun entityModelClass(): ProjectionClass<View<Any, EntityState<Any>, *>> =
         ProjectionClass.asProjectionClass(cls)
 
     override fun logName(): String =

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
@@ -69,9 +69,15 @@ public sealed class LineNumber {
          * Creates a `LineNumber` pointing at a given line.
          */
         @JvmStatic
-        // TODO:2021-05-17:dmytro.dashenkov: Should be a UInt. Migrate to unsigned when issue
-        //  resolved: https://youtrack.jetbrains.com/issue/KT-46725
         public fun at(number: Int): LineNumber = LineIndex(number)
+
+        /**
+         * Creates a `LineNumber` pointing at the start of the file.
+         *
+         * This is a convenience method equivalent to calling `at(0)`.
+         */
+        @JvmStatic
+        public fun startOfFile(): LineNumber = at(0)
 
         /**
          * Creates a `LineNumber` pointing at the end of the file, no matter the index of the actual
@@ -90,9 +96,12 @@ public sealed class LineNumber {
 
 /**
  * A [LineNumber] pointing at a particular line.
+ *
+ * Implementation note. We do not use unsigned integers here by design. `UInt`s in Kotlin are
+ * designed to only provide the whole bit range, not to insure invariants.
+ * See [this thread](https://youtrack.jetbrains.com/issue/KT-46144) for more details.
  */
 internal data class LineIndex constructor(val value: Int) : LineNumber() {
-
     init {
         if (value < 0) {
             throw IndexOutOfBoundsException("Invalid line number: `$value`.")

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -72,7 +72,7 @@ protected constructor(
      * This method is targeted for Java API users. If you use Kotlin, see the no-param overload for
      * prettier code.
      */
-    protected fun <P : EntityState> select(type: Class<P>): QueryingClient<P> {
+    protected fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> {
         return QueryingClient(protoDataContext, type, javaClass.name)
     }
 
@@ -81,7 +81,7 @@ protected constructor(
      *
      * Users may create their own views and submit them via a [io.spine.protodata.plugin.Plugin].
      */
-    protected inline fun <reified P : EntityState> select(): QueryingClient<P> {
+    protected inline fun <reified P : EntityState<*>> select(): QueryingClient<P> {
         val cls = P::class.java
         return select(cls)
     }

--- a/compiler/src/test/kotlin/io/spine/protodata/ContextTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ContextTest.kt
@@ -34,7 +34,7 @@ import io.spine.protobuf.AnyPacker
 import io.spine.protodata.PrimitiveType.TYPE_BOOL
 import io.spine.protodata.events.CompilerEvents
 import io.spine.protodata.test.DoctorProto
-import io.spine.testing.server.blackbox.BlackBoxContext
+import io.spine.testing.server.blackbox.BlackBox
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat as assertMessage
@@ -49,7 +49,7 @@ class `'Code Generation' context should` {
 
     @Test
     fun `construct 'ProtobufSource' based on a descriptor set`() {
-        val ctx = BlackBoxContext.from(CodeGenerationContext.builder())
+        val ctx = BlackBox.from(CodeGenerationContext.builder())
         val protoDescriptor = DoctorProto.getDescriptor().toProto()
         val set = CodeGeneratorRequest
             .newBuilder()

--- a/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
@@ -121,7 +121,7 @@ class `'Pipeline' should` {
 
     @Test
     fun `delete files`() {
-        val sourceFile = write("io/spine/protodata/test/_DeleteMe.java", "foo bar")
+        val sourceFile = write("io/spine/protodata/test/DeleteMe_.java", "foo bar")
         Pipeline(
             listOf(TestPlugin()),
             listOf(DeletingRenderer()),
@@ -135,7 +135,7 @@ class `'Pipeline' should` {
     @Test
     fun `write into insertion points`() {
         val initialContent = "foo bar"
-        val sourceFile = write("io/spine/protodata/test/_DeleteMe.java", initialContent)
+        val sourceFile = write("io/spine/protodata/test/DeleteMe_.java", initialContent)
         val renderer = PrependingRenderer()
         Pipeline(
             listOf(TestPlugin()),

--- a/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
@@ -147,6 +147,7 @@ class `'Pipeline' should` {
             .isEqualTo("""
                 // INSERT:'file_start'
                 Hello from ${renderer.javaClass.name}
+                // INSERT:'file_middle'
                 $initialContent
                 // INSERT:'file_end'
             """.trimIndent())

--- a/testutil/build.gradle.kts
+++ b/testutil/build.gradle.kts
@@ -24,12 +24,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.generateProtoTasks
+import com.google.protobuf.gradle.plugins
+import com.google.protobuf.gradle.protobuf
+import io.spine.gradle.internal.Grpc
+
 dependencies {
     implementation(project(":compiler"))
+    implementation(Grpc.stub)
+    implementation(Grpc.protobuf)
 }
 
-spine.enableJava {
-    codegen {
-        grpc = true
+val grpcPluginName = "grpc"
+
+protobuf {
+    generateProtoTasks {
+        all().whenTaskAdded {
+            plugins {
+                maybeCreate(grpcPluginName)
+            }
+        }
     }
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
@@ -38,9 +38,11 @@ import io.spine.server.route.EventRouting
 public class DeletedTypeView : View<TypeName, DeletedType, DeletedType.Builder>() {
 
     @Subscribe
-    internal fun to(@External event: TypeEntered) = update {
-        name = event.type.name
-        type = event.type
+    internal fun to(@External event: TypeEntered) {
+        update {
+            name = event.type.name
+            type = event.type
+        }
     }
 }
 

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
@@ -51,7 +51,7 @@ public class DeletedTypeRepository
         super.setupEventRouting(routing)
         routing.route(TypeEntered::class.java) { e, _ ->
             val name = e.type.name
-            return@route if (name.simpleName.startsWith("_")) {
+            return@route if (name.simpleName.endsWith("_")) {
                 setOf(name)
             } else {
                 setOf()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DeletedTypeView.kt
@@ -32,15 +32,15 @@ import io.spine.protodata.TypeEntered
 import io.spine.protodata.TypeName
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
+import io.spine.server.entity.update
 import io.spine.server.route.EventRouting
 
 public class DeletedTypeView : View<TypeName, DeletedType, DeletedType.Builder>() {
 
     @Subscribe
-    internal fun to(@External event: TypeEntered) {
-        builder()
-            .setName(event.type.name)
-            .setType(event.type)
+    internal fun to(@External event: TypeEntered) = update {
+        name = event.type.name
+        type = event.type
     }
 }
 

--- a/testutil/src/main/kotlin/io/spine/protodata/test/InternalMessageView.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/InternalMessageView.kt
@@ -32,6 +32,7 @@ import io.spine.protodata.TypeEntered
 import io.spine.protodata.TypeName
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
+import io.spine.server.entity.update
 import io.spine.server.route.EventRoute.withId
 import io.spine.server.route.EventRouting
 
@@ -39,8 +40,8 @@ public class InternalMessageView
     : View<TypeName, InternalType, InternalType.Builder>() {
 
     @Subscribe
-    internal fun on(@External e: TypeEntered) {
-        builder().name = e.type.name
+    internal fun on(@External e: TypeEntered) = update {
+        name = e.type.name
     }
 }
 

--- a/testutil/src/main/kotlin/io/spine/protodata/test/InternalMessageView.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/InternalMessageView.kt
@@ -40,8 +40,10 @@ public class InternalMessageView
     : View<TypeName, InternalType, InternalType.Builder>() {
 
     @Subscribe
-    internal fun on(@External e: TypeEntered) = update {
-        name = e.type.name
+    internal fun on(@External e: TypeEntered) {
+        update {
+            name = e.type.name
+        }
     }
 }
 

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
@@ -41,7 +41,10 @@ public class JavaGenericInsertionPointPrinter : InsertionPointPrinter(
 public enum class GenericInsertionPoint : InsertionPoint {
 
     FILE_START {
-        override fun locate(lines: List<String>): LineNumber = LineNumber.at(0)
+        override fun locate(lines: List<String>): LineNumber = LineNumber.startOfFile()
+    },
+    FILE_MIDDLE {
+        override fun locate(lines: List<String>): LineNumber = LineNumber.at(lines.size / 2)
     },
     FILE_END {
         override fun locate(lines: List<String>): LineNumber = LineNumber.endOfFile()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
@@ -26,17 +26,17 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 import io.spine.protodata.theOnly
 import kotlin.io.path.name
 
-public class PrependingRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.Java)) {
+public class PrependingRenderer : Renderer(supportedLanguages = setOf(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val file = sources
-            .filter { it.path.name.startsWith("_") }
+            .filter { it.path.name.endsWith("_.java") }
             .theOnly()
         file.at(GenericInsertionPoint.FILE_START)
             .add("Hello from ${this.javaClass.name}")

--- a/testutil/src/main/proto/spine/protodata/test/doctor.proto
+++ b/testutil/src/main/proto/spine/protodata/test/doctor.proto
@@ -87,11 +87,11 @@ service DoctorsPhone {
     rpc which_actor(stream Episode) returns (stream spine.people.PersonName);
 }
 
-// A test type starting with an underscore.
+// A test type ending with an underscore.
 //
 // In tests, the files generated from this type are deleted from the source set.
 //
 // Please, DO NOT delete this type.
 //
-message _DeleteMe {
+message DeleteMe_ {
 }


### PR DESCRIPTION
In this PR we migrate ProtoData to Spine 2.0.

Spine 2.0 is currently in pre-release development phase. However, we need some bug fixes from the latest version.