### PR TITLE
Remove Kotlin plugin from a non-Kotlin project

### DIFF
--- a/tests/protodata-extension/build.gradle.kts
+++ b/tests/protodata-extension/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import io.spine.internal.gradle.Scripts
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("RemoveRedundantQualifierName")
 buildscript {
@@ -36,21 +35,6 @@ buildscript {
     val spineBaseVersion: String by extra
     dependencies {
         classpath("io.spine.tools:spine-mc-java:$spineBaseVersion")
-    }
-}
-// TODO:2021-06-22:dmytro.dashenkov: https://github.com/SpineEventEngine/ProtoData/issues/24
-plugins {
-    kotlin("jvm") version io.spine.internal.dependency.Kotlin.version
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = freeCompilerArgs + listOf(
-            "-Xopt-in=kotlin.io.path.ExperimentalPathApi,kotlin.ExperimentalUnsignedTypes",
-            "-Xinline-classes",
-            "-Xjvm-default=all"
-        )
     }
 }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.24"
+extra["protoDataVersion"] = "0.0.25"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.34"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.26"


### PR DESCRIPTION
We used to have to apply the Kotlin Gradle plugin to Java-only projects so that IntelliJ does not report false compiler errors.
Now, this bug is fixed in the IDE and we don't have to have the unnecessary plugin there.