### PR TITLE
Configuration API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Build project and run tests
         run: ./gradlew build --stacktrace -PprotoDataLocation=$(pwd)/protodata-current-exe
       - name: Upload code coverage report
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+          verbose: true
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
       - run: git submodule update --init --recursive
       - name: Build project and run tests
         run: ./gradlew build --stacktrace -PprotoDataLocation=$(pwd)/protodata-current-exe
+      - name: Upload code coverage report
+        run: bash <(curl -s https://codecov.io/bash)
 
   publish:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.Kotlin
 import io.spine.internal.dependency.Truth
 import io.spine.internal.gradle.PublishingRepos
+import io.spine.internal.gradle.Scripts
 import io.spine.internal.gradle.applyStandard
 import io.spine.internal.gradle.spinePublishing
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
@@ -58,6 +59,8 @@ plugins {
     }
     idea
     `integration-test`
+    jacoco
+    `force-jacoco`
 }
 
 spinePublishing {
@@ -131,4 +134,8 @@ subprojects {
         archiveClassifier.set("javadoc")
         dependsOn(dokkaJavadoc)
     }
+}
+
+afterEvaluate {
+    apply(from = Scripts.jacoco(project))
 }

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -74,7 +74,7 @@ class MarkdownReportRenderer implements ReportRenderer {
     }
 
     @Input
-    private String getFileNameCache() { return this.fileName }
+    String getFileNameCache() { return this.fileName }
 
     void render(final ProjectData data) {
         project = data.project

--- a/buildSrc/src/main/groovy/publish-proto.gradle
+++ b/buildSrc/src/main/groovy/publish-proto.gradle
@@ -82,7 +82,7 @@ artifacts {
  * except those included into the returned {@code Collection}.
  */
 Collection<File> collectProto() {
-    final def dependencies = configurations.compile.files
+    final def dependencies = configurations.runtimeClasspath.files
     final def jarFiles = dependencies.collect { JarFileName.ofFile(it) }
     final def result = new HashSet<>()
     for (final File jarFile in dependencies) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -35,4 +35,6 @@ object Jackson {
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
     // https://github.com/FasterXML/jackson-dataformats-text/releases
     const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
+    // https://github.com/FasterXML/jackson-module-kotlin/releases
+    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,9 +28,11 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.12.3"
+    private const val version = "2.12.4"
     // https://github.com/FasterXML/jackson-databind
     const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
     // https://github.com/FasterXML/jackson-dataformat-xml/releases
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
+    // https://github.com/FasterXML/jackson-dataformats-text/releases
+    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.0"
+    const val version      = "1.5.20"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
@@ -39,7 +39,7 @@ object Kotlin {
     // https://github.com/Kotlin/dokka
     object Dokka {
 
-        const val version = "1.4.32"
+        const val version = "1.5.0"
         const val pluginId = "org.jetbrains.dokka"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,13 +29,14 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.17.0"
+    const val version    = "3.17.3"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
     )
     const val compiler = "com.google.protobuf:protoc:${version}"
 
+    // https://github.com/google/protobuf-gradle-plugin/releases
     object GradlePlugin {
         const val version = "0.8.16"
         const val id = "com.google.protobuf"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
 object Roaster {
-    private const val version = "2.22.2.Final"
+    private const val version = "2.23.0.Final"
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -28,13 +28,13 @@ package io.spine.internal.gradle
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import java.io.FileNotFoundException
-import java.net.URL
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import java.io.FileNotFoundException
+import java.net.URL
 
 /**
  * A task which verifies that the current version of the library has not been published to the given

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -129,8 +129,8 @@ fun ConfigurationContainer.excludeProtobufLite() {
         )
     }
 
-    excludeProtoLite("runtime")
-    excludeProtoLite("testRuntime")
+    excludeProtoLite("runtimeOnly")
+    excludeProtoLite("testRuntimeOnly")
 }
 
 @Suppress("unused")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
     application
     `version-to-resources`
     `build-proto-model`
+    jacoco
 }
 
 dependencies {

--- a/cli/src/main/kotlin/io/spine/protodata/cli/Main.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/Main.kt
@@ -46,6 +46,7 @@ import io.spine.protodata.Pipeline
 import io.spine.protodata.config.Configuration
 import io.spine.protodata.config.ConfigurationFormat
 import io.spine.protodata.config.ConfigurationFormat.JSON
+import io.spine.protodata.config.ConfigurationFormat.PLAIN
 import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
 import io.spine.protodata.config.ConfigurationFormat.YAML
 import io.spine.protodata.option.OptionsProvider
@@ -178,10 +179,10 @@ internal class Run(version: String) : CliktCommand(
     """.trimIndent())
     private val configurationFormat: String? by option(ConfigOpt.FORMAT, "--cf", help = """
         The format of the custom configuration.
-        Must be one of: `yaml`, `json`, `proto_json`.
+        Must be one of: `yaml`, `json`, `proto_json`, `plain`.
         Must be used alongside with `--configuration-value`.
     """.trimIndent(), completionCandidates = CompletionCandidates.Fixed(
-        setOf(YAML, JSON, PROTO_JSON).map { it.name.lowercase() }.toSet()
+        setOf(YAML, JSON, PROTO_JSON, PLAIN).map { it.name.lowercase() }.toSet()
     ))
 
     private object ConfigOpt {

--- a/cli/src/main/kotlin/io/spine/protodata/cli/ReflectiveBuilder.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/ReflectiveBuilder.kt
@@ -53,23 +53,12 @@ internal open class ReflectiveBuilder<T: Any> {
         return create(tClass)
     }
 
-    private fun create(cls: KClass<T>) : T {
+    private fun create(cls: KClass<T>): T {
         val ctor = cls.constructors.find {
             it.visibility == KVisibility.PUBLIC && it.parameters.isEmpty()
         } ?: throw IllegalStateException(
             "Class `${cls.qualifiedName} should have a public zero-parameter constructor.`"
         )
-        val instance = ctor.call()
-        prepareInstance(instance)
-        return instance
-    }
-
-    /**
-     * Initializes the [instance] after creation.
-     *
-     * This preparation is executed before the instance is returned to the caller of
-     * [createByName].
-     */
-    protected open fun prepareInstance(instance: T) {
+        return ctor.call()
     }
 }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
@@ -36,16 +36,19 @@ import io.spine.protodata.cli.given.CustomOptionRenderer
 import io.spine.protodata.cli.given.TestOptionProvider
 import io.spine.protodata.cli.test.TestOptionsProto
 import io.spine.protodata.cli.test.TestProto
+import io.spine.protodata.test.GREETING_FILE
+import io.spine.protodata.test.GreetingRenderer
 import io.spine.protodata.test.Project
 import io.spine.protodata.test.ProjectProto
 import io.spine.protodata.test.TestPlugin
 import io.spine.protodata.test.TestRenderer
 import java.nio.file.Path
+import kotlin.io.path.createFile
+import kotlin.io.path.pathString
 import kotlin.io.path.readText
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
 import kotlin.reflect.jvm.jvmName
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -122,6 +125,29 @@ class `Command line application should` {
         val generatedFile = srcRoot.resolve(CustomOptionRenderer.FILE_NAME)
         assertThat(generatedFile.readText())
             .isEqualTo("custom_field_for_test")
+    }
+
+    @Nested
+    inner class `Receive custom configuration through` {
+
+        @Test
+        fun `configuration file`(@TempDir configDir: Path) {
+            val name = "Internet"
+            val configFile = configDir.resolve("name.json")
+            configFile.createFile()
+            configFile.writeText("""
+                { "value": "$name" }
+            """.trimIndent())
+
+            launchApp(
+                "-r", GreetingRenderer::class.jvmName,
+                "--src", srcRoot.toString(),
+                "-t", codegenRequestFile.toString(),
+                "-c", configFile.pathString
+            )
+            assertThat(srcRoot.resolve(GREETING_FILE).readText())
+                .isEqualTo(name)
+        }
     }
 
     @Nested

--- a/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
@@ -148,6 +148,20 @@ class `Command line application should` {
             assertThat(srcRoot.resolve(GREETING_FILE).readText())
                 .isEqualTo(name)
         }
+
+        @Test
+        fun `configuration value`() {
+            val name = "Mr. World"
+            launchApp(
+                "-r", GreetingRenderer::class.jvmName,
+                "--src", srcRoot.toString(),
+                "-t", codegenRequestFile.toString(),
+                "--cv", """{ "value": "$name" }""",
+                "--cf", "json"
+            )
+            assertThat(srcRoot.resolve(GREETING_FILE).readText())
+                .isEqualTo(name)
+        }
     }
 
     @Nested

--- a/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/CliTest.kt
@@ -43,6 +43,7 @@ import io.spine.protodata.cli.test.TestProto
 import io.spine.protodata.tesst.Echo
 import io.spine.protodata.test.ECHO_FILE
 import io.spine.protodata.test.EchoRenderer
+import io.spine.protodata.test.PlainStringRenderer
 import io.spine.protodata.test.Project
 import io.spine.protodata.test.ProjectProto
 import io.spine.protodata.test.ProtoEchoRenderer
@@ -265,6 +266,20 @@ class `Command line application should` {
             )
             assertThat(srcRoot.resolve(ECHO_FILE).readText())
                 .isEqualTo(name)
+        }
+
+        @Test
+        fun `plain string`() {
+            val plainString = "dont.mail.me:42@example.org"
+            launchApp(
+                "-r", PlainStringRenderer::class.jvmName,
+                "--src", srcRoot.toString(),
+                "-t", codegenRequestFile.toString(),
+                "--cv", plainString,
+                "--cf", "plain"
+            )
+            assertThat(srcRoot.resolve(ECHO_FILE).readText())
+                .isEqualTo(plainString)
         }
     }
 

--- a/cli/src/test/kotlin/io/spine/protodata/cli/ReflectiveBuilderTest.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/ReflectiveBuilderTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.cli
+
+import io.spine.protodata.cli.given.CtorWithArgsSpiImpl
+import io.spine.protodata.cli.given.PrivateCtorSpiImpl
+import io.spine.protodata.cli.given.TestReflectiveBuilder
+import io.spine.protodata.cli.given.TestSpiImpl
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class `'ReflectiveBuilder' should` {
+
+    private val loader = this.javaClass.classLoader
+
+    @Test
+    fun `create an instance of an existing class`() {
+        val builder = TestReflectiveBuilder()
+        builder.createByName(TestSpiImpl::class.qualifiedName!!, loader)
+    }
+
+    @Test
+    fun `fail to create an instance of a non-existing class`() {
+        val builder = TestReflectiveBuilder()
+        assertThrows<ClassNotFoundException> {
+            builder.createByName("com.acme.Impl", loader)
+        }
+    }
+
+    @Test
+    fun `fail to create an instance if class does not have a public ctor`() {
+        val builder = TestReflectiveBuilder()
+        assertThrows<IllegalStateException> {
+            builder.createByName(PrivateCtorSpiImpl::class.qualifiedName!!, loader)
+        }
+    }
+
+    @Test
+    fun `fail to create an instance if class does not have a ctor with no arguments`() {
+        val builder = TestReflectiveBuilder()
+        assertThrows<IllegalStateException> {
+            builder.createByName(CtorWithArgsSpiImpl::class.qualifiedName!!, loader)
+        }
+    }
+}

--- a/cli/src/test/kotlin/io/spine/protodata/cli/given/TestReflectiveBuilder.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/given/TestReflectiveBuilder.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.cli.given
+
+import io.spine.protodata.cli.ReflectiveBuilder
+
+internal class TestReflectiveBuilder : ReflectiveBuilder<TestSpi>()

--- a/cli/src/test/kotlin/io/spine/protodata/cli/given/TestSpi.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/given/TestSpi.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.cli.given
+
+interface TestSpi
+
+class TestSpiImpl : TestSpi
+
+class PrivateCtorSpiImpl
+private constructor() : TestSpi
+
+class CtorWithArgsSpiImpl(@Suppress("UNUSED_PARAMETER") ignored: String) : TestSpi

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api("io.spine:spine-server:$spineCoreVersion")
     implementation(Jackson.databind)
     implementation(Jackson.dataformatYaml)
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.4")
 
     testImplementation(project(":testutil"))
     testImplementation(JUnit.params)

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.internal.dependency.JUnit
+import io.spine.internal.dependency.Jackson
 
 plugins {
     `build-proto-model`
@@ -34,6 +35,8 @@ val spineCoreVersion: String by extra
 
 dependencies {
     api("io.spine:spine-server:$spineCoreVersion")
+    implementation(Jackson.databind)
+    implementation(Jackson.dataformatYaml)
 
     testImplementation(project(":testutil"))
     testImplementation(JUnit.params)

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -35,9 +35,11 @@ val spineCoreVersion: String by extra
 
 dependencies {
     api("io.spine:spine-server:$spineCoreVersion")
-    implementation(Jackson.databind)
-    implementation(Jackson.dataformatYaml)
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.4")
+    with(Jackson) {
+        implementation(databind)
+        implementation(dataformatYaml)
+        implementation(moduleKotlin)
+    }
 
     testImplementation(project(":testutil"))
     testImplementation(JUnit.params)

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -37,9 +37,9 @@ val spineCoreVersion: String by extra
 dependencies {
     api("io.spine:spine-server:$spineCoreVersion")
     with(Jackson) {
-        implementation(databind)
+        api(databind)
         implementation(dataformatYaml)
-        implementation(moduleKotlin)
+        runtimeOnly(moduleKotlin)
     }
 
     testImplementation(project(":testutil"))

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -29,6 +29,7 @@ import io.spine.internal.dependency.Jackson
 
 plugins {
     `build-proto-model`
+    jacoco
 }
 
 val spineCoreVersion: String by extra

--- a/compiler/src/main/kotlin/io/spine/protodata/ConfigView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/ConfigView.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import io.spine.core.External
+import io.spine.core.Subscribe
+import io.spine.protodata.config.Config
+import io.spine.protodata.config.ConfigId
+import io.spine.protodata.config.FileConfigDiscovered
+import io.spine.protodata.config.RawConfigDiscovered
+import io.spine.protodata.plugin.View
+import io.spine.protodata.plugin.ViewRepository
+import io.spine.server.entity.alter
+import io.spine.server.route.EventRoute.withId
+import io.spine.server.route.EventRouting
+
+internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
+
+    @Subscribe
+    internal fun on(@External event: FileConfigDiscovered) = alter {
+        file = event.file
+    }
+
+    @Subscribe
+    internal fun on(@External event: RawConfigDiscovered) = alter {
+        raw = event.config
+    }
+
+    internal class Repo : ViewRepository<ConfigId, ConfigView, Config>() {
+
+        override fun setupEventRouting(routing: EventRouting<ConfigId>) {
+            super.setupEventRouting(routing)
+            routing.replaceDefault { _, _ -> withId(ConfigId.getDefaultInstance()) }
+        }
+    }
+}

--- a/compiler/src/main/kotlin/io/spine/protodata/ConfigView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/ConfigView.kt
@@ -35,7 +35,6 @@ import io.spine.protodata.config.RawConfigDiscovered
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
 import io.spine.server.entity.alter
-import io.spine.server.route.EventRoute.withId
 import io.spine.server.route.EventRouting
 
 internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
@@ -52,9 +51,16 @@ internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
 
     internal class Repo : ViewRepository<ConfigId, ConfigView, Config>() {
 
+        private val theId = setOf(
+            ConfigId
+                .newBuilder()
+                .setValue("configuration_instance")
+                .build()
+        )
+
         override fun setupEventRouting(routing: EventRouting<ConfigId>) {
             super.setupEventRouting(routing)
-            routing.replaceDefault { _, _ -> withId(ConfigId.getDefaultInstance()) }
+            routing.replaceDefault { _, _ -> theId }
         }
     }
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/Context.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Context.kt
@@ -44,12 +44,11 @@ public object CodeGenerationContext {
      * Creates a builder of the bounded context.
      */
     @JvmStatic
-    public fun builder(): BoundedContextBuilder {
-        val builder = BoundedContext
-            .singleTenant("Code Generation")
-        builder.add(ViewRepository.default(builtinView()))
-        return builder
-    }
+    public fun builder(): BoundedContextBuilder =
+        BoundedContext.singleTenant("Code Generation").apply {
+            add(ViewRepository.default(builtinView()))
+            add(ConfigView.Repo())
+        }
 
     @Suppress("UNCHECKED_CAST")
     private fun builtinView(): Class<View<*, *, *>> =
@@ -81,4 +80,7 @@ internal object ProtobufCompilerContext {
             context.emittedEvent(it, actor)
         }
     }
+
+    fun emitted(singleEvent: EventMessage) =
+        emitted(sequenceOf(singleEvent))
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/Context.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Context.kt
@@ -28,6 +28,7 @@ package io.spine.protodata
 
 import io.spine.base.EventMessage
 import io.spine.core.UserId
+import io.spine.protodata.config.ConfigView
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
 import io.spine.server.BoundedContext

--- a/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
@@ -73,20 +73,24 @@ public class Pipeline(
     public operator fun invoke() {
         val contextBuilder = CodeGenerationContext.builder()
         plugins.forEach { contextBuilder.apply(it) }
-        val context = contextBuilder.build()
+        val codeGenContext = contextBuilder.build()
 
+        val configurationContext = ConfigurationContext()
+        val protocContext = ProtobufCompilerContext()
         if (config != null) {
             val event = config.produceEvent()
-            ProtobufCompilerContext.emitted(event)
+            configurationContext.emitted(event)
         }
         val events = CompilerEvents.parse(request)
-        ProtobufCompilerContext.emitted(events)
+        protocContext.emitted(events)
 
         renderers.forEach {
-            it.protoDataContext = context
+            it.protoDataContext = codeGenContext
             it.renderSources(sourceSet)
         }
         sourceSet.write()
-        context.close()
+        protocContext.close()
+        configurationContext.close()
+        codeGenContext.close()
     }
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/Pipeline.kt
@@ -29,6 +29,7 @@ package io.spine.protodata
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.annotation.Internal
 import io.spine.environment.Production
+import io.spine.protodata.config.Configuration
 import io.spine.protodata.events.CompilerEvents
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.apply
@@ -55,7 +56,8 @@ public class Pipeline(
     private val plugins: List<Plugin>,
     private val renderers:  List<Renderer>,
     private val sourceSet: SourceSet,
-    private val request: CodeGeneratorRequest
+    private val request: CodeGeneratorRequest,
+    private val config: Configuration? = null
 ) {
 
     init {
@@ -73,6 +75,10 @@ public class Pipeline(
         plugins.forEach { contextBuilder.apply(it) }
         val context = contextBuilder.build()
 
+        if (config != null) {
+            val event = config.produceEvent()
+            ProtobufCompilerContext.emitted(event)
+        }
         val events = CompilerEvents.parse(request)
         ProtobufCompilerContext.emitted(events)
 

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
@@ -52,6 +52,9 @@ internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
         raw = event.config
     }
 
+    /**
+     * A repository for the `ConfigView`.
+     */
     internal class Repo : ViewRepository<ConfigId, ConfigView, Config>() {
 
         private val theId = setOf(

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
@@ -24,19 +24,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.protodata
+package io.spine.protodata.config
 
 import io.spine.core.External
 import io.spine.core.Subscribe
-import io.spine.protodata.config.Config
-import io.spine.protodata.config.ConfigId
-import io.spine.protodata.config.FileConfigDiscovered
-import io.spine.protodata.config.RawConfigDiscovered
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
 import io.spine.server.entity.alter
 import io.spine.server.route.EventRouting
 
+/**
+ * A view on the ProtoData user configuration.
+ *
+ * Can contain either a configuration file path or a string value of the configuration.
+ *
+ * @see io.spine.protodata.config.Configured for fetching the value of the user configuration
+ */
 internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
 
     @Subscribe

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
@@ -28,9 +28,6 @@ package io.spine.protodata.config
 
 import io.spine.annotation.Internal
 import io.spine.base.EventMessage
-import io.spine.protodata.config.ConfigurationFormat.JSON
-import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
-import io.spine.protodata.config.ConfigurationFormat.YAML
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
@@ -43,11 +40,8 @@ public sealed class Configuration {
 
         public fun file(file: Path): Configuration = File(file)
 
-        public fun json(value: String): Configuration = Raw(value, JSON)
-
-        public fun protoJson(value: String): Configuration = Raw(value, PROTO_JSON)
-
-        public fun yaml(value: String): Configuration = Raw(value, YAML)
+        public fun rawValue(value: String, format: ConfigurationFormat): Configuration =
+            Raw(value, format)
     }
 }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.config
+
+import io.spine.annotation.Internal
+import io.spine.base.EventMessage
+import io.spine.protodata.config.ConfigurationFormat.JSON
+import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
+import io.spine.protodata.config.ConfigurationFormat.YAML
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+@Internal
+public sealed class Configuration {
+
+    internal abstract fun produceEvent(): EventMessage
+
+    public companion object {
+
+        public fun file(file: Path): Configuration = File(file)
+
+        public fun json(value: String): Configuration = Raw(value, JSON)
+
+        public fun protoJson(value: String): Configuration = Raw(value, PROTO_JSON)
+
+        public fun yaml(value: String): Configuration = Raw(value, YAML)
+    }
+}
+
+private class File(private val file: Path) : Configuration() {
+
+    override fun produceEvent() = FileConfigDiscovered
+        .newBuilder()
+        .setFile(file.toConfigFile())
+        .build()
+
+    private fun Path.toConfigFile() = ConfigFile
+        .newBuilder()
+        .setPath(absolutePathString())
+        .build()
+}
+
+private class Raw(
+    private val value: String,
+    private val format: ConfigurationFormat
+) : Configuration() {
+
+    override fun produceEvent() = RawConfigDiscovered
+        .newBuilder()
+        .setConfig(config())
+        .build()
+
+    private fun config() = RawConfig
+        .newBuilder()
+        .setFormat(format)
+        .setValue(value)
+        .build()
+}

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configuration.kt
@@ -31,15 +31,31 @@ import io.spine.base.EventMessage
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
+/**
+ * User-provided custom configuration for ProtoData.
+ *
+ * @see Configured
+ */
 @Internal
 public sealed class Configuration {
 
+    /**
+     * Constructs an event which contains the value of the configuration.
+     *
+     * The events belongs to the [io.spine.protodata.ConfigurationContext].
+     */
     internal abstract fun produceEvent(): EventMessage
 
     public companion object {
 
+        /**
+         * Creates a configuration written in a file with the given path.
+         */
         public fun file(file: Path): Configuration = File(file)
 
+        /**
+         * Creates a configuration from the given value in the given format.
+         */
         public fun rawValue(value: String, format: ConfigurationFormat): Configuration =
             Raw(value, format)
     }

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
@@ -47,18 +47,18 @@ import kotlin.io.path.name
 /**
  * A parser for the ProtoData user-provided configuration.
  */
-internal sealed class ConfigurationParser {
+internal sealed interface ConfigurationParser {
 
     /**
      * Attempts to deserialize the given configuration value into the given class.
      */
-    abstract fun <T> parse(source: ByteSource, cls: Class<T>): T
+    fun <T> parse(source: ByteSource, cls: Class<T>): T
 }
 
 /**
  * A configuration parser for Protobuf messages.
  */
-private sealed class ProtobufParser : ConfigurationParser() {
+private sealed class ProtobufParser : ConfigurationParser {
 
     final override fun <T> parse(source: ByteSource, cls: Class<T>): T {
         if (!Message::class.java.isAssignableFrom(cls)) {
@@ -104,7 +104,7 @@ private object ProtoJsonParser : ProtobufParser() {
 /**
  * A configuration parser for text-based formats.
  */
-private sealed class JacksonParser : ConfigurationParser() {
+private sealed class JacksonParser : ConfigurationParser {
 
     protected abstract val factory: JsonFactory
 

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
@@ -91,7 +91,7 @@ private sealed class JacksonParser : ConfigurationParser() {
     protected abstract val factory: JsonFactory
 
     final override fun <T> parse(source: ByteSource, cls: Class<T>): T {
-        val mapper = ObjectMapper(factory)
+        val mapper = ObjectMapper(factory).findAndRegisterModules()
         val charSource = source.asCharSource(defaultCharset())
         return charSource.openBufferedStream().use {
             mapper.readValue(it, cls)

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
@@ -42,6 +42,7 @@ import io.spine.protodata.config.ConfigurationFormat.UNRECOGNIZED
 import io.spine.protodata.config.ConfigurationFormat.YAML
 import java.nio.charset.Charset.defaultCharset
 import java.nio.file.Path
+import kotlin.io.path.name
 
 internal sealed class ConfigurationParser {
 
@@ -111,7 +112,8 @@ private object YamlParser : JacksonParser() {
 }
 
 internal fun formatOf(file: Path): ConfigurationFormat =
-    ConfigurationFormat.values().first { it.matches(file) }
+    ConfigurationFormat.values().find { it.matches(file) }
+        ?: throw ConfigurationError("Unrecognized configuration format: `${file.name}`.")
 
 internal val ConfigurationFormat.parser: ConfigurationParser
     get() = when(this) {

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigurationParser.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.config
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.google.common.io.ByteSource
+import com.google.protobuf.Message
+import io.spine.json.Json.fromJson
+import io.spine.protobuf.Messages
+import io.spine.protodata.ConfigurationError
+import io.spine.protodata.config.ConfigurationFormat.JSON
+import io.spine.protodata.config.ConfigurationFormat.PROTO_BINARY
+import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
+import io.spine.protodata.config.ConfigurationFormat.RCF_UNKNOWN
+import io.spine.protodata.config.ConfigurationFormat.UNRECOGNIZED
+import io.spine.protodata.config.ConfigurationFormat.YAML
+import java.nio.charset.Charset.defaultCharset
+import java.nio.file.Path
+
+internal sealed class ConfigurationParser {
+
+    abstract fun <T> parse(source: ByteSource, cls: Class<T>): T
+}
+
+private sealed class ProtobufParser : ConfigurationParser() {
+
+    final override fun <T> parse(source: ByteSource, cls: Class<T>): T {
+        if (!Message::class.java.isAssignableFrom(cls)) {
+            throw IllegalStateException("Expected a message class but got `${cls.canonicalName}`.")
+        }
+        return doParse(source, cls)
+    }
+
+    abstract fun <T> doParse(source: ByteSource, cls: Class<T>): T
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun <T> Message.asT() = this as T
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun Class<*>.asMessageClass() = this as Class<out Message>
+}
+
+private object ProtoBinaryParser : ProtobufParser() {
+
+    override fun <T> doParse(source: ByteSource, cls: Class<T>): T {
+        val builder = Messages.builderFor(cls.asMessageClass())
+        builder.mergeFrom(source.read())
+        return builder.build().asT()
+    }
+}
+
+private object ProtoJsonParser : ProtobufParser() {
+
+    override fun <T> doParse(source: ByteSource, cls: Class<T>): T {
+        val charSource = source.asCharSource(defaultCharset())
+        val json = charSource.read()
+        val parsed = fromJson(json, cls.asMessageClass())
+        return parsed.asT()
+    }
+}
+
+private sealed class JacksonParser : ConfigurationParser() {
+
+    protected abstract val factory: JsonFactory
+
+    final override fun <T> parse(source: ByteSource, cls: Class<T>): T {
+        val mapper = ObjectMapper(factory)
+        val charSource = source.asCharSource(defaultCharset())
+        return charSource.openBufferedStream().use {
+            mapper.readValue(it, cls)
+        }
+    }
+}
+
+private object JsonParser : JacksonParser() {
+
+    private val commonJsonFactory = JsonFactory()
+    override val factory: JsonFactory by this::commonJsonFactory
+}
+
+private object YamlParser : JacksonParser() {
+
+    private val commonYamlFactory = YAMLFactory()
+    override val factory: JsonFactory by this::commonYamlFactory
+}
+
+internal fun formatOf(file: Path): ConfigurationFormat =
+    ConfigurationFormat.values().first { it.matches(file) }
+
+internal val ConfigurationFormat.parser: ConfigurationParser
+    get() = when(this) {
+        PROTO_BINARY -> ProtoBinaryParser
+        PROTO_JSON -> ProtoJsonParser
+        JSON -> JsonParser
+        YAML -> YamlParser
+        UNRECOGNIZED, RCF_UNKNOWN -> throw ConfigurationError(
+            "Unable to parse configuration: unknown format."
+        )
+    }

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.config
+
+public interface Configured {
+
+    public fun <T> configAs(cls: Class<T>): T
+}
+
+public inline fun <reified T> Configured.configAs(): T =
+    configAs(T::class.java)

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
@@ -26,10 +26,40 @@
 
 package io.spine.protodata.config
 
+/**
+ * A ProtoData component which obtains the configuration provided by the user.
+ */
 public interface Configured {
 
+    /**
+     * Obtains the configuration provided by the user as an instance of the given class.
+     *
+     * It is the API user's responsibility to know the format of the configuration and provide
+     * an appropriate class.
+     *
+     * For Protobuf messages, either encoded in binary or in the Protobuf JSON format, the [cls]
+     * must be a subtype of [com.google.protobuf.Message] and must be able to deserialize from
+     * the given binary/JSON.
+     *
+     * For JSON/YAML configuration, we use [Jackson](https://github.com/FasterXML/jackson) to
+     * deserialize values. Users may use Jackson's API, such as annotations and modules to define
+     * classes to represent the configuration. Modules will be included automatically via classpath
+     * scanning.
+     *
+     * In Kotlin, the simplest way to define a type compatible with a configuration is a data class.
+     * Jackson is capable of working with Kotlin `val`-s, so the data class can be immutable.
+     * In Java, Jackson is capable of working with immutable types as well, however it may require
+     * some annotations to be added to the class. See the Jackson doc for more info.
+     *
+     * @throws io.spine.protodata.ConfigurationError if no configuration is provided to ProtoData
+     */
     public fun <T> configAs(cls: Class<T>): T
 }
 
+/**
+ * Obtains the configuration provided by the user as an instance of the given class.
+ *
+ * This is Kotlin-specific convenience API. See [the general API][Configured.configAs] for more.
+ */
 public inline fun <reified T> Configured.configAs(): T =
     configAs(T::class.java)

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Configured.kt
@@ -37,7 +37,7 @@ public interface Configured {
      * It is the API user's responsibility to know the format of the configuration and provide
      * an appropriate class.
      *
-     * For Protobuf messages, either encoded in binary or in the Protobuf JSON format, the [cls]
+     * For Protobuf messages, encoded either in binary or in the Protobuf JSON format, the [cls]
      * must be a subtype of [com.google.protobuf.Message] and must be able to deserialize from
      * the given binary/JSON.
      *

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfiguredQuerying.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfiguredQuerying.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.config
+
+import com.google.common.io.CharSource
+import com.google.common.io.Files.asByteSource
+import io.spine.protodata.ConfigurationError
+import io.spine.protodata.Querying
+import io.spine.protodata.config.Config.KindCase.EMPTY
+import io.spine.protodata.config.Config.KindCase.FILE
+import io.spine.protodata.config.Config.KindCase.KIND_NOT_SET
+import io.spine.protodata.config.Config.KindCase.RAW
+import io.spine.protodata.select
+import io.spine.protodata.theOnly
+import java.nio.charset.Charset.defaultCharset
+import kotlin.io.path.Path
+
+public interface ConfiguredQuerying : Querying, Configured {
+
+    override fun <T> configAs(cls: Class<T>): T {
+        val configurations = select<Config>().all()
+        val config = configurations.theOnly()
+        return when (config.kindCase!!) {
+            FILE -> parseFile(config.file, cls)
+            RAW -> parseRaw(config.raw, cls)
+            EMPTY, KIND_NOT_SET -> throw ConfigurationError(
+                "No configuration provided. Expected `${cls.canonicalName}`."
+            )
+        }
+    }
+}
+
+private fun <T> parseFile(file: ConfigFile, cls: Class<T>): T {
+    val path = Path(file.path)
+    val format = formatOf(path)
+    val bytes = asByteSource(path.toFile())
+    return format.parser.parse(bytes, cls)
+}
+
+private fun <T> parseRaw(config: RawConfig, cls: Class<T>): T {
+    val bytes = CharSource
+        .wrap(config.value)
+        .asByteSource(defaultCharset())
+    return config.format.parser.parse(bytes, cls)
+}

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.config
+
+import com.google.common.annotations.VisibleForTesting
+import io.spine.protodata.file.Glob
+import java.nio.file.Path
+
+internal fun ConfigurationFormat.matches(file: Path): Boolean =
+    extensions
+            .map(Glob::extension)
+            .any { it.matches(file) }
+
+@VisibleForTesting
+internal val ConfigurationFormat.extensions: Set<String>
+    get() = valueDescriptor.options.getExtension(ConfigurationProto.extension).toSet()

--- a/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
@@ -30,6 +30,9 @@ import com.google.common.annotations.VisibleForTesting
 import io.spine.protodata.file.Glob
 import java.nio.file.Path
 
+/**
+ * Checks if the given file matches this configuration format.
+ */
 internal fun ConfigurationFormat.matches(file: Path): Boolean =
     extensions
             .map(Glob::extension)

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -32,8 +32,8 @@ import io.spine.base.EntityState
 import io.spine.base.EventMessage
 import io.spine.logging.Logging
 import io.spine.protodata.ConfigurationError
-import io.spine.protodata.Querying
 import io.spine.protodata.QueryingClient
+import io.spine.protodata.config.ConfiguredQuerying
 import io.spine.server.BoundedContext
 import io.spine.server.event.AbstractEventReactor
 import io.spine.server.type.EventClass
@@ -80,9 +80,12 @@ import io.spine.server.type.EventClass
  *
  * @param E the type of the event handled by this policy
  */
-public abstract class Policy<E : EventMessage> : AbstractEventReactor(), Querying, Logging {
+public abstract class Policy<E : EventMessage> :
+    AbstractEventReactor(),
+    ConfiguredQuerying,
+    Logging {
 
-    private var context: BoundedContext? = null
+    private lateinit var context: BoundedContext
 
     /**
      * Handles an event and produces some number of events in responce.
@@ -95,7 +98,7 @@ public abstract class Policy<E : EventMessage> : AbstractEventReactor(), Queryin
     }
 
     final override fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> {
-        return QueryingClient(context!!, type, javaClass.name)
+        return QueryingClient(context, type, javaClass.name)
     }
 
     final override fun messageClasses(): ImmutableSet<EventClass> {
@@ -112,4 +115,6 @@ public abstract class Policy<E : EventMessage> : AbstractEventReactor(), Queryin
             )
         }
     }
+
+    final override fun <T> configAs(cls: Class<T>): T = super.configAs(cls)
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -27,8 +27,8 @@
 package io.spine.protodata.renderer
 
 import io.spine.base.EntityState
-import io.spine.protodata.Querying
 import io.spine.protodata.QueryingClient
+import io.spine.protodata.config.ConfiguredQuerying
 import io.spine.protodata.language.Language
 import io.spine.server.BoundedContext
 
@@ -42,7 +42,7 @@ import io.spine.server.BoundedContext
 public abstract class Renderer
 protected constructor(
     private val supportedLanguage: Language
-) : Querying {
+) : ConfiguredQuerying {
 
     internal lateinit var protoDataContext: BoundedContext
 
@@ -66,4 +66,6 @@ protected constructor(
     final override fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> {
         return QueryingClient(protoDataContext, type, javaClass.name)
     }
+
+    final override fun <T> configAs(cls: Class<T>): T = super.configAs(cls)
 }

--- a/compiler/src/main/proto/spine/protodata/configuration.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration.proto
@@ -27,7 +27,9 @@ message Config {
     }
 }
 
-message ConfigId {}
+message ConfigId {
+    string value = 1;
+}
 
 message ConfigFile {
 

--- a/compiler/src/main/proto/spine/protodata/configuration.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package spine.protodata;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.config";
+option java_outer_classname = "ConfigurationProto";
+option java_multiple_files = true;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+
+message Config {
+    option (entity).kind = PROJECTION;
+
+    ConfigId id = 1;
+
+    oneof kind {
+
+        google.protobuf.Empty empty = 2;
+
+        ConfigFile file = 3;
+
+        RawConfig raw = 4;
+    }
+}
+
+message ConfigId {}
+
+message ConfigFile {
+
+    string path = 1;
+}
+
+message RawConfig {
+
+    string value = 1;
+
+    ConfigurationFormat format = 2;
+}
+
+extend google.protobuf.EnumValueOptions {
+
+    repeated string extension = 73980;
+}
+
+enum ConfigurationFormat {
+
+    RCF_UNKNOWN = 0;
+
+    PROTO_BINARY = 1 [(extension) = "pb", (extension) = "bin"];
+
+    PROTO_JSON = 2 [(extension) = "pb.json"];
+
+    JSON = 3 [(extension) = "json"];
+
+    YAML = 4 [(extension) = "yaml", (extension) = "yml"];
+}

--- a/compiler/src/main/proto/spine/protodata/configuration.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration.proto
@@ -12,6 +12,13 @@ option java_multiple_files = true;
 import "google/protobuf/empty.proto";
 import "google/protobuf/descriptor.proto";
 
+// A view on the ProtoData user configuration.
+//
+// Describes the parameters passed by the user to ProtoData. The user may then obtain those
+// parameters by finding the instance of this view.
+//
+// There can only ever be one `Config` instance.
+//
 message Config {
     option (entity).kind = PROJECTION;
 
@@ -27,15 +34,28 @@ message Config {
     }
 }
 
+// The ID of the `Config` view.
+//
+// It is required by the Spine framework that the ID was a non-empty message. By convention, there
+// is only one `Config` with the ID value "configuration_instance".
+//
 message ConfigId {
     string value = 1;
 }
 
+// A file which contains the configuration.
+//
+// The format of the configuration is inferred from the file extension.
+//
 message ConfigFile {
 
     string path = 1;
 }
 
+// The raw string representation of the configuration.
+//
+// The format of the raw configuration can be `PROTO_JSON`, `JSON`, or `YAML`.
+//
 message RawConfig {
 
     string value = 1;
@@ -45,18 +65,28 @@ message RawConfig {
 
 extend google.protobuf.EnumValueOptions {
 
-    repeated string extension = 73980;
+    // Possible file extensions associated with a file format.
+    //
+    // Only applicable to the `ConfigurationFormat` enum.
+    //
+    repeated string extension = 73980 [(internal) = true];
 }
 
+// The format of a custom configuration for ProtoData.
+//
 enum ConfigurationFormat {
 
     RCF_UNKNOWN = 0;
 
+    // A Protobuf message encoded in binary.
     PROTO_BINARY = 1 [(extension) = "pb", (extension) = "bin"];
 
+    // A Protobuf message encoded in Protobuf JSON.
     PROTO_JSON = 2 [(extension) = "pb.json"];
 
+    // A plain JSON value.
     JSON = 3 [(extension) = "json"];
 
+    // A plain YAML value.
     YAML = 4 [(extension) = "yaml", (extension) = "yml"];
 }

--- a/compiler/src/main/proto/spine/protodata/configuration.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration.proto
@@ -89,4 +89,7 @@ enum ConfigurationFormat {
 
     // A plain YAML value.
     YAML = 4 [(extension) = "yaml", (extension) = "yml"];
+
+    // A plain string value.
+    PLAIN = 5;
 }

--- a/compiler/src/main/proto/spine/protodata/configuration_events.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration_events.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package spine.protodata;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.config";
+option java_outer_classname = "ConfigurationEventsProto";
+option java_multiple_files = true;
+
+import "spine/protodata/configuration.proto";
+
+message FileConfigDiscovered {
+
+    ConfigFile file = 1;
+}
+
+message RawConfigDiscovered {
+
+    RawConfig config = 1;
+}

--- a/compiler/src/main/proto/spine/protodata/configuration_events.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration_events.proto
@@ -11,11 +11,13 @@ option java_multiple_files = true;
 
 import "spine/protodata/configuration.proto";
 
+// An event emitted when the user configures ProtoData via a config file.
 message FileConfigDiscovered {
 
     ConfigFile file = 1;
 }
 
+// An event emitted when the user configures ProtoData via a raw string config value.
 message RawConfigDiscovered {
 
     RawConfig config = 1;

--- a/compiler/src/test/kotlin/io/spine/protodata/AstTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/AstTest.kt
@@ -40,8 +40,6 @@ import org.junit.jupiter.api.Test
 
 class `AST extensions should` {
 
-
-
     @Nested
     inner class `Check if a field is` {
 

--- a/compiler/src/test/kotlin/io/spine/protodata/ConfigurationContextTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ConfigurationContextTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import com.google.common.collect.ImmutableSet
+import com.google.common.truth.Truth.assertThat
+import io.spine.base.EventMessage
+import io.spine.protodata.config.ConfigFile
+import io.spine.protodata.config.ConfigurationFormat
+import io.spine.protodata.config.FileConfigDiscovered
+import io.spine.protodata.config.RawConfig
+import io.spine.protodata.config.RawConfigDiscovered
+import io.spine.server.BoundedContext
+import io.spine.server.BoundedContextBuilder
+import io.spine.server.event.EventDispatcher
+import io.spine.server.type.EventClass
+import io.spine.server.type.EventEnvelope
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class `'ConfigurationContext' should` {
+
+    private lateinit var context: BoundedContext
+    private lateinit var subscriber: TestSubscriber
+
+    @BeforeEach
+    fun prepareReceiverContext() {
+        subscriber = TestSubscriber()
+        context = BoundedContextBuilder.assumingTests()
+            .addEventDispatcher(subscriber)
+            .build()
+    }
+
+    @AfterEach
+    fun closeContext() {
+        context.close()
+    }
+
+    @Test
+    fun `emit file configuration event`() {
+        val event = FileConfigDiscovered.newBuilder()
+            .setFile(ConfigFile.newBuilder().setPath("foo/bar.bin"))
+            .build()
+        checkEvent(event)
+    }
+
+    @Test
+    fun `emit raw configuration event`() {
+        val raw = RawConfig
+            .newBuilder()
+            .setFormat(ConfigurationFormat.JSON)
+            .setValue("{}")
+            .build()
+        val event = RawConfigDiscovered
+            .newBuilder()
+            .setConfig(raw)
+            .build()
+        checkEvent(event)
+    }
+
+    private fun checkEvent(event: EventMessage) {
+        ConfigurationContext().use {
+            it.emitted(event)
+        }
+        assertThat(subscriber.receivedEvents)
+            .containsExactly(event)
+    }
+}
+
+private class TestSubscriber : EventDispatcher {
+
+    val receivedEvents = mutableListOf<EventMessage>()
+
+    override fun messageClasses(): ImmutableSet<EventClass> = externalEventClasses()
+
+    override fun dispatch(envelope: EventEnvelope) {
+        receivedEvents.add(envelope.message())
+    }
+
+    override fun externalEventClasses(): ImmutableSet<EventClass> =
+        EventClass.setOf(FileConfigDiscovered::class.java, RawConfigDiscovered::class.java)
+
+    override fun domesticEventClasses(): ImmutableSet<EventClass> =
+        EventClass.emptySet()
+}

--- a/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
@@ -28,6 +28,7 @@ package io.spine.protodata
 
 import com.google.common.truth.Truth.assertThat
 import io.spine.protodata.config.ConfigurationFormat.JSON
+import io.spine.protodata.config.ConfigurationFormat.PLAIN
 import io.spine.protodata.config.ConfigurationFormat.PROTO_BINARY
 import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
 import io.spine.protodata.config.ConfigurationFormat.RCF_UNKNOWN
@@ -50,5 +51,7 @@ class `ConfigurationFormat should` {
             .containsExactly("pb", "bin")
         assertThat(YAML.extensions)
             .containsExactly("yml", "yaml")
+        assertThat(PLAIN.extensions)
+            .isEmpty()
     }
 }

--- a/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import com.google.common.truth.Truth.assertThat
+import io.spine.protodata.config.ConfigurationFormat.JSON
+import io.spine.protodata.config.ConfigurationFormat.PROTO_BINARY
+import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
+import io.spine.protodata.config.ConfigurationFormat.RCF_UNKNOWN
+import io.spine.protodata.config.ConfigurationFormat.YAML
+import io.spine.protodata.config.extensions
+import org.junit.jupiter.api.Test
+
+class `ConfigurationFormat should` {
+
+    @Test
+    fun `provide allowed extensions`() {
+        assertThat(RCF_UNKNOWN.extensions)
+            .isEmpty()
+
+        assertThat(JSON.extensions)
+            .containsExactly("json")
+        assertThat(PROTO_JSON.extensions)
+            .containsExactly("pb.json")
+        assertThat(PROTO_BINARY.extensions)
+            .containsExactly("pb", "bin")
+        assertThat(YAML.extensions)
+            .containsExactly("yml", "yaml")
+    }
+}

--- a/compiler/src/test/kotlin/io/spine/protodata/ContextTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ContextTest.kt
@@ -56,7 +56,9 @@ class `'Code Generation' context should` {
             .addProtoFile(protoDescriptor)
             .addFileToGenerate(protoDescriptor.name)
             .build()
-        ProtobufCompilerContext.emitted(CompilerEvents.parse(set))
+        ProtobufCompilerContext().use {
+            it.emitted(CompilerEvents.parse(set))
+        }
 
         val path = DoctorProto.getDescriptor().path()
         val assertSourceFile = ctx.assertEntity(path, ProtoSourceFileView::class.java)

--- a/compiler/src/test/kotlin/io/spine/protodata/MoreCollectionsTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/MoreCollectionsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import com.google.common.truth.Truth.assertThat
+import java.util.stream.Stream
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class `Collection extensions should` {
+
+    @Test
+    fun `obtain the only element of a collection`() {
+        val list = listOf(42)
+        assertThat(list.theOnly())
+            .isEqualTo(42)
+    }
+
+    @Test
+    fun `fail to obtain the only element if collection is empty`() {
+        val set = setOf<Any>()
+        assertThrows<NoSuchElementException> { set.theOnly() }
+    }
+
+    @Test
+    fun `fail to obtain the only element if collection has many elements`() {
+        val set = setOf<Any>("foo", "bar")
+        assertThrows<IllegalArgumentException> { set.theOnly() }
+    }
+
+    @ParameterizedTest
+    @MethodSource("interlaceCollections")
+    fun `interlace a collection`(elements: List<Any>, separator: Any, expected: List<Any>) {
+        assertThat(elements.interlaced(separator).toList())
+            .isEqualTo(expected)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun interlaceCollections(): Stream<Arguments> = Stream.of(
+            arguments(listOf(0, 1, 2), 42, listOf(0, 42, 1, 42, 2)),
+            arguments(
+                listOf("sea", "Moon", "Earth", "Sun"),
+                "of",
+                listOf("sea", "of", "Moon", "of", "Earth", "of", "Sun")
+            ),
+            arguments(listOf<String>(), "doesn't matter", listOf<String>()),
+        )
+    }
+}

--- a/compiler/src/test/kotlin/io/spine/protodata/MoreCollectionsTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/MoreCollectionsTest.kt
@@ -65,6 +65,7 @@ class `Collection extensions should` {
 
     companion object {
 
+        @Suppress("unused") // Used by JUnit.
         @JvmStatic
         fun interlaceCollections(): Stream<Arguments> = Stream.of(
             arguments(listOf(0, 1, 2), 42, listOf(0, 42, 1, 42, 2)),

--- a/compiler/src/test/kotlin/io/spine/protodata/QueryingClientTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/QueryingClientTest.kt
@@ -59,7 +59,9 @@ class `'QueryingClient' should` {
             .addAllFileToGenerate(files.map { it.name })
             .build()
         val events = CompilerEvents.parse(request)
-        ProtobufCompilerContext.emitted(events)
+        ProtobufCompilerContext().use {
+            it.emitted(events)
+        }
     }
 
     @AfterEach

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish").version("0.15.0")
     `version-to-resources`
+    jacoco
 }
 
 val spineBaseVersion: String by extra

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
@@ -32,11 +32,13 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.OutputDirectory
 
@@ -50,7 +52,7 @@ import org.gradle.api.tasks.OutputDirectory
  * Users should NOT change the CLI command, user directory, etc. directly.
  * Please refer to the `protoData { }` extension to configure ProtoData.
  */
-public open class LaunchProtoData : JavaExec() {
+public abstract class LaunchProtoData : JavaExec() {
 
     @get:Input
     internal lateinit var renderers: Provider<List<String>>
@@ -79,6 +81,9 @@ public open class LaunchProtoData : JavaExec() {
     @get:InputFiles
     internal lateinit var protoDataConfig: Configuration
 
+    @get:Internal
+    public abstract val configuration: RegularFileProperty
+
     /**
      * Configures the CLI command for this task.
      *
@@ -103,7 +108,7 @@ public open class LaunchProtoData : JavaExec() {
                 yield(it)
             }
             yield("--request")
-            yield(requestFile.get().asFile.absolutePath)
+            yield(project.file(requestFile).absolutePath)
 
             yield("--source-root")
             yield(source.absolutePath)
@@ -115,6 +120,11 @@ public open class LaunchProtoData : JavaExec() {
             if (userCp.isNotEmpty()) {
                 yield("--user-classpath")
                 yield(userCp)
+            }
+
+            if (configuration.isPresent) {
+                yield("--configuration-file")
+                yield(project.file(configuration).absolutePath)
             }
         }.asIterable()
         if (logger.isDebugEnabled) {

--- a/protoc/build.gradle.kts
+++ b/protoc/build.gradle.kts
@@ -26,6 +26,10 @@
 
 import io.spine.internal.dependency.Protobuf
 
+plugins {
+    jacoco
+}
+
 dependencies {
     Protobuf.libs.forEach { implementation(it) }
 }

--- a/protoc/src/main/kotlin/io/spine/protodata/protoc/Plugin.kt
+++ b/protoc/src/main/kotlin/io/spine/protodata/protoc/Plugin.kt
@@ -46,6 +46,6 @@ public fun main() {
                .mkdirs()
     requestFile.writeBytes(request.toByteArray(), CREATE, TRUNCATE_EXISTING)
 
-    val emptyResponce = CodeGeneratorResponse.getDefaultInstance()
-    System.out.write(emptyResponce.toByteArray())
+    val emptyResponse = CodeGeneratorResponse.getDefaultInstance()
+    System.out.write(emptyResponse.toByteArray())
 }

--- a/protoc/src/test/kotlin/io/spine/protodata/protoc/PluginTest.kt
+++ b/protoc/src/test/kotlin/io/spine/protodata/protoc/PluginTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.protoc
+
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.TimestampProto
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import com.google.protobuf.compiler.PluginProtos.Version
+import java.io.ByteArrayInputStream
+import java.io.File
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class `Protobuf compiler plugin should` {
+
+    private lateinit var file: File
+
+    @BeforeEach
+    fun prepareFile(@TempDir dir: File) {
+        file = dir.resolve("request.bin")
+    }
+
+    @Test
+    fun `write code generation request into the given file`() {
+        checkWritesRequestToFile()
+    }
+
+    @Test
+    fun `overwrite existing file`() {
+        file.writeText("""
+               This is a place holder designed to be longer than
+               the code generation request.
+        """.trimIndent().repeat(100))
+
+        checkWritesRequestToFile()
+    }
+
+    private fun checkWritesRequestToFile() {
+        val request = constructRequest()
+        launchMain(request)
+        val read = file.readBytes()
+        val restoredRequest = CodeGeneratorRequest.parseFrom(read)
+        assertThat(restoredRequest)
+            .isEqualTo(request)
+    }
+
+    private fun constructRequest(): CodeGeneratorRequest {
+        val version = Version
+            .newBuilder()
+            .setMajor(42)
+            .setMinor(314)
+            .setPatch(271)
+            .build()
+        return CodeGeneratorRequest
+            .newBuilder()
+            .addProtoFile(TimestampProto.getDescriptor().toProto())
+            .addFileToGenerate("google/protobuf/timestamp.proto")
+            .setCompilerVersion(version)
+            .setParameter(file.absolutePath)
+            .build()
+    }
+
+    private fun launchMain(request: CodeGeneratorRequest) {
+        val requestStream = ByteArrayInputStream(request.toByteArray())
+        val stdIn = System.`in`
+        try {
+            System.setIn(requestStream)
+            main()
+        } finally {
+            System.setIn(stdIn)
+        }
+    }
+}

--- a/tests/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/tests/buildSrc/src/main/groovy/license-report-project.gradle
@@ -74,7 +74,7 @@ class MarkdownReportRenderer implements ReportRenderer {
     }
 
     @Input
-    private String getFileNameCache() { return this.fileName }
+    String getFileNameCache() { return this.fileName }
 
     void render(final ProjectData data) {
         project = data.project

--- a/tests/buildSrc/src/main/groovy/publish-proto.gradle
+++ b/tests/buildSrc/src/main/groovy/publish-proto.gradle
@@ -82,7 +82,7 @@ artifacts {
  * except those included into the returned {@code Collection}.
  */
 Collection<File> collectProto() {
-    final def dependencies = configurations.compile.files
+    final def dependencies = configurations.runtimeClasspath.files
     final def jarFiles = dependencies.collect { JarFileName.ofFile(it) }
     final def result = new HashSet<>()
     for (final File jarFile in dependencies) {

--- a/tests/buildSrc/src/main/kotlin/integration-test.gradle.kts
+++ b/tests/buildSrc/src/main/kotlin/integration-test.gradle.kts
@@ -26,18 +26,8 @@
 
 import io.spine.internal.gradle.RunBuild
 
-val protoDataLocationProperty = "protoDataLocation"
-
-allprojects {
-    extra["protoDataLocationProperty"] = protoDataLocationProperty
-}
-
 val integrationTest by tasks.creating(RunBuild::class) {
     directory = "$rootDir/tests"
-    includeGradleProperties.add(protoDataLocationProperty)
-
-    dependsOn(":cli:installProtoData")
 }
 
 tasks["check"].finalizedBy(integrationTest)
-

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -35,4 +35,6 @@ object Jackson {
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
     // https://github.com/FasterXML/jackson-dataformats-text/releases
     const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
+    // https://github.com/FasterXML/jackson-module-kotlin/releases
+    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,9 +28,11 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.12.3"
+    private const val version = "2.12.4"
     // https://github.com/FasterXML/jackson-databind
     const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
     // https://github.com/FasterXML/jackson-dataformat-xml/releases
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
+    // https://github.com/FasterXML/jackson-dataformats-text/releases
+    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.0"
+    const val version      = "1.5.20"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
@@ -39,7 +39,7 @@ object Kotlin {
     // https://github.com/Kotlin/dokka
     object Dokka {
 
-        const val version = "1.4.32"
+        const val version = "1.5.0"
         const val pluginId = "org.jetbrains.dokka"
     }
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,13 +29,14 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.17.0"
+    const val version    = "3.17.3"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
     )
     const val compiler = "com.google.protobuf:protoc:${version}"
 
+    // https://github.com/google/protobuf-gradle-plugin/releases
     object GradlePlugin {
         const val version = "0.8.16"
         const val id = "com.google.protobuf"

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
 object Roaster {
-    private const val version = "2.22.2.Final"
+    private const val version = "2.23.0.Final"
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -129,8 +129,8 @@ fun ConfigurationContainer.excludeProtobufLite() {
         )
     }
 
-    excludeProtoLite("runtime")
-    excludeProtoLite("testRuntime")
+    excludeProtoLite("runtimeOnly")
+    excludeProtoLite("testRuntimeOnly")
 }
 
 @Suppress("unused")

--- a/testutil/src/main/kotlin/io/spine/protodata/test/EchoRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/EchoRenderer.kt
@@ -65,4 +65,12 @@ public class ProtoEchoRenderer : Renderer(any) {
     }
 }
 
+public class PlainStringRenderer : Renderer(any) {
+
+    override fun render(sources: SourceSet) {
+        val echo = configAs<String>()
+        sources.createFile(Path(ECHO_FILE), echo)
+    }
+}
+
 public data class Name(public val value: String)

--- a/testutil/src/main/kotlin/io/spine/protodata/test/EchoRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/EchoRenderer.kt
@@ -26,19 +26,42 @@
 
 package io.spine.protodata.test
 
+import com.google.protobuf.StringValue
+import io.spine.protobuf.AnyPacker
 import io.spine.protodata.config.configAs
-import io.spine.protodata.language.CommonLanguages
+import io.spine.protodata.language.CommonLanguages.any
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceSet
+import io.spine.protodata.tesst.Echo
+import io.spine.time.toInstant
 import kotlin.io.path.Path
 
-public const val GREETING_FILE: String = "name.txt";
+public const val ECHO_FILE: String = "name.txt"
 
-public class GreetingRenderer : Renderer(CommonLanguages.Java) {
+public class EchoRenderer : Renderer(any) {
 
     override fun render(sources: SourceSet) {
         val name = configAs<Name>()
-        sources.createFile(Path(GREETING_FILE), name.value)
+        sources.createFile(Path(ECHO_FILE), name.value)
+    }
+}
+
+public class ProtoEchoRenderer : Renderer(any) {
+
+    override fun render(sources: SourceSet) {
+        val echo = configAs<Echo>()
+        val message = buildString {
+            with(echo) {
+                append(`when`.toInstant())
+                append(':')
+                val arg = AnyPacker.unpack(arg, StringValue::class.java)
+                val formatted = message.format(arg.value)
+                append(formatted)
+                append(':')
+                append(extraMessage.value)
+            }
+        }
+        sources.createFile(Path(ECHO_FILE), message)
     }
 }
 

--- a/testutil/src/main/kotlin/io/spine/protodata/test/GreedyPolicy.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/GreedyPolicy.kt
@@ -33,6 +33,9 @@ import io.spine.protodata.plugin.Policy
 import io.spine.server.event.React
 import io.spine.server.model.Nothing
 
+/**
+ * A greedy policy reacts to more than one event.
+ */
 public class GreedyPolicy : Policy<TypeEntered>() {
 
     @React

--- a/testutil/src/main/kotlin/io/spine/protodata/test/GreetingRenderer.kt
+++ b/testutil/src/main/kotlin/io/spine/protodata/test/GreetingRenderer.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.test
+
+import io.spine.protodata.config.configAs
+import io.spine.protodata.language.CommonLanguages
+import io.spine.protodata.renderer.Renderer
+import io.spine.protodata.renderer.SourceSet
+import kotlin.io.path.Path
+
+public const val GREETING_FILE: String = "name.txt";
+
+public class GreetingRenderer : Renderer(CommonLanguages.Java) {
+
+    override fun render(sources: SourceSet) {
+        val name = configAs<Name>()
+        sources.createFile(Path(GREETING_FILE), name.value)
+    }
+}
+
+public data class Name(public val value: String)

--- a/testutil/src/main/proto/spine/protodata/test/echo.proto
+++ b/testutil/src/main/proto/spine/protodata/test/echo.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package spine.protodata.tesst;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.tesst";
+option java_outer_classname = "EchoProto";
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/any.proto";
+
+message Echo {
+
+    google.protobuf.Timestamp when = 1;
+
+    string message = 2;
+
+    google.protobuf.StringValue extra_message = 3;
+
+    google.protobuf.Any arg = 4;
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.23"
+extra["protoDataVersion"] = "0.0.24"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.34"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.26"


### PR DESCRIPTION
## Configuration API

In this PR we introduce configuration API for users to pass custom configuration to their ProtoData extensions.

As of now, users may choose between 5 formats to provide configuration:
 - a Protobuf message encoded in binary;
 - a Protobuf message encoded as a Protobuf JSON string;
 - a plain JSON;
 - a YAML;
 - a plain string value.

JSON and YAML values are deserialized into Java objects using Jackson. Users may choose to use Jackson annotations, modules, etc. to improve the configuration model.

To specify the configuration, users may supply a file with the serialized configuration in one of the supported formats. ProtoData infers the format from the file extension: `.bin` and `.pb` are for Protobuf binary, `.pb.json` is for Protobuf JSON, `.json` is for plain JSON, `.yaml` and `.yml` are for YAML. Users cannot provide a plain string configuration via a file.

Another way to specify the configuration is by providing its raw value via a CLI argument. This option is not available for the Protobuf binary format. A second CLI argument is required to specify the format of the configuration.
For example:
```
protodata <...> --configuration-value "foo:bar" ----configuration-format plain
```

When using the Gradle plugin, the only option for specifying the configuration is by a configuration file.

## Code coverage

In this PR we enable code coverage reports for the project.
We collect coverage info from a selected subset of subprojects.
Some low-hanging-fruit coverage wholes were patched right away. More may come in the nearest future.