### PR TITLE
Re-publish the plugin to Gradle Plugin portal

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,4 +34,4 @@ val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.99")
 val devProtoDataVersion: String by extra("0.2.12")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.2.14")
+val protoDataVersion: String by extra("0.2.15")


### PR DESCRIPTION
For some reason, all files of `0.2.14` version were published successfully except for the `.pom` file. According to Gradle forums, it does happen from time to time. 

The quickest way to address is just to re-publish. That's what this PR does.