### PR TITLE
Allow file presence checks

### DIFF
--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -124,7 +124,7 @@ internal constructor(
     /**
      * Looks up a file by its path and throws an `IllegalArgumentException` if not found.
      *
-     * The [path] may be a relative or an absolute path the file.
+     * The [path] may be absolute or relative to the source root.
      */
     public fun file(path: Path): SourceFile =
         findFile(path).orElseThrow { IllegalArgumentException("File not found: `$path`.") }
@@ -132,7 +132,7 @@ internal constructor(
     /**
      * Looks up a file by its path.
      *
-     * The [path] may be a relative or an absolute path the file.
+     * The [path] may be absolute or relative to the source root.
      *
      * @return the source file or an `Optional.empty()` if the file is missing from this set.
      */

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -142,10 +142,11 @@ internal constructor(
             return Optional.of(file)
         }
         val filtered = files.filterKeys { path.endsWith(it) }
-        if (filtered.isEmpty()) {
-            return Optional.empty()
+        return if (filtered.isEmpty()) {
+            Optional.empty()
+        } else {
+            Optional.of(filtered.entries.theOnly().value)
         }
-        return Optional.of(filtered.entries.theOnly().value)
     }
 
     /**

--- a/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -34,6 +34,7 @@ import io.spine.protodata.theOnly
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.*
 import kotlin.io.path.exists
 import kotlin.io.path.isRegularFile
 import kotlin.text.Charsets.UTF_8
@@ -121,23 +122,30 @@ internal constructor(
     }
 
     /**
-     * Looks up a file by its path.
+     * Looks up a file by its path and throws an `IllegalArgumentException` if not found.
      *
      * The [path] may be a relative or an absolute path the file.
      */
     public fun file(path: Path): SourceFile =
-        findFile(path).second
+        findFile(path).orElseThrow { IllegalArgumentException("File not found: `$path`.") }
 
-    private fun findFile(path: Path): Pair<Path, SourceFile> {
+    /**
+     * Looks up a file by its path.
+     *
+     * The [path] may be a relative or an absolute path the file.
+     *
+     * @return the source file or an `Optional.empty()` if the file is missing from this set.
+     */
+    public fun findFile(path: Path): Optional<SourceFile> {
         val file = files[path]
         if (file != null) {
-            return path to file
+            return Optional.of(file)
         }
-        val filtered = files.filterKeys { it.endsWith(path) }
+        val filtered = files.filterKeys { path.endsWith(it) }
         if (filtered.isEmpty()) {
-            throw IllegalArgumentException("File not found: `$path`.")
+            return Optional.empty()
         }
-        return filtered.entries.theOnly().toPair()
+        return Optional.of(filtered.entries.theOnly().value)
     }
 
     /**
@@ -160,8 +168,8 @@ internal constructor(
      * the [write] method.
      */
     internal fun delete(file: Path) {
-        val (path, sourceFile) = findFile(file)
-        files.remove(path)
+        val sourceFile = file(file)
+        files.remove(sourceFile.relativePath)
         deletedFiles.add(sourceFile)
     }
 

--- a/compiler/src/test/kotlin/io/spine/protodata/SourceFileSetTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/SourceFileSetTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import com.google.common.truth.Truth8.assertThat
+import io.spine.protodata.renderer.SourceFileSet
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.div
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class `'SourceFile' should` {
+
+    private lateinit var set: SourceFileSet
+    private lateinit var existingSourceFile: Path
+    private lateinit var existingSourceFileAbsolute: Path
+
+    @BeforeEach
+    fun createSet(@TempDir tempDir: Path) {
+        existingSourceFile = Path("pkg/example/foo.txt")
+        existingSourceFileAbsolute = tempDir / existingSourceFile
+        existingSourceFileAbsolute.parent.toFile().mkdirs()
+        existingSourceFileAbsolute.toFile().let { textFile ->
+            textFile.createNewFile()
+            textFile.writeText("this is a non-empty file")
+        }
+        set = SourceFileSet.from(tempDir)
+    }
+
+    @Test
+    fun `find existing file by relative path`() {
+        val found = set.findFile(existingSourceFile)
+        assertThat(found)
+            .isPresent()
+        assertThat(found.get().relativePath)
+            .isEqualTo(existingSourceFile)
+    }
+
+    @Test
+    fun `find existing file by absolute path`() {
+        val found = set.findFile(existingSourceFileAbsolute)
+        assertThat(found)
+            .isPresent()
+        assertThat(found.get().relativePath)
+            .isEqualTo(existingSourceFile)
+    }
+
+    @Test
+    fun `not find a non-existing file`() {
+        val found = set.findFile(existingSourceFile)
+        assertThat(found)
+            .isEmpty()
+    }
+
+    @Test
+    fun `fail when a non-existing file must be present`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            set.file(Path("i/don/t/exis.txt"))
+        }
+    }
+}

--- a/compiler/src/test/kotlin/io/spine/protodata/SourceFileSetTest.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/SourceFileSetTest.kt
@@ -74,7 +74,7 @@ class `'SourceFile' should` {
 
     @Test
     fun `not find a non-existing file`() {
-        val found = set.findFile(existingSourceFile)
+        val found = set.findFile(Path("non/existing/file.txt"))
         assertThat(found)
             .isEmpty()
     }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-cli:0.2.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -700,12 +700,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:52 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:03 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -1388,12 +1388,12 @@ This report was generated on **Tue Sep 27 14:53:52 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:52 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:04 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.2.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -2093,12 +2093,12 @@ This report was generated on **Tue Sep 27 14:53:52 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:53 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:05 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.11`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2509,12 +2509,12 @@ This report was generated on **Tue Sep 27 14:53:53 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:54 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:06 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3031,12 +3031,12 @@ This report was generated on **Tue Sep 27 14:53:54 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:54 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.2.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3501,12 +3501,12 @@ This report was generated on **Tue Sep 27 14:53:54 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:55 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.2.10`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.2.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.2.**No license information found**
@@ -4213,4 +4213,4 @@ This report was generated on **Tue Sep 27 14:53:55 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 27 14:53:56 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 27 20:41:08 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.2.10</version>
+<version>0.2.11</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,7 +31,7 @@ val mcVersion: String by extra("2.0.0-SNAPSHOT.89")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.97")
 
 /** The version of ProtoData used for developing [protoDataVersion]. */
-val devProtoDataVersion: String by extra("0.2.9")
+val devProtoDataVersion: String by extra("0.2.10")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.2.10")
+val protoDataVersion: String by extra("0.2.11")


### PR DESCRIPTION
Previously, it was cumbersome to check if a file is present in a `SourceFileSet` or not. Now we provide a simple API for that. The need for such API arises because previously, there was only one `SourceFileSet` per run and now there can be multiple.