### PR TITLE
Filter files with custom options being built

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Upload code coverage report
         uses: codecov/codecov-action@v2
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,6 +102,14 @@ allprojects {
 
     repositories.applyStandard()
     repositories.applyGitHubPackages("base-types", rootProject)
+
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.internal.dependency.Grpc.protobufPlugin
+            )
+        }
+    }
 }
 
 subprojects {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.19.2"
+    const val version       = "3.19.3"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -49,6 +49,7 @@ import org.gradle.process.CommandLineArgumentProvider
  * }
  *```
  */
+@Suppress("unused")
 fun JavaCompile.configureErrorProne() {
     options.errorprone
         .errorproneArgumentProviders
@@ -67,7 +68,8 @@ private object ErrorProneConfig {
         listOf(
 
             // Exclude generated sources from being analyzed by ErrorProne.
-            "-XepExcludedPaths:.*/generated/.*",
+            // Include all directories started from `generated`, such as `generated-proto`.
+            "-XepExcludedPaths:.*/generated.*/.*",
 
             // Turn the check off until ErrorProne can handle `@Nested` JUnit classes.
             // See issue: https://github.com/google/error-prone/issues/956

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -24,10 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle
+package io.spine.internal.gradle.publish
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.spine.internal.gradle.Repository
 import java.io.FileNotFoundException
 import java.net.URL
 import org.gradle.api.DefaultTask

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
@@ -26,9 +26,8 @@
 
 @file:Suppress("unused")
 
-package io.spine.internal.gradle
+package io.spine.internal.gradle.publish
 
-import io.spine.internal.gradle.publish.PublishingRepos
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
@@ -40,6 +40,7 @@ abstract class PublishExtension @Inject constructor() {
     abstract val projectsToPublish: SetProperty<String>
     abstract val targetRepositories: SetProperty<Repository>
     abstract val spinePrefix: Property<Boolean>
+    abstract val customPrefix: Property<String>
 
     /**
      * The project to be published _instead_ of [projectsToPublish].
@@ -54,7 +55,7 @@ abstract class PublishExtension @Inject constructor() {
         const val name = "spinePublishing"
 
         /** The prefix to be used before the project name if [spinePrefix] is set to `true`. */
-        const val artifactPrefix = "spine-"
+        const val standardPrefix = "spine-"
 
         /**
          * Creates a new instance of the extension and adds it to the given project.
@@ -62,22 +63,32 @@ abstract class PublishExtension @Inject constructor() {
         fun createIn(project: Project): PublishExtension {
             val extension = project.extensions.create(name, PublishExtension::class.java)
             extension.spinePrefix.convention(true)
+            extension.customPrefix.convention("")
             return extension
         }
     }
 
     /**
      * Obtains an artifact ID of the given project, taking into account the value of
-     * the [spinePrefix] property. If the property is set to `true`, [artifactPrefix] will
+     * the [spinePrefix] and [customPrefix] properties.
+     *
+     * If the `customPrefix` property is set to a non-empty string, it will be used before
+     * the published project name. Otherwise, the [spinePrefix] property is taken into account.
+     *
+     * If the `spinePrefix` property is set to `true`, [standardPrefix] will
      * be used before the project name. Otherwise, just the name of the project will be
      * used as the artifact ID.
      */
-    fun artifactId(project: Project): String =
-        if (spinePrefix.get()) {
-            "$artifactPrefix${project.name}"
+    fun artifactId(project: Project): String {
+        val customPrefix = customPrefix.get()
+        return if (customPrefix.isNotEmpty()) {
+            "$customPrefix${project.name}"
+        } else if (spinePrefix.get()) {
+            "$standardPrefix${project.name}"
         } else {
             project.name
         }
+    }
 
     /**
      * Instructs to publish the passed project _instead_ of [projectsToPublish].

--- a/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
+++ b/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
@@ -41,11 +41,9 @@ pmd {
     // Disable the default rule set to use the custom rules (see below).
     ruleSets = listOf()
 
-    // Load PMD settings from a file in `buildSrc/resources/`.
-    val classLoader = Pmd.javaClass.classLoader
-    val settingsResource = classLoader.getResource("pmd.xml")!!
-    val pmdSettings: String = settingsResource.readText()
-    val textResource: TextResource = resources.text.fromString(pmdSettings)
+    // Load PMD settings.
+    val pmdSettings = file("$rootDir/config/quality/pmd.xml")
+    val textResource: TextResource = resources.text.fromFile(pmdSettings)
     ruleSetConfig = textResource
 
     reportsDir = file("build/reports/pmd")

--- a/cli/src/main/kotlin/io/spine/protodata/cli/DescriptorExtensions.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/DescriptorExtensions.kt
@@ -65,7 +65,7 @@ internal val FileDescriptor.outerClass: Class<*>?
 internal fun FileDescriptor.registerAllExtensions(registry: ExtensionRegistry) {
     if (outerClass == null) {
         throw IllegalStateException(
-            "The outer class $outerClassName for the file $name does not exist."
+            "The outer class `$outerClassName` for the file `$name` does not exist."
         )
     }
     val method = outerClass!!.getDeclaredMethod(

--- a/cli/src/main/kotlin/io/spine/protodata/cli/DescriptorExtensions.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/DescriptorExtensions.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.cli
+
+import com.google.protobuf.Descriptors.FileDescriptor
+import com.google.protobuf.ExtensionRegistry
+import io.spine.code.java.ClassName
+
+/**
+ * Obtains a name of the outer Java class associated with this file.
+ */
+internal val FileDescriptor.outerClassName: String
+    get() {
+        val outerClass = ClassName.outerClass(this)
+        return outerClass.binaryName()
+    }
+
+/**
+ * Obtains an outer Java class associated with this proto file, if such a class already exists.
+ * Otherwise, returns `null`.
+ */
+internal val FileDescriptor.outerClass: Class<*>?
+    get() {
+        val outerClass: Class<*>?
+        try {
+            val classLoader = javaClass.classLoader
+            outerClass = classLoader.loadClass(outerClassName)
+        } catch (e: ClassNotFoundException) {
+            return null
+        }
+        return outerClass
+    }
+
+/**
+ * Reflectively calls the static `registerAllExtensions(..)` method, such as
+ * [io.spine.option.OptionsProto.registerAllExtensions], on the [outerClass] generated for
+ * this Protobuf file with the custom options declared.
+ *
+ * @throws IllegalStateException if the outer class for this proto file does not exist
+ */
+internal fun FileDescriptor.registerAllExtensions(registry: ExtensionRegistry) {
+    if (outerClass == null) {
+        throw IllegalStateException(
+            "The outer class $outerClassName for the file $name does not exist."
+        )
+    }
+    val method = outerClass!!.getDeclaredMethod(
+        "registerAllExtensions", ExtensionRegistry::class.java
+    )
+    method.invoke(null, registry)
+}

--- a/cli/src/main/kotlin/io/spine/protodata/cli/FileOptionsProvider.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/FileOptionsProvider.kt
@@ -28,35 +28,20 @@ package io.spine.protodata.cli
 
 import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.ExtensionRegistry
-import io.spine.code.java.ClassName
 import io.spine.protodata.option.OptionsProvider
 
 /**
  * An [OptionsProvider] which provides all the options defined in a single Protobuf file.
  */
-internal class FileOptionsProvider(
-    private val descriptor: FileDescriptor
-) : OptionsProvider {
+internal class FileOptionsProvider(private val descriptor: FileDescriptor) : OptionsProvider {
 
     /**
-     * Supplies the given [registry] with the options from the associated file descriptor.
+     * Supplies the given [registry] with the options from the associated descriptor
+     * of the proto file. The outer class for the file must exist.
      *
-     * Reflectively calls the static `registerAllExtensions(..)` method, such
-     * as [io.spine.option.OptionsProto.registerAllExtensions], on the outer class generated for
-     * the Protobuf file where the custom options are declared.
+     * @throws IllegalStateException if the outer class for the proto file does not exist.
      */
     override fun registerIn(registry: ExtensionRegistry) {
-        val outerClassName = outerClassName()
-        val classLoader = this.javaClass.classLoader
-        val optionsClass = classLoader.loadClass(outerClassName)
-        val method = optionsClass.getDeclaredMethod(
-            "registerAllExtensions", ExtensionRegistry::class.java
-        )
-        method.invoke(null, registry)
-    }
-
-    private fun outerClassName(): String {
-        val outerClass = ClassName.outerClass(descriptor)
-        return outerClass.binaryName()
+        descriptor.registerAllExtensions(registry)
     }
 }

--- a/cli/src/main/kotlin/io/spine/protodata/cli/ReflectiveBuilder.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/ReflectiveBuilder.kt
@@ -43,8 +43,10 @@ internal open class ReflectiveBuilder<T: Any> {
      * It is necessary that the class defined by the [className] parameter is a subtype of `T`.
      * Otherwise, a casting error occurs.
      *
-     * @param className name of the concrete class to instantiate
-     * @param classLoader the [ClassLoader] to load the class by its name
+     * @param className
+     *         name of the concrete class to instantiate
+     * @param classLoader
+     *         the [ClassLoader] to load the class by its name
      */
     fun createByName(className: String, classLoader: ClassLoader): T {
         val cls = classLoader.loadClass(className).kotlin

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -26,8 +26,8 @@
 
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.Jackson
-import io.spine.internal.gradle.CheckVersionIncrement
-import io.spine.internal.gradle.IncrementGuard
+import io.spine.internal.gradle.publish.CheckVersionIncrement
+import io.spine.internal.gradle.publish.IncrementGuard
 import io.spine.internal.gradle.publish.PublishingRepos
 
 plugins {

--- a/gradle-plugin/src/test/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/empty-test/build.gradle.kts
@@ -64,6 +64,6 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:+"
+        artifact = io.spine.internal.dependency.Protobuf.compiler
     }
 }

--- a/gradle-plugin/src/test/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/launch-test/build.gradle.kts
@@ -63,6 +63,6 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:+"
+        artifact = io.spine.internal.dependency.Protobuf.compiler
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -423,7 +423,7 @@
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.43.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -761,7 +761,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1171,7 +1171,7 @@ This report was generated on **Fri Jan 21 17:24:02 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.43.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1481,7 +1481,7 @@ This report was generated on **Fri Jan 21 17:24:02 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1887,7 +1887,7 @@ This report was generated on **Fri Jan 21 17:24:03 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.43.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2215,7 +2215,7 @@ This report was generated on **Fri Jan 21 17:24:03 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2737,7 +2737,7 @@ This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3230,7 +3230,7 @@ This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3620,7 +3620,7 @@ This report was generated on **Fri Jan 21 17:24:06 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.43.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3935,4 +3935,4 @@ This report was generated on **Fri Jan 21 17:24:06 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 21 17:24:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:59:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -74,15 +74,15 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.38.0.
@@ -331,7 +331,7 @@
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -339,11 +339,11 @@
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
@@ -761,7 +761,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -835,15 +835,15 @@ This report was generated on **Tue Jan 11 17:02:25 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
@@ -1079,7 +1079,7 @@ This report was generated on **Tue Jan 11 17:02:25 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -1087,11 +1087,11 @@ This report was generated on **Tue Jan 11 17:02:25 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
@@ -1481,7 +1481,7 @@ This report was generated on **Tue Jan 11 17:02:25 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1555,15 +1555,15 @@ This report was generated on **Tue Jan 11 17:02:26 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.38.0.
@@ -1795,7 +1795,7 @@ This report was generated on **Tue Jan 11 17:02:26 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -1803,11 +1803,11 @@ This report was generated on **Tue Jan 11 17:02:26 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
@@ -2215,7 +2215,7 @@ This report was generated on **Tue Jan 11 17:02:26 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:27 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:12 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2737,7 +2737,7 @@ This report was generated on **Tue Jan 11 17:02:27 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2770,15 +2770,15 @@ This report was generated on **Tue Jan 11 17:02:28 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.5.
@@ -2897,15 +2897,15 @@ This report was generated on **Tue Jan 11 17:02:28 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -3230,7 +3230,7 @@ This report was generated on **Tue Jan 11 17:02:28 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3304,15 +3304,15 @@ This report was generated on **Tue Jan 11 17:02:29 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.43.1.
@@ -3548,7 +3548,7 @@ This report was generated on **Tue Jan 11 17:02:29 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -3556,11 +3556,11 @@ This report was generated on **Tue Jan 11 17:02:29 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
@@ -3935,4 +3935,4 @@ This report was generated on **Tue Jan 11 17:02:29 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:02:30 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 14:31:14 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -761,7 +761,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1481,7 +1481,7 @@ This report was generated on **Thu Jan 20 14:31:10 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2215,7 +2215,7 @@ This report was generated on **Thu Jan 20 14:31:11 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:12 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2737,7 +2737,7 @@ This report was generated on **Thu Jan 20 14:31:12 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3230,7 +3230,7 @@ This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3935,4 +3935,4 @@ This report was generated on **Thu Jan 20 14:31:13 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:31:14 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 20 21:18:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -761,7 +761,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1481,7 +1481,7 @@ This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2215,7 +2215,7 @@ This report was generated on **Thu Jan 20 21:18:03 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2737,7 +2737,7 @@ This report was generated on **Thu Jan 20 21:18:04 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3230,7 +3230,7 @@ This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3935,4 +3935,4 @@ This report was generated on **Thu Jan 20 21:18:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 21:18:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 21 17:24:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -56,19 +56,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-kotlin</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.19.2"
+    const val version       = "3.19.3"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -49,6 +49,7 @@ import org.gradle.process.CommandLineArgumentProvider
  * }
  *```
  */
+@Suppress("unused")
 fun JavaCompile.configureErrorProne() {
     options.errorprone
         .errorproneArgumentProviders
@@ -67,7 +68,8 @@ private object ErrorProneConfig {
         listOf(
 
             // Exclude generated sources from being analyzed by ErrorProne.
-            "-XepExcludedPaths:.*/generated/.*",
+            // Include all directories started from `generated`, such as `generated-proto`.
+            "-XepExcludedPaths:.*/generated.*/.*",
 
             // Turn the check off until ErrorProne can handle `@Nested` JUnit classes.
             // See issue: https://github.com/google/error-prone/issues/956

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -24,10 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle
+package io.spine.internal.gradle.publish
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.spine.internal.gradle.Repository
 import java.io.FileNotFoundException
 import java.net.URL
 import org.gradle.api.DefaultTask

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
@@ -26,9 +26,8 @@
 
 @file:Suppress("unused")
 
-package io.spine.internal.gradle
+package io.spine.internal.gradle.publish
 
-import io.spine.internal.gradle.publish.PublishingRepos
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
@@ -40,6 +40,7 @@ abstract class PublishExtension @Inject constructor() {
     abstract val projectsToPublish: SetProperty<String>
     abstract val targetRepositories: SetProperty<Repository>
     abstract val spinePrefix: Property<Boolean>
+    abstract val customPrefix: Property<String>
 
     /**
      * The project to be published _instead_ of [projectsToPublish].
@@ -54,7 +55,7 @@ abstract class PublishExtension @Inject constructor() {
         const val name = "spinePublishing"
 
         /** The prefix to be used before the project name if [spinePrefix] is set to `true`. */
-        const val artifactPrefix = "spine-"
+        const val standardPrefix = "spine-"
 
         /**
          * Creates a new instance of the extension and adds it to the given project.
@@ -62,22 +63,32 @@ abstract class PublishExtension @Inject constructor() {
         fun createIn(project: Project): PublishExtension {
             val extension = project.extensions.create(name, PublishExtension::class.java)
             extension.spinePrefix.convention(true)
+            extension.customPrefix.convention("")
             return extension
         }
     }
 
     /**
      * Obtains an artifact ID of the given project, taking into account the value of
-     * the [spinePrefix] property. If the property is set to `true`, [artifactPrefix] will
+     * the [spinePrefix] and [customPrefix] properties.
+     *
+     * If the `customPrefix` property is set to a non-empty string, it will be used before
+     * the published project name. Otherwise, the [spinePrefix] property is taken into account.
+     *
+     * If the `spinePrefix` property is set to `true`, [standardPrefix] will
      * be used before the project name. Otherwise, just the name of the project will be
      * used as the artifact ID.
      */
-    fun artifactId(project: Project): String =
-        if (spinePrefix.get()) {
-            "$artifactPrefix${project.name}"
+    fun artifactId(project: Project): String {
+        val customPrefix = customPrefix.get()
+        return if (customPrefix.isNotEmpty()) {
+            "$customPrefix${project.name}"
+        } else if (spinePrefix.get()) {
+            "$standardPrefix${project.name}"
         } else {
             project.name
         }
+    }
 
     /**
      * Instructs to publish the passed project _instead_ of [projectsToPublish].

--- a/tests/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
+++ b/tests/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
@@ -41,11 +41,9 @@ pmd {
     // Disable the default rule set to use the custom rules (see below).
     ruleSets = listOf()
 
-    // Load PMD settings from a file in `buildSrc/resources/`.
-    val classLoader = Pmd.javaClass.classLoader
-    val settingsResource = classLoader.getResource("pmd.xml")!!
-    val pmdSettings: String = settingsResource.readText()
-    val textResource: TextResource = resources.text.fromString(pmdSettings)
+    // Load PMD settings.
+    val pmdSettings = file("$rootDir/config/quality/pmd.xml")
+    val textResource: TextResource = resources.text.fromFile(pmdSettings)
     ruleSetConfig = textResource
 
     reportsDir = file("build/reports/pmd")


### PR DESCRIPTION
This PR fixes an issue resulted in `ClassNotFoundException` when trying to load custom options form a proto file containing custom options _and_ being built by ProtoData.

Recently, instead of specifying option files, we started detecting them by the presence of extensions (`FileDescriptor.getExtensions()`). It works well until we try to use ProtoData on a newly created `proto` file with custom extensions declared, but without outer class generated yet. Until this PR we attempted to load a Java class by the name corresponding to the given descriptor. Since there was no Java file produced at this stage, the attempt failed with `ClassNotFoundException`.

This PR fixes the issue by skipping the proto files without outer class already available.
