### PR TITLE
Policy Contract

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/AstExtension.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/AstExtension.kt
@@ -77,7 +77,9 @@ public fun TypeName.qualifiedName(): String {
     names.add(packageName)
     names.addAll(nestingTypeNameList)
     names.add(simpleName)
-    return names.joinToString(separator = ".")
+    return names
+        .filter { it.isNotEmpty() }
+        .joinToString(separator = ".")
 }
 
 /**

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableSet
 import com.google.protobuf.Message
 import io.spine.base.EntityState
 import io.spine.base.EventMessage
+import io.spine.core.ContractFor
+import io.spine.core.Subscribe
 import io.spine.logging.Logging
 import io.spine.protodata.ConfigurationError
 import io.spine.protodata.QueryingClient
@@ -90,6 +92,7 @@ public abstract class Policy<E : EventMessage> :
     /**
      * Handles an event and produces some number of events in responce.
      */
+    @ContractFor(handler = Subscribe::class)
     public abstract fun whenever(event: E): Iterable<Message>
 
     final override fun registerWith(context: BoundedContext) {

--- a/compiler/src/test/kotlin/io/spine/protodata/AstTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/AstTest.kt
@@ -39,6 +39,8 @@ import io.spine.protodata.test.TopLevelEnum
 import io.spine.protodata.test.TopLevelMessage
 import io.spine.protodata.test.TopLevelMessage.NestedEnum
 import io.spine.protodata.test.TopLevelMessage.NestedMessage.VeryNestedMessage
+import io.spine.protodata.test.packageless.GlobalMessage
+import io.spine.protodata.test.packageless.GlobalMessage.LocalMessage
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -146,6 +148,20 @@ class `AST extensions should` {
             val name = NestedEnum.getDescriptor().name()
             assertThat(name.qualifiedName())
                 .isEqualTo("spine.protodata.test.TopLevelMessage.NestedEnum")
+        }
+
+        @Test
+        fun `for a top-level message without a package`() {
+            val name = GlobalMessage.getDescriptor().name()
+            assertThat(name.typeUrl())
+                .isEqualTo("type.googleapis.com/GlobalMessage")
+        }
+
+        @Test
+        fun `for a nested message without a package`() {
+            val name = LocalMessage.getDescriptor().name()
+            assertThat(name.qualifiedName())
+                .isEqualTo("GlobalMessage.LocalMessage")
         }
     }
 }

--- a/compiler/src/test/proto/spine/protodata/test/packageless_names.proto
+++ b/compiler/src/test/proto/spine/protodata/test/packageless_names.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "io.spine.protodata.test.packageless";
+option java_outer_classname = "PackagelessNamesProto";
+option java_multiple_files = true;
+
+message GlobalMessage {
+    message LocalMessage {
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Extension.kt
@@ -129,6 +129,7 @@ public class Extension(private val project: Project) {
 
     private val srcBaseDirProperty: DirectoryProperty = with(project) {
         objects.directoryProperty().convention(provider {
+            @Suppress("DEPRECATION") // Protobuf Gradle plugin must migrate to extensions.
             val protobuf = convention.getPlugin<ProtobufConvention>().protobuf
             layout.projectDirectory.dir(protobuf.generatedFilesBaseDir)
         })

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/LaunchProtoData.kt
@@ -132,7 +132,7 @@ public abstract class LaunchProtoData : JavaExec() {
         }
         classpath(protoDataConfig)
         classpath(userClasspathConfig)
-        main = "io.spine.protodata.cli.MainKt"
+        mainClass.set("io.spine.protodata.cli.MainKt")
         args(command)
 
         doFirst(CleanAction())

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/ProjectExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/ProjectExtensions.kt
@@ -27,17 +27,17 @@
 package io.spine.protodata.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.getPlugin
+import org.gradle.kotlin.dsl.getByType
 
 /**
  * The [sourceSets][SourceSetContainer] of this project.
  */
 internal val Project.sourceSets: SourceSetContainer
-    get() = convention.getPlugin<JavaPluginConvention>().sourceSets
+    get() = extensions.getByType<JavaPluginExtension>().sourceSets
 
 /**
  * Attempts to obtain the Java compilation Gradle task for the given source set.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.29"
+extra["protoDataVersion"] = "0.0.30"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.40"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.41"


### PR DESCRIPTION
In this PR we update the declaration of `Policy` to adhere to the newly added to Spine contract method definition.

We also fix an issue with constructing a qualified name of a Protobuf type and address the new deprecation warnings that appeared after migrating to Gradle v7.