### PR TITLE
Simplify field getters

### DIFF
--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Expression.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Expression.kt
@@ -284,14 +284,7 @@ internal constructor(
      * A getter expression for the associated field.
      */
     public val getter: MethodCall
-        get() {
-            val simpleAccess = MethodCall(message, getterName)
-            return when (cardinality) {
-                LIST -> immutableListClass.call(COPY_OF, listOf(simpleAccess))
-                MAP -> immutableMapClass.call(COPY_OF, listOf(simpleAccess))
-                else -> simpleAccess
-            }
-        }
+        get() = MethodCall(message, getterName)
 
     /**
      * Constructs a setter expression for the associated field.

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/ExpressionTest.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/ExpressionTest.kt
@@ -26,8 +26,6 @@
 
 package io.spine.protodata.codegen.java
 
-import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Empty
@@ -143,8 +141,7 @@ class `'MessageReference' should` {
             .setList(Empty.getDefaultInstance())
             .build()
         val fieldAccess = messageReference.field(field)
-        assertCode(fieldAccess.getter,
-                   "${ImmutableList::class.qualifiedName}.copyOf(msg.getBazList())")
+        assertCode(fieldAccess.getter, "msg.getBazList()")
     }
 
     @Test
@@ -156,8 +153,7 @@ class `'MessageReference' should` {
             .setMap(Field.OfMap.newBuilder().setKeyType(TYPE_STRING))
             .build()
         val fieldAccess = messageReference.field(field)
-        assertCode(fieldAccess.getter,
-                   "${ImmutableMap::class.qualifiedName}.copyOf(msg.getBazMap())")
+        assertCode(fieldAccess.getter, "msg.getBazMap()")
     }
 }
 

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/FieldAccessTest.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/FieldAccessTest.kt
@@ -55,9 +55,7 @@ class `'FieldAccess' should` {
         val access = listField().access()
         assertCode(
             access.getter,
-            prefix = "$IMMUTABLE_LIST.copyOf(",
             accessor = "getRouteList()",
-            suffix = ")"
         )
     }
 
@@ -66,9 +64,7 @@ class `'FieldAccess' should` {
         val access = mapField().access()
         assertCode(
             access.getter,
-            prefix = "$IMMUTABLE_MAP.copyOf(",
             accessor = "getAttributesMap()",
-            suffix = ")"
         )
     }
 
@@ -147,10 +143,8 @@ private fun oneofField() = Field
 
 private fun assertCode(
     expression: Expression,
-    accessor: String,
-    prefix: String = "",
-    suffix: String = ""
+    accessor: String
 ) {
     assertThat(expression.toCode())
-        .isEqualTo("${prefix}msg.${accessor}${suffix}")
+        .isEqualTo("msg.${accessor}")
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.26"
+extra["protoDataVersion"] = "0.0.27"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.34"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.26"


### PR DESCRIPTION
Previously, a field getter for a list or a map field used to copy the field contents into a Guava immutable collection.

Now, we remove copying. API users should do it manually if then need.