### PR TITLE
Fix publishing of `test-env` module

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.10.0"
+    private const val version = "2.11.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 

--- a/cli/src/main/kotlin/io/spine/protodata/cli/Main.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/Main.kt
@@ -59,9 +59,9 @@ import kotlin.system.exitProcess
 /**
  * The resource file containing the version of ProtoData.
  *
- * Such a resource name might be duplicated in other places in ProtoData code base. The reason for
- * this is to avoid creating an extra dependencies. Search by the string value of this constant
- * when making changes.
+ * Such a resource name might be duplicated in other places in ProtoData code base.
+ * The reason for this is to avoid creating extra dependencies just to get the version number.
+ * Search by the string value of this constant when making changes.
  */
 private const val VERSION_FILE_NAME = "version.txt"
 

--- a/gradle-plugin/src/test/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/empty-test/build.gradle.kts
@@ -37,7 +37,7 @@ buildscript {
 plugins {
     java
     id("com.google.protobuf")
-    id("io.spine.proto-data") version "0.1.7"
+    id("io.spine.proto-data") version "0.1.8"
 }
 
 fun RepositoryHandler.addCouple(baseUrl: String) {

--- a/gradle-plugin/src/test/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/launch-test/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 plugins {
     java
     id("com.google.protobuf")
-    id("io.spine.proto-data") version "0.1.7"
+    id("io.spine.proto-data") version "0.1.8"
 }
 
 fun RepositoryHandler.addCouple(baseUrl: String) {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-cli:0.1.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -721,12 +721,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:14 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:40 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.1.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -1394,12 +1394,12 @@ This report was generated on **Wed Jan 26 19:57:14 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:40 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.1.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -2102,12 +2102,12 @@ This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:41 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.1.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2607,12 +2607,12 @@ This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:41 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.1.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3083,12 +3083,12 @@ This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:41 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.1.7`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.1.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -3764,4 +3764,4 @@ This report was generated on **Wed Jan 26 19:57:15 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 26 19:57:16 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 26 21:18:42 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.1.7</version>
+<version>0.1.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/test-env/build.gradle.kts
+++ b/test-env/build.gradle.kts
@@ -54,10 +54,9 @@ protobuf {
 /**
  * We only need to publish `test-env` locally for integration tests.
  * Do not publish to public Maven repositories.
- * See https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks
+ * 
+ * See https://bit.ly/gradle-cond-pub for details.
  */
-val publish: Task by tasks.getting
-
-afterEvaluate {
-    publish.enabled = false
+tasks.withType<PublishToMavenRepository>().configureEach {
+    onlyIf { false }
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.10.0"
+    private const val version = "2.11.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,4 +40,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.85")
 val devProtoDataVersion: String by extra("0.1.2")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.1.7")
+val protoDataVersion: String by extra("0.1.8")


### PR DESCRIPTION
This PR attempts to fix to publishing of `test-env` module to work only for Maven Local, avoiding exposing its artifacts (that serve only for the testing purposes) via public Maven repositories.
