### PR TITLE
Plugin publishing

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -77,3 +77,8 @@ pluginBundle {
         }
     }
 }
+
+rootProject.afterEvaluate {
+    val pluginProject = project(":gradle-plugin")
+    pluginProject.tasks["publish"].dependsOn(pluginProject.tasks["publishPlugins"])
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -69,8 +69,6 @@ pluginBundle {
         version = project.version.toString()
     }
 
-    withDependencies { clear() }
-
     plugins {
         named("protoDataPlugin") {
             version = project.version.toString()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.13"
+extra["protoDataVersion"] = "0.0.14"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.34"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.24"


### PR DESCRIPTION
In this PR we add a missing piece in the Gradle plugin publishing configuration.

Previously, the plugin was not published. It turned out that task `publishPlugins` does not automatically depend on `publish`. In this PR we fix that by manually adding the task dependency.