### PR TITLE
Rollback to Kotlin sets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ spinePublishing {
 
 allprojects {
     group = "io.spine.protodata"
-    version = "0.0.11"
+    version = "0.0.12"
 
     repositories.applyStandard()
 }

--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -55,6 +55,21 @@ ext {
     repositoryTempDir = Files.createTempDirectory("repoTemp")
 }
 
+/**
+ * Prints a message telling those who read build logs about what happened.
+ */
+if (isSnapshot()) {
+    println("GitHub Pages update will be skipped since this project" +
+            " is a snapshot: `$project.name-$project.version`.")
+}
+
+/**
+ * Tells whether this project is a snapshot.
+ */
+def isSnapshot() {
+    return project.version.toLowerCase().contains("snapshot")
+}
+
 final String propertyName = 'allowInternalJavadoc'
 
 final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
@@ -87,6 +102,13 @@ task copyJavadoc(type: Copy) {
 task updateGitHubPages {
     description "Updates the Javadoc published to GitHub Pages website."
     dependsOn copyJavadoc
+}
+
+/**
+ * Prevents this task from execution in case this project is in its `SNAPSHOT` version.
+ */
+updateGitHubPages.onlyIf {
+    !isSnapshot()
 }
 
 /**
@@ -128,7 +150,7 @@ static String execute(final File baseDir, final String... command) {
     } else {
         final String errorMsg = "Command `$command` finished with exit code $result.exitCode:" +
                 " ${System.lineSeparator()}${result.error}" +
-                " ${System.lineSeparator()}${result.out}"
+                " ${System.lineSeparator()}${result.out}."
         throw new IllegalStateException(errorMsg)
     }
 }
@@ -194,7 +216,7 @@ Host github.com-publish
 
     execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
     execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH
-    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`")
+    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`.")
     docDir.mkdir()
 
     copy {
@@ -202,7 +224,7 @@ Host github.com-publish
         into docDir
     }
 
-    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`")
+    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`.")
     versionedDocDir.mkdir()
     copy {
         from generatedDocs
@@ -224,5 +246,5 @@ Host github.com-publish
 
     execute repoBaseDir, "git", "commit", "--allow-empty", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
     execute repoBaseDir, "git", "push"
-    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
+    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` successfully.")
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/truth
 object Truth {
-    private const val version = "1.1.2"
+    private const val version = "1.1.3"
     val libs = listOf(
         "com.google.truth:truth:${version}",
         "com.google.truth.extensions:truth-java8-extension:${version}",

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.plugin
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.ConfigurationError
 import io.spine.server.BoundedContextBuilder
 
@@ -48,8 +47,7 @@ public interface Plugin {
      *
      * A [View] may not have a need for repository. In such case, use [Plugin.views] instead.
      */
-    public fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> =
-        ImmutableSet.of()
+    public fun viewRepositories(): Set<ViewRepository<*, *, *>> = setOf()
 
     /**
      * Obtains the [views][View] added by this plugin represented via their classes.
@@ -57,14 +55,12 @@ public interface Plugin {
      * A [View] may require a repository to route events. In such case, use
      * [Plugin.viewRepositories] instead.
      */
-    public fun views(): ImmutableSet<Class<out View<*, *, *>>> =
-        ImmutableSet.of()
+    public fun views(): Set<Class<out View<*, *, *>>> = setOf()
 
     /**
      * Obtains the [policies][Policy] added by this plugin.
      */
-    public fun policies(): ImmutableSet<Policy<*>> =
-        ImmutableSet.of()
+    public fun policies(): Set<Policy<*>> = setOf()
 }
 
 /**

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
@@ -27,7 +27,6 @@
 package io.spine.protodata.renderer
 
 import com.google.common.base.Preconditions.checkPositionIndex
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.Language
 
 /**
@@ -44,14 +43,14 @@ import io.spine.protodata.language.Language
  */
 public abstract class InsertionPointPrinter(
     private val target: Language
-) : Renderer(ImmutableSet.of(target)) {
+) : Renderer(setOf(target)) {
 
     /**
      * [InsertionPoint]s which could be added to source code by this `InsertionPointPrinter`.
      *
      * The property getter may use [Renderer.select] to find out more info about the message types.
      */
-    protected abstract fun supportedInsertionPoints(): ImmutableSet<InsertionPoint>
+    protected abstract fun supportedInsertionPoints(): Set<InsertionPoint>
 
     final override fun doRender(sources: SourceSet) {
         sources.prepareCode { file ->

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.renderer
 
-import com.google.common.collect.ImmutableSet
 import io.spine.base.EntityState
 import io.spine.protodata.QueryingClient
 import io.spine.protodata.language.Language
@@ -41,7 +40,7 @@ import io.spine.server.BoundedContext
  */
 public abstract class Renderer
 protected constructor(
-    private val supportedLanguages: ImmutableSet<Language>
+    private val supportedLanguages: Set<Language>
 ) {
 
     internal lateinit var protoDataContext: BoundedContext

--- a/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/PipelineTest.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata
 
-import com.google.common.collect.ImmutableSet
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.protodata.renderer.SourceSet
@@ -211,7 +210,7 @@ class `'Pipeline' should` {
         fun `a policy handles too many events at once`() {
             val policy = GreedyPolicy()
             val pipeline = Pipeline(
-                listOf(DocilePlugin(policies = ImmutableSet.of(policy))),
+                listOf(DocilePlugin(policies = setOf(policy))),
                 listOf(renderer),
                 SourceSet.fromContentsOf(srcRoot),
                 request
@@ -227,8 +226,8 @@ class `'Pipeline' should` {
             val viewClass = DeletedTypeView::class.java
             val pipeline = Pipeline(
                 listOf(DocilePlugin(
-                    views = ImmutableSet.of(viewClass),
-                    viewRepositories = ImmutableSet.of(DeletedTypeRepository())
+                    views = setOf(viewClass),
+                    viewRepositories = setOf(DeletedTypeRepository())
                 )),
                 listOf(renderer),
                 SourceSet.fromContentsOf(srcRoot),

--- a/testutil/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.any
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
@@ -38,7 +37,7 @@ import io.spine.protodata.renderer.SourceSet
  * Releases the proverbial Schrödinger's cat (insertion points) out of the box by observing
  * the code.
  */
-public class CatOutOfTheBoxEmancipator : Renderer(supportedLanguages = ImmutableSet.of(any)) {
+public class CatOutOfTheBoxEmancipator : Renderer(supportedLanguages = setOf(any)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import com.google.protobuf.StringValue
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.find
@@ -36,7 +35,7 @@ import io.spine.protodata.renderer.SourceSet
 import kotlin.io.path.Path
 import kotlin.io.path.div
 
-public class DeletingRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
+public class DeletingRenderer : Renderer(supportedLanguages = setOf(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val types = select<DeletedType>().all()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/DocilePlugin.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.Policy
 import io.spine.protodata.plugin.View
@@ -36,14 +35,14 @@ import io.spine.protodata.plugin.ViewRepository
  * A plugin which does whatever it's told.
  */
 public class DocilePlugin(
-    private val viewRepositories: ImmutableSet<ViewRepository<*, *, *>> = ImmutableSet.of(),
-    private val views: ImmutableSet<Class<out View<*, *, *>>> = ImmutableSet.of(),
-    private val policies: ImmutableSet<Policy<*>> = ImmutableSet.of()
+    private val viewRepositories: Set<ViewRepository<*, *, *>> = setOf(),
+    private val views: Set<Class<out View<*, *, *>>> = setOf(),
+    private val policies: Set<Policy<*>> = setOf()
 ) : Plugin {
 
-    override fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> = viewRepositories
+    override fun viewRepositories(): Set<ViewRepository<*, *, *>> = viewRepositories
 
-    override fun views(): ImmutableSet<Class<out View<*, *, *>>> = views
+    override fun views(): Set<Class<out View<*, *, *>>> = views
 
-    override fun policies(): ImmutableSet<Policy<*>> = policies
+    override fun policies(): Set<Policy<*>> = policies
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.qualifiedName
 import io.spine.protodata.renderer.Renderer
@@ -37,7 +36,7 @@ import kotlin.io.path.Path
 /**
  * Creates a new package-private class for each [InternalType].
  */
-public class InternalAccessRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
+public class InternalAccessRenderer : Renderer(supportedLanguages = setOf(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val internalTypes = select<InternalType>().all()

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages
 import io.spine.protodata.renderer.InsertionPoint
 import io.spine.protodata.renderer.InsertionPointPrinter
@@ -35,8 +34,8 @@ import io.spine.protodata.renderer.LineNumber
 public class JavaGenericInsertionPointPrinter : InsertionPointPrinter(
     target = CommonLanguages.Java
 ) {
-    override fun supportedInsertionPoints(): ImmutableSet<InsertionPoint> =
-        ImmutableSet.copyOf(GenericInsertionPoint.values())
+    override fun supportedInsertionPoints(): Set<InsertionPoint> =
+        GenericInsertionPoint.values().toSet()
 }
 
 public enum class GenericInsertionPoint : InsertionPoint {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
@@ -26,12 +26,11 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.JavaScript
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class JsRenderer : Renderer(supportedLanguages = ImmutableSet.of(JavaScript)) {
+public class JsRenderer : Renderer(supportedLanguages = setOf(JavaScript)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
@@ -26,12 +26,11 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.Kotlin
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class KtRenderer : Renderer(supportedLanguages = ImmutableSet.of(Kotlin)) {
+public class KtRenderer : Renderer(supportedLanguages = setOf(Kotlin)) {
 
     override fun doRender(sources: SourceSet) {
         sources.forEach {

--- a/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/PrependingRenderer.kt
@@ -26,14 +26,13 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 import io.spine.protodata.theOnly
 import kotlin.io.path.name
 
-public class PrependingRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
+public class PrependingRenderer : Renderer(supportedLanguages = setOf(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val file = sources

--- a/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/TestPlugin.kt
@@ -26,12 +26,11 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.ViewRepository
 
 public class TestPlugin: Plugin {
 
-    override fun viewRepositories(): ImmutableSet<ViewRepository<*, *, *>> =
-        ImmutableSet.of(InternalMessageRepository(), DeletedTypeRepository())
+    override fun viewRepositories(): Set<ViewRepository<*, *, *>> =
+        setOf(InternalMessageRepository(), DeletedTypeRepository())
 }

--- a/testutil/src/main/kotlin/io/spine/protodata/test/TestRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/TestRenderer.kt
@@ -26,12 +26,11 @@
 
 package io.spine.protodata.test
 
-import com.google.common.collect.ImmutableSet
 import io.spine.protodata.language.CommonLanguages.Java
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
 
-public class TestRenderer : Renderer(supportedLanguages = ImmutableSet.of(Java)) {
+public class TestRenderer : Renderer(supportedLanguages = setOf(Java)) {
 
     override fun doRender(sources: SourceSet) {
         val internalTypes = select<InternalType>().all()


### PR DESCRIPTION
In a recent PR, we've migrated from using Kotlin `Set`s to using Guava `ImmutableSet`s. The motivation for this change was to bring down the chances of an error for users of ProtoData who write in Java.

However, we also want to untie ourselves from Java and, possibly, with time, make ProtoData multiplatform, in the Kotlin-multiplatform way.
This goal is far away and might and might not change in future, but, for now, we're going to make small steps towards it and see what's what.

Due to the stated goal, we remove usages of Guava immutable collections from ProtoData API.