### PR TITLE
Fix `@ContractFor` in `Policy`

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -31,13 +31,13 @@ import com.google.protobuf.Message
 import io.spine.base.EntityState
 import io.spine.base.EventMessage
 import io.spine.core.ContractFor
-import io.spine.core.Subscribe
 import io.spine.logging.Logging
 import io.spine.protodata.ConfigurationError
 import io.spine.protodata.QueryingClient
 import io.spine.protodata.config.ConfiguredQuerying
 import io.spine.server.BoundedContext
 import io.spine.server.event.AbstractEventReactor
+import io.spine.server.event.React
 import io.spine.server.type.EventClass
 
 /**
@@ -92,7 +92,7 @@ public abstract class Policy<E : EventMessage> :
     /**
      * Handles an event and produces some number of events in responce.
      */
-    @ContractFor(handler = Subscribe::class)
+    @ContractFor(handler = React::class)
     public abstract fun whenever(event: E): Iterable<Message>
 
     final override fun registerWith(context: BoundedContext) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.30"
+extra["protoDataVersion"] = "0.0.31"
 extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.40"
 extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.41"


### PR DESCRIPTION
The annotation on `Policy.whenever` had a wrong type of handler method annotation and thus did not serve its purpose to validate the `protected` method access.