### PR TITLE
Bring back the multiple extensions formats for `Configuration`

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/Formats.kt
@@ -40,10 +40,4 @@ internal fun ConfigurationFormat.matches(file: Path): Boolean =
 
 @VisibleForTesting
 internal val ConfigurationFormat.extensions: Set<String>
-    get() {
-        val value = valueDescriptor.options.getExtension(ConfigurationProto.extension)
-        return if (value.isEmpty())
-            setOf()
-        else
-            setOf(value)
-    }
+    get() = valueDescriptor.options.getExtension(ConfigurationProto.extension).toSet()

--- a/compiler/src/main/proto/spine/protodata/configuration.proto
+++ b/compiler/src/main/proto/spine/protodata/configuration.proto
@@ -69,7 +69,7 @@ extend google.protobuf.EnumValueOptions {
     //
     // Only applicable to the `ConfigurationFormat` enum.
     //
-    string extension = 73981 [(internal) = true];
+    repeated string extension = 73980 [(internal) = true];
 }
 
 // The format of a custom configuration for ProtoData.
@@ -79,7 +79,7 @@ enum ConfigurationFormat {
     RCF_UNKNOWN = 0;
 
     // A Protobuf message encoded in binary.
-    PROTO_BINARY = 1 [(extension) = "bin"];        /*(extension) = "pb",*/
+    PROTO_BINARY = 1 [(extension) = "pb", (extension) = "bin"];
 
     // A Protobuf message encoded in Protobuf JSON.
     PROTO_JSON = 2 [(extension) = "pb.json"];
@@ -88,7 +88,7 @@ enum ConfigurationFormat {
     JSON = 3 [(extension) = "json"];
 
     // A plain YAML value.
-    YAML = 4 [(extension) = "yml"];                /*, (extension) = "yaml"*/
+    YAML = 4 [(extension) = "yml", (extension) = "yaml"];
 
     // A plain string value.
     PLAIN = 5;

--- a/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/ConfigurationFormatTest.kt
@@ -48,9 +48,9 @@ class `ConfigurationFormat should` {
         assertThat(PROTO_JSON.extensions)
             .containsExactly("pb.json")
         assertThat(PROTO_BINARY.extensions)
-            .containsExactly("bin")
+            .containsExactly("pb", "bin")
         assertThat(YAML.extensions)
-            .containsExactly("yml")
+            .containsExactly("yml", "yaml")
         assertThat(PLAIN.extensions)
             .isEmpty()
     }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.2.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -732,12 +732,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:03:58 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -1456,12 +1456,12 @@ This report was generated on **Wed Jul 13 09:43:07 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:08 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:03:59 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.2.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -2184,12 +2184,12 @@ This report was generated on **Wed Jul 13 09:43:08 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:10 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:04:00 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.6`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2619,12 +2619,12 @@ This report was generated on **Wed Jul 13 09:43:10 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:04:00 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3164,12 +3164,12 @@ This report was generated on **Wed Jul 13 09:43:14 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:04:01 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.2.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3653,12 +3653,12 @@ This report was generated on **Wed Jul 13 09:43:15 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:04:01 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.2.5.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.2.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -4389,4 +4389,4 @@ This report was generated on **Wed Jul 13 09:43:15 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 13 09:43:16 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 14 17:04:02 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.2.5.1</version>
+<version>0.2.6</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -204,28 +204,28 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-cli</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.5.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.5.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.93</version>
+    <version>2.0.0-SNAPSHOT.94</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.93</version>
+    <version>2.0.0-SNAPSHOT.94</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protodata-params</artifactId>
-    <version>2.0.0-SNAPSHOT.93</version>
+    <version>2.0.0-SNAPSHOT.94</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -28,10 +28,10 @@ val baseVersion: String by extra("2.0.0-SNAPSHOT.91")
 val coreVersion: String by extra("2.0.0-SNAPSHOT.91")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.93")
 val mcVersion: String by extra("2.0.0-SNAPSHOT.89")
-val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.93")
+val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.94")
 
 /** The version of ProtoData used for developing [protoDataVersion]. */
-val devProtoDataVersion: String by extra("0.2.5")
+val devProtoDataVersion: String by extra("0.2.5.1")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.2.5.1")
+val protoDataVersion: String by extra("0.2.6")


### PR DESCRIPTION
This changeset migrates to the fresh `modelCompiler`, which in turn runs on top of ProtoData `0.2.5.1`.

As far as the `0.2.5.1` ProtoData is now able to process the `repeated` fields in Protobuf extensions, this PR also brings back the multiple `Configuration` formats. Previously, this feature was stripped out in #69 to allow the compilation pass successfully.

This PR depends on the latest [`mc-java` changeset](https://github.com/SpineEventEngine/mc-java/pull/38).

The version of ProtoData modules is set to `0.2.6`.