### PR TITLE
Make `CodeGenerationContext` public for testing

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/Context.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Context.kt
@@ -38,12 +38,13 @@ import io.spine.server.integration.ThirdPartyContext
 /**
  * A factory for the `Code Generation` bounded context.
  */
-internal object CodeGenerationContext {
+public object CodeGenerationContext {
 
     /**
      * Creates a builder of the bounded context.
      */
-    fun builder(): BoundedContextBuilder {
+    @JvmStatic
+    public fun builder(): BoundedContextBuilder {
         val builder = BoundedContext
             .singleTenant("Code Generation")
         builder.add(ViewRepository.default(builtinView()))

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.19"
+extra["protoDataVersion"] = "0.0.20"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.34"
-extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.24"
+extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.26"


### PR DESCRIPTION
In order to allow users who extend ProtoData to test their code via Spine `BlackBox`, we expose `CodeGenerationContext.builder()` into the public API.