### PR TITLE
Resolve `:compiler` dependency conflict

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,8 +133,7 @@ subprojects {
                     JUnit.bom,
                     "io.spine:spine-base:$baseVersion",
                     "io.spine:spine-server:$coreVersion",
-                    "io.spine.tools:spine-testlib:$baseVersion",
-                    "io.spine.protodata:compiler:$protoDataVersion"
+                    "io.spine.tools:spine-testlib:$baseVersion"
                 )
             }
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -32,6 +32,10 @@ package io.spine.internal.dependency
  */
 object J2ObjC {
     // https://github.com/google/j2objc/releases
+    // `1.3.` is the latest version available from Maven Central.
+    // https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations
     private const val version = "1.3"
-    const val lib = "com.google.j2objc:j2objc-annotations:${version}"
+    const val annotations = "com.google.j2objc:j2objc-annotations:${version}"
+    @Deprecated("Please use `annotations` instead.", ReplaceWith("annotations"))
+    const val lib = annotations
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -110,7 +110,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         AutoValue.annotations,
         Gson.lib,
-        J2ObjC.lib,
+        J2ObjC.annotations,
         Plexus.utils,
         Okio.lib,
         CommonsCli.lib,

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -36,6 +36,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.exclude
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.api.Plugin as GradlePlugin
@@ -70,7 +71,7 @@ public class Plugin : GradlePlugin<Project> {
         val version = readVersion()
         with(target) {
             val extension = createExtension()
-            configureProtobufPlugin(extension, version)
+            configureWithProtobufPlugin(extension, version)
             createLaunchTasks(extension, version)
             configureSourceSets(extension)
             configureIdea(extension)
@@ -143,6 +144,16 @@ private fun Project.createCleanTask(ext: Extension, sourceSet: SourceSet) {
 
         tasks.getByName("clean").dependsOn(this)
         tasks.getByName(launchTaskName(sourceSet)).mustRunAfter(this)
+    }
+}
+
+private fun Project.configureWithProtobufPlugin(extension: Extension, version: String) {
+    if (pluginManager.hasPlugin("com.google.protobuf")) {
+        configureProtobufPlugin(extension, version)
+    } else {
+        pluginManager.withPlugin("com.google.protobuf") {
+            configureProtobufPlugin(extension, version)
+        }
     }
 }
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -95,6 +95,8 @@ private const val VERSION_RESOURCE = "version.txt"
 
 private const val PROTOC_PLUGIN = "protodata"
 
+private const val PROTOBUF_PLUGIN = "com.google.protobuf"
+
 private fun Project.createLaunchTasks(extension: Extension, version: String) {
     val artifactConfig = configurations.create("protoDataRawArtifact") {
         it.isVisible = false
@@ -150,10 +152,10 @@ private fun Project.createCleanTask(ext: Extension, sourceSet: SourceSet) {
 }
 
 private fun Project.configureWithProtobufPlugin(extension: Extension, version: String) {
-    if (pluginManager.hasPlugin("com.google.protobuf")) {
+    if (pluginManager.hasPlugin(PROTOBUF_PLUGIN)) {
         configureProtobufPlugin(extension, version)
     } else {
-        pluginManager.withPlugin("com.google.protobuf") {
+        pluginManager.withPlugin(PROTOBUF_PLUGIN) {
             configureProtobufPlugin(extension, version)
         }
     }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/Plugin.kt
@@ -100,7 +100,9 @@ private fun Project.createLaunchTasks(extension: Extension, version: String) {
         it.isVisible = false
     }
     dependencies.add(artifactConfig.name, "io.spine.protodata:cli:$version")
-    val userCpConfig = configurations.create("protoData")
+    val userCpConfig = configurations.create("protoData") {
+        it.exclude(group = "io.spine.protodata", module = "compiler")
+    }
     sourceSets.forEach { sourceSet ->
         createLaunchTask(extension, sourceSet, artifactConfig, userCpConfig)
         createCleanTask(extension, sourceSet)

--- a/license-report.md
+++ b/license-report.md
@@ -630,7 +630,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:20 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1232,7 +1232,7 @@ This report was generated on **Fri Dec 17 22:06:20 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:22 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1857,7 +1857,7 @@ This report was generated on **Fri Dec 17 22:06:22 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:23 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2313,7 +2313,7 @@ This report was generated on **Fri Dec 17 22:06:23 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:24 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2745,7 +2745,7 @@ This report was generated on **Fri Dec 17 22:06:24 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3343,4 +3343,4 @@ This report was generated on **Fri Dec 17 22:06:25 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 22:06:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 11:58:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:cli:0.1.3`
+# Dependencies of `io.spine.protodata:cli:0.1.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.**No license information found**
@@ -630,12 +630,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:27:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:codegen-java:0.1.3`
+# Dependencies of `io.spine.protodata:codegen-java:0.1.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.**No license information found**
@@ -1232,12 +1232,12 @@ This report was generated on **Mon Dec 20 11:58:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:27:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:compiler:0.1.3`
+# Dependencies of `io.spine.protodata:compiler:0.1.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.**No license information found**
@@ -1857,12 +1857,12 @@ This report was generated on **Mon Dec 20 11:58:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:27:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:gradle-plugin:0.1.3`
+# Dependencies of `io.spine.protodata:gradle-plugin:0.1.4`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2313,12 +2313,12 @@ This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:27:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protoc:0.1.3`
+# Dependencies of `io.spine.protodata:protoc:0.1.4`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2745,12 +2745,12 @@ This report was generated on **Mon Dec 20 11:58:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:28:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:testutil:0.1.3`
+# Dependencies of `io.spine.protodata:testutil:0.1.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.**No license information found**
@@ -3343,4 +3343,4 @@ This report was generated on **Mon Dec 20 11:58:31 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 20 11:58:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:28:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.1.3</version>
+<version>0.1.4</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -32,6 +32,10 @@ package io.spine.internal.dependency
  */
 object J2ObjC {
     // https://github.com/google/j2objc/releases
+    // `1.3.` is the latest version available from Maven Central.
+    // https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations
     private const val version = "1.3"
-    const val lib = "com.google.j2objc:j2objc-annotations:${version}"
+    const val annotations = "com.google.j2objc:j2objc-annotations:${version}"
+    @Deprecated("Please use `annotations` instead.", ReplaceWith("annotations"))
+    const val lib = annotations
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -110,7 +110,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         AutoValue.annotations,
         Gson.lib,
-        J2ObjC.lib,
+        J2ObjC.annotations,
         Plexus.utils,
         Okio.lib,
         CommonsCli.lib,

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -28,7 +28,7 @@ val baseVersion: String by extra("2.0.0-SNAPSHOT.80")
 val coreVersion: String by extra("2.0.0-SNAPSHOT.89")
 
 val mcVersion: String by extra("2.0.0-SNAPSHOT.87")
-val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.87")
+val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.85")
 
-val protoDataVersion: String by extra("0.1.3")
+val protoDataVersion: String by extra("0.1.4")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -28,7 +28,7 @@ val baseVersion: String by extra("2.0.0-SNAPSHOT.80")
 val coreVersion: String by extra("2.0.0-SNAPSHOT.89")
 
 val mcVersion: String by extra("2.0.0-SNAPSHOT.87")
-val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
+val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.87")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.85")
 
 val protoDataVersion: String by extra("0.1.3")


### PR DESCRIPTION
In this PR we exclude the `:compiler` module dependency from the `protoData` configuration.

This helps us to remove a duplicate `:compiler` artifact (which is not supposed to be there at all).