### PR TITLE
Java-friendly SPI anatomy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ spinePublishing {
 
 allprojects {
     group = "io.spine.protodata"
-    version = "0.0.9"
+    version = "0.0.10"
 
     repositories.applyStandard()
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import io.spine.annotation.Internal
 import io.spine.environment.Production
 import io.spine.logging.Logging
 import io.spine.protodata.events.CompilerEvents
@@ -50,6 +51,7 @@ import io.spine.server.transport.memory.InMemoryTransportFactory
  * in the `Code Generation` context, alters the source set. This may include creating new files,
  * modifying, or deleting existing ones. Lastly, the source set is stored back onto the file system.
  */
+@Internal
 public class Pipeline(
     private val plugins: List<Plugin>,
     private val renderers:  List<Renderer>,

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -42,35 +42,36 @@ import io.spine.server.BoundedContextBuilder
 public interface Plugin {
 
     /**
-     * The [views][View] added by this plugin represented via their [repositories][ViewRepository].
+     * Obtains the [views][View] added by this plugin represented via their
+     * [repositories][ViewRepository].
      *
      * A [View] may not have a need for repository. In such case, use [Plugin.views] instead.
      */
-    public val viewRepositories: Set<ViewRepository<*, *, *>>
-        get() = setOf()
+    public fun viewRepositories(): Set<ViewRepository<*, *, *>> =
+        setOf()
 
     /**
-     * The [views][View] added by this plugin represented via their classes.
+     * Obtains the [views][View] added by this plugin represented via their classes.
      *
      * A [View] may require a repository to route events. In such case, use
      * [Plugin.viewRepositories] instead.
      */
-    public val views: Set<Class<out View<*, *, *>>>
-        get() = setOf()
+    public fun views(): Set<Class<out View<*, *, *>>> =
+        setOf()
 
     /**
-     * The [policies][Policy] added by this plugin.
+     * Obtains the [policies][Policy] added by this plugin.
      */
-    public val policies: Set<Policy<*>>
-        get() = setOf()
+    public fun policies(): Set<Policy<*>> =
+        setOf()
 }
 
 /**
  * Applies the given plugin to the receiver bounded context.
  */
 internal fun BoundedContextBuilder.apply(plugin: Plugin) {
-    val repos = plugin.viewRepositories.toMutableList()
-    val defaultRepos = plugin.views.map { ViewRepository.default(it) }
+    val repos = plugin.viewRepositories().toMutableList()
+    val defaultRepos = plugin.views().map { ViewRepository.default(it) }
     repos.addAll(defaultRepos)
     val repeatedView = repos.map { it.entityClass() }
                             .groupingBy { it }
@@ -85,7 +86,7 @@ internal fun BoundedContextBuilder.apply(plugin: Plugin) {
         )
     }
     repos.forEach(this::add)
-    plugin.policies.forEach {
+    plugin.policies().forEach {
         addEventDispatcher(it)
     }
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.plugin
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.ConfigurationError
 import io.spine.server.BoundedContextBuilder
 
@@ -47,8 +48,8 @@ public interface Plugin {
      *
      * A [View] may not have a need for repository. In such case, use [Plugin.views] instead.
      */
-    public fun viewRepositories(): Set<ViewRepository<*, *, *>> =
-        setOf()
+    public fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> =
+        ImmutableSet.of()
 
     /**
      * Obtains the [views][View] added by this plugin represented via their classes.
@@ -56,14 +57,14 @@ public interface Plugin {
      * A [View] may require a repository to route events. In such case, use
      * [Plugin.viewRepositories] instead.
      */
-    public fun views(): Set<Class<out View<*, *, *>>> =
-        setOf()
+    public fun views(): ImmutableSet<Class<out View<*, *, *>>> =
+        ImmutableSet.of()
 
     /**
      * Obtains the [policies][Policy] added by this plugin.
      */
-    public fun policies(): Set<Policy<*>> =
-        setOf()
+    public fun policies(): ImmutableSet<Policy<*>> =
+        ImmutableSet.of()
 }
 
 /**

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
@@ -50,17 +50,17 @@ public abstract class InsertionPointPrinter(
      *
      * The property getter may use [Renderer.select] to find out more info about the message types.
      */
-    protected abstract val supportedInsertionPoints: Set<InsertionPoint>
+    protected abstract fun supportedInsertionPoints(): Set<InsertionPoint>
 
     final override fun doRender(sources: SourceSet) {
         sources.prepareCode { file ->
             val lines = file.lines().toMutableList()
-            supportedInsertionPoints.forEach { point ->
+            supportedInsertionPoints().forEach { point ->
                 val lineNumber = point.locate(lines)
                 val comment = target.comment(point.codeLine)
                 when(lineNumber) {
                     is LineIndex -> {
-                        val index = lineNumber.value.toInt()
+                        val index = lineNumber.value
                         checkPositionIndex(index, lines.size, "Line number")
                         lines.add(index, comment)
                     }

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata.renderer
 
 import com.google.common.base.Preconditions.checkPositionIndex
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.Language
 
 /**
@@ -43,14 +44,14 @@ import io.spine.protodata.language.Language
  */
 public abstract class InsertionPointPrinter(
     private val target: Language
-) : Renderer(setOf(target)) {
+) : Renderer(ImmutableSet.of(target)) {
 
     /**
      * [InsertionPoint]s which could be added to source code by this `InsertionPointPrinter`.
      *
      * The property getter may use [Renderer.select] to find out more info about the message types.
      */
-    protected abstract fun supportedInsertionPoints(): Set<InsertionPoint>
+    protected abstract fun supportedInsertionPoints(): ImmutableSet<InsertionPoint>
 
     final override fun doRender(sources: SourceSet) {
         sources.prepareCode { file ->

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.renderer
 
+import com.google.common.collect.ImmutableSet
 import io.spine.base.EntityState
 import io.spine.protodata.QueryingClient
 import io.spine.protodata.language.Language
@@ -40,7 +41,7 @@ import io.spine.server.BoundedContext
  */
 public abstract class Renderer
 protected constructor(
-    private val supportedLanguages: Set<Language>
+    private val supportedLanguages: ImmutableSet<Language>
 ) {
 
     internal lateinit var protoDataContext: BoundedContext

--- a/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata
 
+import com.google.common.collect.ImmutableSet
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.protodata.renderer.SourceSet
@@ -210,7 +211,7 @@ class `'Pipeline' should` {
         fun `a policy handles too many events at once`() {
             val policy = GreedyPolicy()
             val pipeline = Pipeline(
-                listOf(DocilePlugin(policies = setOf(policy))),
+                listOf(DocilePlugin(policies = ImmutableSet.of(policy))),
                 listOf(renderer),
                 SourceSet.fromContentsOf(srcRoot),
                 request
@@ -226,8 +227,8 @@ class `'Pipeline' should` {
             val viewClass = DeletedTypeView::class.java
             val pipeline = Pipeline(
                 listOf(DocilePlugin(
-                    views = setOf(viewClass),
-                    viewRepositories = setOf(DeletedTypeRepository())
+                    views = ImmutableSet.of(viewClass),
+                    viewRepositories = ImmutableSet.of(DeletedTypeRepository())
                 )),
                 listOf(renderer),
                 SourceSet.fromContentsOf(srcRoot),

--- a/testutil/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
@@ -26,7 +26,8 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import com.google.common.collect.ImmutableSet
+import io.spine.protodata.language.CommonLanguages.any
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
@@ -37,7 +38,7 @@ import io.spine.protodata.renderer.SourceSet
  * Releases the proverbial Schrödinger's cat (insertion points) out of the box by observing
  * the code.
  */
-public class CatOutOfTheBoxEmancipator : Renderer(supportedLanguages = setOf(CommonLanguages.any)) {
+public class CatOutOfTheBoxEmancipator : Renderer(supportedLanguages = ImmutableSet.of(any)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
@@ -26,13 +26,14 @@
 
 package io.spine.protodata.test
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.javaFile
-import io.spine.protodata.language.CommonLanguages
+import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class DeletingRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.Java)) {
+public class DeletingRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val types = select<DeletedType>().all()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.test
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.Policy
 import io.spine.protodata.plugin.View
@@ -35,14 +36,14 @@ import io.spine.protodata.plugin.ViewRepository
  * A plugin which does whatever it's told.
  */
 public class DocilePlugin(
-    private val viewRepositories: Set<ViewRepository<*, *, *>> = setOf(),
-    private val views: Set<Class<out View<*, *, *>>> = setOf(),
-    private val policies: Set<Policy<*>> = setOf()
+    private val viewRepositories: ImmutableSet<ViewRepository<*, *, *>> = ImmutableSet.of(),
+    private val views: ImmutableSet<Class<out View<*, *, *>>> = ImmutableSet.of(),
+    private val policies: ImmutableSet<Policy<*>> = ImmutableSet.of()
 ) : Plugin {
 
-    override fun viewRepositories(): Set<ViewRepository<*, *, *>> = viewRepositories
+    override fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> = viewRepositories
 
-    override fun views(): Set<Class<out View<*, *, *>>> = views
+    override fun views(): ImmutableSet<Class<out View<*, *, *>>> = views
 
-    override fun policies(): Set<Policy<*>> = policies
+    override fun policies(): ImmutableSet<Policy<*>> = policies
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
@@ -35,7 +35,14 @@ import io.spine.protodata.plugin.ViewRepository
  * A plugin which does whatever it's told.
  */
 public class DocilePlugin(
-    override val viewRepositories: Set<ViewRepository<*, *, *>> = setOf(),
-    override val views: Set<Class<out View<*, *, *>>> = setOf(),
-    override val policies: Set<Policy<*>> = setOf()
-) : Plugin
+    private val viewRepositories: Set<ViewRepository<*, *, *>> = setOf(),
+    private val views: Set<Class<out View<*, *, *>>> = setOf(),
+    private val policies: Set<Policy<*>> = setOf()
+) : Plugin {
+
+    override fun viewRepositories(): Set<ViewRepository<*, *, *>> = viewRepositories
+
+    override fun views(): Set<Class<out View<*, *, *>>> = views
+
+    override fun policies(): Set<Policy<*>> = policies
+}

--- a/testutil/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
@@ -26,7 +26,8 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import com.google.common.collect.ImmutableSet
+import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.qualifiedName
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
@@ -36,7 +37,7 @@ import kotlin.io.path.Path
 /**
  * Creates a new package-private class for each [InternalType].
  */
-public class InternalAccessRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.Java)) {
+public class InternalAccessRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val internalTypes = select<InternalType>().all()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
@@ -34,8 +34,8 @@ import io.spine.protodata.renderer.LineNumber
 public class JavaGenericInsertionPointPrinter : InsertionPointPrinter(
     target = CommonLanguages.Java
 ) {
-    override val supportedInsertionPoints: Set<InsertionPoint>
-        get() = GenericInsertionPoint.values().toSet()
+    override fun supportedInsertionPoints(): Set<InsertionPoint> =
+        GenericInsertionPoint.values().toSet()
 }
 
 public enum class GenericInsertionPoint : InsertionPoint {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.test
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages
 import io.spine.protodata.renderer.InsertionPoint
 import io.spine.protodata.renderer.InsertionPointPrinter
@@ -34,8 +35,8 @@ import io.spine.protodata.renderer.LineNumber
 public class JavaGenericInsertionPointPrinter : InsertionPointPrinter(
     target = CommonLanguages.Java
 ) {
-    override fun supportedInsertionPoints(): Set<InsertionPoint> =
-        GenericInsertionPoint.values().toSet()
+    override fun supportedInsertionPoints(): ImmutableSet<InsertionPoint> =
+        ImmutableSet.copyOf(GenericInsertionPoint.values())
 }
 
 public enum class GenericInsertionPoint : InsertionPoint {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
@@ -26,11 +26,12 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import com.google.common.collect.ImmutableSet
+import io.spine.protodata.language.CommonLanguages.JavaScript
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class JsRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.JavaScript)) {
+public class JsRenderer : Renderer(supportedLanguages = ImmutableSet.of(JavaScript)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
@@ -26,11 +26,12 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import com.google.common.collect.ImmutableSet
+import io.spine.protodata.language.CommonLanguages.Kotlin
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class KtRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.Kotlin)) {
+public class KtRenderer : Renderer(supportedLanguages = ImmutableSet.of(Kotlin)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
@@ -26,13 +26,14 @@
 
 package io.spine.protodata.test
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 import io.spine.protodata.theOnly
 import kotlin.io.path.name
 
-public class PrependingRenderer : Renderer(supportedLanguages = setOf(Java)) {
+public class PrependingRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val file = sources

--- a/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
@@ -31,6 +31,6 @@ import io.spine.protodata.plugin.ViewRepository
 
 public class TestPlugin: Plugin {
 
-    override val viewRepositories: Set<ViewRepository<*, *, *>>
-        get() = setOf(InternalMessageRepository(), DeletedTypeRepository())
+    override fun viewRepositories(): Set<ViewRepository<*, *, *>> =
+        setOf(InternalMessageRepository(), DeletedTypeRepository())
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
@@ -26,11 +26,12 @@
 
 package io.spine.protodata.test
 
+import com.google.common.collect.ImmutableSet
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.ViewRepository
 
 public class TestPlugin: Plugin {
 
-    override fun viewRepositories(): Set<ViewRepository<*, *, *>> =
-        setOf(InternalMessageRepository(), DeletedTypeRepository())
+    override fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> =
+        ImmutableSet.of(InternalMessageRepository(), DeletedTypeRepository())
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/TestRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/TestRenderer.kt
@@ -26,11 +26,12 @@
 
 package io.spine.protodata.test
 
-import io.spine.protodata.language.CommonLanguages
+import com.google.common.collect.ImmutableSet
+import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class TestRenderer : Renderer(supportedLanguages = setOf(CommonLanguages.Java)) {
+public class TestRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val internalTypes = select<InternalType>().all()


### PR DESCRIPTION
In this PR we remove abstract properties from SPI interfaces and abstract classes and replace them with similarly named methods.

Consider this Java code:
```java
public final class MyPlugin implements Plugin {

    public Set<Class<? extends View>> getViews() { ... }
}
```
VS
```java
public final class MyPlugin implements Plugin {

    public ImmutableSet<Class<? extends View>> views() { ... }
}
```

The former hints at the presence of some kind of a property, which is not an intended effect.
The latter is easier to read.

Additionally, we replace `Set` with `ImmutableSet` so that the user does not think they can modify this set to change the views. In Kotlin this was already expressed by Kotlin `Set` being immutable, but this constraint is lost in translation to Java.