### PR TITLE
Mark generated enums

### DIFF
--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
@@ -32,7 +32,9 @@ import io.spine.protodata.renderer.LineNumber
 import io.spine.protodata.renderer.LineNumber.Companion.notInFile
 import java.lang.System.lineSeparator
 
-private val pattern = Regex("(public\\s+)?(final\\s+)?(abstract\\s+)?((class)|(@?interface)|(enum))\\s+")
+private val pattern = Regex(
+    "(public\\s+)?(final\\s+)?(abstract\\s+)?((class)|(@?interface)|(enum))\\s+"
+)
 
 /**
  * An insertion point located just before the primary declaration of a Java file.

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
@@ -35,7 +35,7 @@ import java.lang.System.lineSeparator
 /**
  * A pattern matching a top-level Java declaration.
  *
- * This pattern matches a type declaration, such as a class, an interface, an annotation
+ * This pattern matches a type declaration, such as a class, an interface, an annotation,
  * or an enum.
  *
  * The pattern expects the matched string to have at least one empty space character after

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
@@ -32,15 +32,24 @@ import io.spine.protodata.renderer.LineNumber
 import io.spine.protodata.renderer.LineNumber.Companion.notInFile
 import java.lang.System.lineSeparator
 
-private val pattern = Regex(
-    "(public\\s+)?(final\\s+)?(abstract\\s+)?((class)|(@?interface)|(enum))\\s+"
-)
+/**
+ * A pattern matching a top-level Java declaration.
+ *
+ * This pattern matches a type declaration, such as a class, an interface, an annotation
+ * or an enum.
+ *
+ * The pattern expects the matched string to have at least one empty space character after
+ * the keyword declaring the type. However, regular expression pattern matching cannot guarantee
+ * that there will be no false positives, i.e. no structure, such as a comment, is going to yield
+ * an unwanted match.
+ */
+private val pattern = Regex("((class)|(@?interface)|(enum))\\s+")
 
 /**
  * An insertion point located just before the primary declaration of a Java file.
  *
- * The primary declaration is the top-level class, interface, or annotation type, which matches by
- * name with the class.
+ * The primary declaration is the top-level class, interface, annotation, or an enum type,
+ * which matches by name with the class.
  *
  * While technically Java allows other top-level declarations is the same file, those are rarely
  * used. `BeforePrimaryDeclaration` does not account for such declarations when searching for
@@ -55,15 +64,15 @@ internal object BeforePrimaryDeclaration : InsertionPoint, Logging {
         get() = this.javaClass.simpleName
 
     override fun locate(lines: List<String>): LineNumber {
-        var isComment = false
+        var isBlockComment = false
         lines.forEachIndexed { index, line ->
             if (line.contains("/*")) {
-                isComment = true
+                isBlockComment = true
             }
             if (line.contains("*/")) {
-                isComment = false
+                isBlockComment = false
             }
-            if (!isComment && pattern.find(line) != null) {
+            if (!isBlockComment && pattern.find(line) != null) {
                 return LineNumber.at(index)
             }
         }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
@@ -32,7 +32,7 @@ import io.spine.protodata.renderer.LineNumber
 import io.spine.protodata.renderer.LineNumber.Companion.notInFile
 import java.lang.System.lineSeparator
 
-private val pattern = Regex("(public\\s+)?(final\\s+)?(abstract\\s+)?(class)|(@?interface)")
+private val pattern = Regex("(public\\s+)?(final\\s+)?(abstract\\s+)?((class)|(@?interface)|(enum))\\s+")
 
 /**
  * An insertion point located just before the primary declaration of a Java file.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.2.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -743,12 +743,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -1442,12 +1442,12 @@ This report was generated on **Tue Feb 22 12:18:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.2.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -2180,12 +2180,12 @@ This report was generated on **Tue Feb 22 12:18:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.1`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2573,12 +2573,12 @@ This report was generated on **Tue Feb 22 12:18:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:51 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.1`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3085,12 +3085,12 @@ This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:51 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.2.1`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3561,12 +3561,12 @@ This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:18:59 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.2.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.2.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.1.**No license information found**
@@ -4272,4 +4272,4 @@ This report was generated on **Tue Feb 22 12:18:59 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 22 12:19:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:46:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -743,7 +743,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:27 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1442,7 +1442,7 @@ This report was generated on **Tue Feb 15 20:10:27 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2180,7 +2180,7 @@ This report was generated on **Tue Feb 15 20:10:28 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2573,7 +2573,7 @@ This report was generated on **Tue Feb 15 20:10:28 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3085,7 +3085,7 @@ This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3561,7 +3561,7 @@ This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:18:59 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4272,4 +4272,4 @@ This report was generated on **Tue Feb 15 20:10:29 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 20:10:30 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 22 12:19:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.2.0</version>
+<version>0.2.1</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.protodata.gradle.CodegenSettings
+import io.spine.internal.dependency.JavaX
 
 @Suppress("RemoveRedundantQualifierName")
 buildscript {
@@ -42,15 +43,18 @@ dependencies {
     val extensionSubproject = project(":protodata-extension")
     "protoData"(extensionSubproject)
     implementation(extensionSubproject)
+    implementation(JavaX.annotations)
 }
 
 extensions.getByType<CodegenSettings>().apply {
     renderers(
         "io.spine.protodata.test.uuid.ClassScopePrinter",
         "io.spine.protodata.test.uuid.UuidJavaRenderer",
+        "io.spine.protodata.codegen.java.file.PrintBeforePrimaryDeclaration",
 
         "io.spine.protodata.test.annotation.PrintFieldGetter",
-        "io.spine.protodata.test.annotation.AnnotationRenderer"
+        "io.spine.protodata.test.annotation.AnnotationRenderer",
+        "io.spine.protodata.codegen.java.generado.GenerateGenerated"
     )
     plugins(
         "io.spine.protodata.test.uuid.UuidPlugin",

--- a/tests/consumer/src/main/proto/protodata/test/outer_class_test.proto
+++ b/tests/consumer/src/main/proto/protodata/test/outer_class_test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package spine.protodata.test;
+
+option java_package = "io.spine.protodata.test";
+option java_outer_classname = "OuterClassTestProto";
+option java_multiple_files = true;
+
+message UserId {
+    string value = 1;
+}

--- a/tests/consumer/src/main/proto/protodata/test/project.proto
+++ b/tests/consumer/src/main/proto/protodata/test/project.proto
@@ -13,4 +13,12 @@ message ProjectId {
     string uuid = 1 [
         (spine.protodata.test.java_annotation) = "io.spine.protodata.test.annotation.GeneratedByProtoData"
     ];
+
+    ProjectStatus status = 2;
+}
+
+enum ProjectStatus {
+    PSTATUS_UNKNOWN = 0;
+    ACTIVE = 1;
+    COMPLETED = 2;
 }

--- a/tests/consumer/src/main/proto/protodata/test/task.proto
+++ b/tests/consumer/src/main/proto/protodata/test/task.proto
@@ -14,5 +14,14 @@ message Task {
 
     string title = 2;
 
-    google.protobuf.Timestamp when_completed = 3;
+    Status status = 3;
+
+    google.protobuf.Timestamp when_closed = 4;
+}
+
+enum Status {
+    TASK_STATUS_UNKNOWN = 0;
+    OPEN = 1;
+    FINISHED = 2;
+    CANCELED = 3;
 }

--- a/tests/consumer/src/main/proto/protodata/test/task.proto
+++ b/tests/consumer/src/main/proto/protodata/test/task.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package protodata.test;
+
+option java_package = "io.spine.protodata.test";
+option java_outer_classname = "TaskProto";
+option java_multiple_files = false;
+
+import "google/protobuf/timestamp.proto";
+
+message Task {
+
+    string uuid = 1;
+
+    string title = 2;
+
+    google.protobuf.Timestamp when_completed = 3;
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,4 +40,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.90")
 val devProtoDataVersion: String by extra("0.1.2")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.2.0")
+val protoDataVersion: String by extra("0.2.1")


### PR DESCRIPTION
`GenerateGenerated` is a Java code renderer that marks all Protobuf sources with the `javax.annotation.Generated` annotation.

Previously, the annotation was not added to enum types.
Also, if the Protobuf file contained one of the Java keywords used to locate line where to put the annotation, such as `class`, the generated code would contain a compilation error. This bug is fixed in this PR.