### PR TITLE
Update Spine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,10 @@ subprojects {
         kotlinOptions {
             jvmTarget = "1.8"
             freeCompilerArgs = freeCompilerArgs + listOf(
-                "-Xopt-in=kotlin.io.path.ExperimentalPathApi,kotlin.ExperimentalUnsignedTypes",
+                "-Xopt-in=" +
+                        "kotlin.io.path.ExperimentalPathApi," +
+                        "kotlin.ExperimentalUnsignedTypes," +
+                        "kotlin.experimental.ExperimentalTypeInference",
                 "-Xinline-classes",
                 "-Xjvm-default=all"
             )

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,7 +30,7 @@
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
  *
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below thrice. 
+ * changed in the Kotlin object _and_ in this file below thrice.
  */
 buildscript {
     repositories {
@@ -58,9 +58,24 @@ repositories {
 }
 
 val jacksonVersion = "2.11.0"
+val googleAuthToolVersion = "2.1.1"
 val licenseReportVersion = "1.16"
+val grGitVersion = "3.1.1"
+
+/**
+ * The version of Guava used in `buildSrc`.
+ *
+ * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
+ * Otherwise, when testing Gradle plugins, clashes may occur.
+ */
+val guavaVersion = "30.1.1-jre"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
+        exclude(group = "com.google.guava")
+    }
+    implementation("com.google.guava:guava:$guavaVersion")
+    api("com.github.jk1:gradle-license-report:$licenseReportVersion")
+    implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
 }

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -25,8 +25,8 @@
  */
 //file:noinspection UnnecessaryQualifiedReference
 
-import com.github.jk1.license.*
 import com.github.jk1.license.render.ReportRenderer
+import io.spine.internal.gradle.PublishExtension
 
 /**
  * This script plugin generates the license report for all dependencies used in a project.
@@ -80,8 +80,9 @@ class MarkdownReportRenderer implements ReportRenderer {
         project = data.project
         config = project.licenseReport
         output = new File(config.outputDir, fileName)
+        final String prefix = prefixFor(project)
         output.text = """
-    \n# Dependencies of `$project.group:spine-$project.name:$project.version`
+    \n# Dependencies of `${project.group}:$prefix${project.name}:${project.version}`
 """
         printDependencies(data)
         output << """
@@ -89,7 +90,23 @@ class MarkdownReportRenderer implements ReportRenderer {
         \n The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 """
         output << "\n\nThis report was generated on **${new Date()}**"
-        output << " using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE)."
+        output << " using [Gradle-License-Report plugin]" +
+                "(https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under" +
+                " [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE)."
+    }
+
+    /**
+     * Obtains the artifact prefix for the passed project.
+     *
+     * <p>If the {@code PublishExtension} has the property {@code spinePrefix} set to {@code true}
+     * returns {@code "spine-"}, otherwise an empty string.
+     */
+    private String prefixFor(final Project project) {
+        final publishExtension = project.rootProject.extensions.findByType(PublishExtension.class)
+        final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false)
+                ? "spine-"
+                : ""
+        prefix
     }
 
     private void printDependencies(final ProjectData data) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -26,6 +26,13 @@
 
 package io.spine.internal.dependency
 
+/**
+ * The dependencies for Guava.
+ *
+ * When changing the version, also change the version used in the `build.gradle.kts`. We need
+ * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
+ * Gradle plugins, errors may occur due to version clashes.
+ */
 // https://github.com/google/guava
 object Guava {
     private const val version = "30.1.1-jre"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.20"
+    const val version      = "1.5.30"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -28,13 +28,13 @@ package io.spine.internal.gradle
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import java.io.FileNotFoundException
+import java.net.URL
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import java.io.FileNotFoundException
-import java.net.URL
 
 /**
  * A task which verifies that the current version of the library has not been published to the given
@@ -45,8 +45,8 @@ open class CheckVersionIncrement : DefaultTask() {
     /**
      * The Maven repository in which to look for published artifacts.
      *
-     * We only check the `releases` repository. Artifacts in `snapshots` repository still may be
-     * overridden.
+     * We check both the `releases` and `snapshots` repositories. Artifacts in either of these repos
+     * may not be overwritten.
      */
     @Input
     lateinit var repository: Repository
@@ -57,7 +57,14 @@ open class CheckVersionIncrement : DefaultTask() {
     @TaskAction
     private fun fetchAndCheck() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
-        val repoUrl = repository.releases
+        checkInRepo(repository.snapshots, artifact)
+
+        if (repository.releases != repository.snapshots) {
+            checkInRepo(repository.releases, artifact)
+        }
+    }
+
+    private fun checkInRepo(repoUrl: String, artifact: String) {
         val metadata = fetch(repoUrl, artifact)
         val versions = metadata?.versioning?.versions
         val versionExists = versions?.contains(version) ?: false

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -58,6 +58,12 @@ open class RunGradle : DefaultTask() {
     private lateinit var taskNames: List<String>
 
     /**
+     * For how many minutes to wait for the Gradle build to complete.
+     */
+    @Internal
+    var maxDurationMins: Long = 10
+
+    /**
      * Names of Gradle properties to copy into the launched build.
      *
      * The properties are looked up in the root project. If a property is not found, it is ignored.
@@ -73,6 +79,15 @@ open class RunGradle : DefaultTask() {
      */
     fun task(vararg tasks: String) {
         taskNames = tasks.asList()
+    }
+
+    /**
+     * Sets the maximum time to wait until the build completion in minutes
+     * and specifies task names to be passed to the Gradle Wrapper script.
+     */
+    fun task(maxDurationMins: Long, vararg tasks: String) {
+        taskNames = tasks.asList()
+        this.maxDurationMins = maxDurationMins
     }
 
     @TaskAction
@@ -96,7 +111,7 @@ open class RunGradle : DefaultTask() {
               https://github.com/gradle/gradle/issues/3987
               https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
          */
-        val completed = process.waitFor(10, TimeUnit.MINUTES)
+        val completed = process.waitFor(maxDurationMins, TimeUnit.MINUTES)
         val exitCode = process.exitValue()
         if (!completed || exitCode != 0) {
             val errorOutExists = errorOut.exists()

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Just.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Just.kt
@@ -34,4 +34,18 @@ import io.spine.server.tuple.Tuple
  *
  * Used when returning an iterable from a handler method for better readability over `List<E>`.
  */
-public class Just<E : EventMessage>(event: E) : Tuple(event)
+public class Just<E : EventMessage>(event: E) : Tuple(event) {
+
+    public companion object {
+
+        /**
+         * A factory method for Java.
+         *
+         * Prefer the primary constructor in Kotlin.
+         *
+         * This method is intended to be imported statically.
+         */
+        @JvmStatic
+        public fun <E : EventMessage> just(event: E): Just<E> = Just(event)
+    }
+}

--- a/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -93,7 +93,7 @@ public abstract class Policy<E : EventMessage> :
      * Handles an event and produces some number of events in responce.
      */
     @ContractFor(handler = React::class)
-    public abstract fun whenever(event: E): Iterable<Message>
+    protected abstract fun whenever(event: E): Iterable<Message>
 
     final override fun registerWith(context: BoundedContext) {
         super.registerWith(context)

--- a/compiler/src/test/kotlin/io/spine/protodata/plugin/JustTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/plugin/JustTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.plugin
+
+import com.google.common.truth.Truth.assertThat
+import io.spine.base.Identifier.newUuid
+import io.spine.protodata.test.ProjectCreated
+import org.junit.jupiter.api.Test
+
+class `Just should` {
+
+    @Test
+    fun `store one value`() {
+        val just = Just(validEvent)
+        assertThat(just)
+            .containsExactly(validEvent)
+    }
+
+    @Test
+    fun `initialize via static method`() {
+        val just = Just.just(validEvent)
+        assertThat(just)
+            .containsExactly(validEvent)
+    }
+}
+
+private val validEvent = ProjectCreated
+    .newBuilder()
+    .setId(newUuid())
+    .build()

--- a/compiler/src/test/kotlin/io/spine/protodata/plugin/JustTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/plugin/JustTest.kt
@@ -48,7 +48,6 @@ class `Just should` {
     }
 }
 
-private val validEvent = ProjectCreated
-    .newBuilder()
+private val validEvent = ProjectCreated.newBuilder()
     .setId(newUuid())
-    .build()
+    .vBuild()

--- a/compiler/src/test/proto/spine/protodata/test/events.proto
+++ b/compiler/src/test/proto/spine/protodata/test/events.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package spine.protodata.test;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.test";
+option java_outer_classname = "EventsProto";
+option java_multiple_files = true;
+
+message ProjectCreated {
+    string id = 1;
+}

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -170,10 +170,10 @@ private fun Project.configureProtobufPlugin(extension: Extension, version: Strin
     }
 
 private fun launchTaskName(sourceSet: SourceSet): String =
-    "launchProtoData${sourceSet.name.replaceFirstChar { it.toUpperCase() }}"
+    "launchProtoData${sourceSet.name.replaceFirstChar { it.uppercaseChar() }}"
 
 private fun cleanTaskName(sourceSet: SourceSet): String =
-    "cleanProtoData${sourceSet.name.replaceFirstChar { it.toUpperCase() }}"
+    "cleanProtoData${sourceSet.name.replaceFirstChar { it.uppercaseChar() }}"
 
 private fun Project.configureSourceSets(extension: Extension) {
     afterEvaluate {

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -170,10 +170,10 @@ private fun Project.configureProtobufPlugin(extension: Extension, version: Strin
     }
 
 private fun launchTaskName(sourceSet: SourceSet): String =
-    "launchProtoData${sourceSet.name.capitalize()}"
+    "launchProtoData${sourceSet.name.replaceFirstChar { it.toUpperCase() }}"
 
 private fun cleanTaskName(sourceSet: SourceSet): String =
-    "cleanProtoData${sourceSet.name.capitalize()}"
+    "cleanProtoData${sourceSet.name.replaceFirstChar { it.toUpperCase() }}"
 
 private fun Project.configureSourceSets(extension: Extension) {
     afterEvaluate {

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -170,10 +170,10 @@ private fun Project.configureProtobufPlugin(extension: Extension, version: Strin
     }
 
 private fun launchTaskName(sourceSet: SourceSet): String =
-    "launchProtoData${sourceSet.name.replaceFirstChar { it.uppercaseChar() }}"
+    "launchProtoData${sourceSet.name.capitalize()}"
 
 private fun cleanTaskName(sourceSet: SourceSet): String =
-    "cleanProtoData${sourceSet.name.replaceFirstChar { it.uppercaseChar() }}"
+    "cleanProtoData${sourceSet.name.capitalize()}"
 
 private fun Project.configureSourceSets(extension: Extension) {
     afterEvaluate {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tests/buildSrc/build.gradle.kts
+++ b/tests/buildSrc/build.gradle.kts
@@ -30,7 +30,7 @@
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
  *
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below thrice. 
+ * changed in the Kotlin object _and_ in this file below thrice.
  */
 buildscript {
     repositories {
@@ -58,9 +58,24 @@ repositories {
 }
 
 val jacksonVersion = "2.11.0"
+val googleAuthToolVersion = "2.1.1"
 val licenseReportVersion = "1.16"
+val grGitVersion = "3.1.1"
+
+/**
+ * The version of Guava used in `buildSrc`.
+ *
+ * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
+ * Otherwise, when testing Gradle plugins, clashes may occur.
+ */
+val guavaVersion = "30.1.1-jre"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
+        exclude(group = "com.google.guava")
+    }
+    implementation("com.google.guava:guava:$guavaVersion")
+    api("com.github.jk1:gradle-license-report:$licenseReportVersion")
+    implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
 }

--- a/tests/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/tests/buildSrc/src/main/groovy/license-report-project.gradle
@@ -25,8 +25,8 @@
  */
 //file:noinspection UnnecessaryQualifiedReference
 
-import com.github.jk1.license.*
 import com.github.jk1.license.render.ReportRenderer
+import io.spine.internal.gradle.PublishExtension
 
 /**
  * This script plugin generates the license report for all dependencies used in a project.
@@ -80,8 +80,9 @@ class MarkdownReportRenderer implements ReportRenderer {
         project = data.project
         config = project.licenseReport
         output = new File(config.outputDir, fileName)
+        final String prefix = prefixFor(project)
         output.text = """
-    \n# Dependencies of `$project.group:spine-$project.name:$project.version`
+    \n# Dependencies of `${project.group}:$prefix${project.name}:${project.version}`
 """
         printDependencies(data)
         output << """
@@ -89,7 +90,23 @@ class MarkdownReportRenderer implements ReportRenderer {
         \n The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 """
         output << "\n\nThis report was generated on **${new Date()}**"
-        output << " using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE)."
+        output << " using [Gradle-License-Report plugin]" +
+                "(https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under" +
+                " [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE)."
+    }
+
+    /**
+     * Obtains the artifact prefix for the passed project.
+     *
+     * <p>If the {@code PublishExtension} has the property {@code spinePrefix} set to {@code true}
+     * returns {@code "spine-"}, otherwise an empty string.
+     */
+    private String prefixFor(final Project project) {
+        final publishExtension = project.rootProject.extensions.findByType(PublishExtension.class)
+        final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false)
+                ? "spine-"
+                : ""
+        prefix
     }
 
     private void printDependencies(final ProjectData data) {

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -26,6 +26,13 @@
 
 package io.spine.internal.dependency
 
+/**
+ * The dependencies for Guava.
+ *
+ * When changing the version, also change the version used in the `build.gradle.kts`. We need
+ * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
+ * Gradle plugins, errors may occur due to version clashes.
+ */
 // https://github.com/google/guava
 object Guava {
     private const val version = "30.1.1-jre"

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.20"
+    const val version      = "1.5.30"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -28,13 +28,13 @@ package io.spine.internal.gradle
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import java.io.FileNotFoundException
+import java.net.URL
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import java.io.FileNotFoundException
-import java.net.URL
 
 /**
  * A task which verifies that the current version of the library has not been published to the given
@@ -45,8 +45,8 @@ open class CheckVersionIncrement : DefaultTask() {
     /**
      * The Maven repository in which to look for published artifacts.
      *
-     * We only check the `releases` repository. Artifacts in `snapshots` repository still may be
-     * overridden.
+     * We check both the `releases` and `snapshots` repositories. Artifacts in either of these repos
+     * may not be overwritten.
      */
     @Input
     lateinit var repository: Repository
@@ -57,7 +57,14 @@ open class CheckVersionIncrement : DefaultTask() {
     @TaskAction
     private fun fetchAndCheck() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
-        val repoUrl = repository.releases
+        checkInRepo(repository.snapshots, artifact)
+
+        if (repository.releases != repository.snapshots) {
+            checkInRepo(repository.releases, artifact)
+        }
+    }
+
+    private fun checkInRepo(repoUrl: String, artifact: String) {
         val metadata = fetch(repoUrl, artifact)
         val versions = metadata?.versioning?.versions
         val versionExists = versions?.contains(version) ?: false

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -58,6 +58,12 @@ open class RunGradle : DefaultTask() {
     private lateinit var taskNames: List<String>
 
     /**
+     * For how many minutes to wait for the Gradle build to complete.
+     */
+    @Internal
+    var maxDurationMins: Long = 10
+
+    /**
      * Names of Gradle properties to copy into the launched build.
      *
      * The properties are looked up in the root project. If a property is not found, it is ignored.
@@ -73,6 +79,15 @@ open class RunGradle : DefaultTask() {
      */
     fun task(vararg tasks: String) {
         taskNames = tasks.asList()
+    }
+
+    /**
+     * Sets the maximum time to wait until the build completion in minutes
+     * and specifies task names to be passed to the Gradle Wrapper script.
+     */
+    fun task(maxDurationMins: Long, vararg tasks: String) {
+        taskNames = tasks.asList()
+        this.maxDurationMins = maxDurationMins
     }
 
     @TaskAction
@@ -96,7 +111,7 @@ open class RunGradle : DefaultTask() {
               https://github.com/gradle/gradle/issues/3987
               https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
          */
-        val completed = process.waitFor(10, TimeUnit.MINUTES)
+        val completed = process.waitFor(maxDurationMins, TimeUnit.MINUTES)
         val exitCode = process.exitValue()
         if (!completed || exitCode != 0) {
             val errorOutExists = errorOut.exists()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra["protoDataVersion"] = "0.0.32"
-extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.40"
-extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.41"
+extra["protoDataVersion"] = "0.0.33"
+extra["spineBaseVersion"] = "2.0.0-SNAPSHOT.53"
+extra["spineCoreVersion"] = "2.0.0-SNAPSHOT.54"


### PR DESCRIPTION
In this PR we:
 1. Update Spine versions. Now, the `spine/options.proto` contains the `compare_by` option. After ProtoData includes this option, we can start developing code generation based on `compare_by` in `base`.
 2. Add a convenience method for creating instances of `Just`.
 3. Use `protected` modifier with `Policy.whenever(..)` to comply with the contract method spec.