### PR TITLE
More integration testing

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceSet.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceSet.kt
@@ -112,7 +112,6 @@ internal constructor(
                 checkArgument(
                     target.isDirectory, "Target root `%s` must be a directory.", targetRoot
                 )
-
                 val children = target.list()!!
                 checkArgument(children.isEmpty(),
                     "Target directory `%s` must be empty. Found children: %s.",

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Extension.kt
@@ -175,7 +175,7 @@ public class Extension(private val project: Project) {
      * @see srcBaseDir for the rules for the source dir construction
      */
     internal fun sourceDir(sourceSet: SourceSet): Provider<Directory> =
-        srcBaseDirProperty.get().dir(sourceSet.name).dir(subDirProperty)
+        compileDir(sourceSet, srcBaseDirProperty)
 
     /**
      * Obtains the target directory for code generation.
@@ -183,5 +183,8 @@ public class Extension(private val project: Project) {
      * @see targetBaseDir for the rules for the target dir construction
      */
     internal fun targetDir(sourceSet: SourceSet): Provider<Directory> =
-        targetBaseDirProperty.get().dir(sourceSet.name).dir(subDirProperty)
+        compileDir(sourceSet, targetBaseDirProperty)
+
+    private fun compileDir(sourceSet: SourceSet, base: DirectoryProperty): Provider<Directory> =
+        base.dir(sourceSet.name).map { it.dir(subDirProperty).get() }
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
@@ -26,6 +26,8 @@
 
 package io.spine.protodata.gradle
 
+import org.gradle.api.Action
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileSystemLocation
@@ -122,6 +124,26 @@ public open class LaunchProtoData : JavaExec() {
         classpath(userClasspathConfig)
         main = "io.spine.protodata.cli.MainKt"
         args(command)
+
+        doFirst(CleanAction())
+    }
+
+    /**
+     * Cleans the target directory to prepare it for ProtoData.
+     */
+    private inner class CleanAction : Action<Task> {
+
+        override fun execute(t: Task) {
+            val sourceDir = source.get().asFile.absoluteFile
+            val targetDir = target.get().asFile.absoluteFile
+            val differentDirs = sourceDir != targetDir
+
+            if (differentDirs && targetDir.exists() && targetDir.list()!!.isNotEmpty()) {
+                logger.info("Cleaning target directory `$targetDir`.")
+                project.delete(targetDir)
+            }
+        }
+
     }
 }
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
@@ -143,7 +143,6 @@ public open class LaunchProtoData : JavaExec() {
                 project.delete(targetDir)
             }
         }
-
     }
 }
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -178,11 +178,14 @@ private fun cleanTaskName(sourceSet: SourceSet): String =
 private fun Project.configureSourceSets(extension: Extension) {
     afterEvaluate {
         sourceSets.forEach { sourceSet ->
-            sourceSet.java.srcDir(extension.targetDir(sourceSet))
-
             val sourceDir = file(extension.sourceDir(sourceSet))
-            val task = javaCompileFor(sourceSet)!!
-            task.source = task.source.filter { file -> !file.residesIn(sourceDir) }.asFileTree
+            val targetDir = file(extension.targetDir(sourceSet))
+
+            sourceSet.java.srcDir(targetDir)
+            if (sourceDir != targetDir) {
+                val task = javaCompileFor(sourceSet)!!
+                task.source = task.source.filter { file -> !file.residesIn(sourceDir) }.asFileTree
+            }
         }
     }
 }

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -24,38 +24,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.protodata.gradle.Extension
-import com.google.protobuf.gradle.protobuf
-
-@Suppress("RemoveRedundantQualifierName")
-buildscript {
-    io.spine.internal.gradle.doApplyStandard(repositories)
-
-    dependencies {
-        classpath("io.spine:proto-data")
-    }
+plugins {
+    id("io.spine.proto-data")
 }
 
-//apply(plugin = "io.spine.proto-data")
-
 dependencies {
-//    "protoData"(project(":protodata-extension"))
+    protoData(project(":protodata-extension"))
 }
 
 val protobufDir = "$projectDir/generated/"
-//
-//extensions.getByType<Extension>().apply {
-//    renderers(
-//        "io.spine.protodata.test.uuid.ClassScopePrinter",
-//        "io.spine.protodata.test.uuid.UuidJavaRenderer"
-//    )
-//    plugins(
-//        "io.spine.protodata.test.uuid.UuidPlugin"
-//    )
-//    srcBaseDir = protobufDir
+
+protoData {
+    renderers(
+        "io.spine.protodata.test.uuid.ClassScopePrinter",
+        "io.spine.protodata.test.uuid.UuidJavaRenderer"
+    )
+    plugins(
+        "io.spine.protodata.test.uuid.UuidPlugin"
+    )
+    //    srcBaseDir = protobufDir
 //    targetBaseDir = protobufDir
-//}
-//
+}
+
 //protobuf {
 //    generatedFilesBaseDir = protobufDir
 //}

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
+
 plugins {
     id("io.spine.proto-data")
 }
@@ -32,7 +34,7 @@ dependencies {
     protoData(project(":protodata-extension"))
 }
 
-val protobufDir = "$projectDir/generated/"
+val protobufDir = "$projectDir/proto-gen/"
 
 protoData {
     renderers(
@@ -42,10 +44,10 @@ protoData {
     plugins(
         "io.spine.protodata.test.uuid.UuidPlugin"
     )
-    //    srcBaseDir = protobufDir
-//    targetBaseDir = protobufDir
+    srcBaseDir = protobufDir
+    targetBaseDir = protobufDir
 }
 
-//protobuf {
-//    generatedFilesBaseDir = protobufDir
-//}
+protobuf {
+    generatedFilesBaseDir = protobufDir
+}

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -24,16 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-include(":consumer")
-include(":in-place-consumer")
-include(":protodata-extension")
+import io.spine.protodata.gradle.Extension
+import com.google.protobuf.gradle.protobuf
 
-includeBuild("..") {
-    dependencySubstitution {
-        substitute(module("io.spine:proto-data")).using(project(":gradle-plugin"))
-        substitute(module("io.spine.protodata:cli")).using(project(":cli"))
-        substitute(module("io.spine.protodata:codegen-java")).using(project(":codegen-java"))
-        substitute(module("io.spine.protodata:compiler")).using(project(":compiler"))
-        substitute(module("io.spine.protodata:protoc")).using(project(":protoc"))
+@Suppress("RemoveRedundantQualifierName")
+buildscript {
+    io.spine.internal.gradle.doApplyStandard(repositories)
+
+    dependencies {
+        classpath("io.spine:proto-data")
     }
 }
+
+//apply(plugin = "io.spine.proto-data")
+
+dependencies {
+//    "protoData"(project(":protodata-extension"))
+}
+
+val protobufDir = "$projectDir/generated/"
+//
+//extensions.getByType<Extension>().apply {
+//    renderers(
+//        "io.spine.protodata.test.uuid.ClassScopePrinter",
+//        "io.spine.protodata.test.uuid.UuidJavaRenderer"
+//    )
+//    plugins(
+//        "io.spine.protodata.test.uuid.UuidPlugin"
+//    )
+//    srcBaseDir = protobufDir
+//    targetBaseDir = protobufDir
+//}
+//
+//protobuf {
+//    generatedFilesBaseDir = protobufDir
+//}

--- a/tests/in-place-consumer/src/main/proto/protodata/test/user.proto
+++ b/tests/in-place-consumer/src/main/proto/protodata/test/user.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package protodata.test;
+
+option java_package = "io.spine.protodata.test";
+option java_outer_classname = "UserProto";
+option java_multiple_files = true;
+
+message UserId {
+
+    string uuid = 1;
+}

--- a/tests/in-place-consumer/src/test/java/io/spine/protodata/test/CodeGenerationTest.java
+++ b/tests/in-place-consumer/src/test/java/io/spine/protodata/test/CodeGenerationTest.java
@@ -24,16 +24,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-include(":consumer")
-include(":in-place-consumer")
-include(":protodata-extension")
+package io.spine.protodata.test;
 
-includeBuild("..") {
-    dependencySubstitution {
-        substitute(module("io.spine:proto-data")).using(project(":gradle-plugin"))
-        substitute(module("io.spine.protodata:cli")).using(project(":cli"))
-        substitute(module("io.spine.protodata:codegen-java")).using(project(":codegen-java"))
-        substitute(module("io.spine.protodata:compiler")).using(project(":compiler"))
-        substitute(module("io.spine.protodata:protoc")).using(project(":protoc"))
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("Code generation should")
+final class CodeGenerationTest {
+
+    @Test
+    @DisplayName("add extra code in-place")
+    void mainScope() {
+//        UserId id = UserId.randomId();
+//        assertThat(id.getUuid())
+//                .isNotEmpty();
     }
 }

--- a/tests/in-place-consumer/src/test/java/io/spine/protodata/test/CodeGenerationTest.java
+++ b/tests/in-place-consumer/src/test/java/io/spine/protodata/test/CodeGenerationTest.java
@@ -29,14 +29,16 @@ package io.spine.protodata.test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertThat;
+
 @DisplayName("Code generation should")
 final class CodeGenerationTest {
 
     @Test
     @DisplayName("add extra code in-place")
     void mainScope() {
-//        UserId id = UserId.randomId();
-//        assertThat(id.getUuid())
-//                .isNotEmpty();
+        UserId id = UserId.randomId();
+        assertThat(id.getUuid())
+                .isNotEmpty();
     }
 }

--- a/tests/in-place-consumer/src/test/java/io/spine/protodata/test/package-info.java
+++ b/tests/in-place-consumer/src/test/java/io/spine/protodata/test/package-info.java
@@ -24,19 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@CheckReturnValue
+@ParametersAreNonnullByDefault
 package io.spine.protodata.test;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.google.errorprone.annotations.CheckReturnValue;
 
-@DisplayName("Code generation should")
-final class CodeGenerationTest {
-
-    @Test
-    @DisplayName("add extra code in-place")
-    void mainScope() {
-//        UserId id = UserId.randomId();
-//        assertThat(id.getUuid())
-//                .isNotEmpty();
-    }
-}
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
In this PR we add another submodule in `tests` to check slightly different settings of ProtoData.

The new module `in-place-consumer` is different from the regular consumer in that it applies ProtoData in-place, i.e. the source dir and the target dir are the same. This has a few consequences for the way ProtoData Gradle plugin configures the project.