### PR TITLE
Trigger publish

### DIFF
--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -1,6 +1,3 @@
-import org.gradle.api.Project
-import org.gradle.api.Task
-
 /*
  * Copyright 2022, TeamDev. All rights reserved.
  *
@@ -27,6 +24,9 @@ import org.gradle.api.Task
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.gradle.api.Project
+import org.gradle.api.Task
+
 /**
  * Configures the dependencies between third-party Gradle tasks
  * and those defined via ProtoData and Spine Model Compiler.
@@ -35,6 +35,7 @@ import org.gradle.api.Task
  * usage of Spine-specific task output by other tasks,
  * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
  */
+@Suppress("unused")
 fun Project.configureTaskDependencies() {
 
     /**

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-cli:0.2.18`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.14.0-rc1.**No license information found**
@@ -722,12 +722,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:56 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.18`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.14.0-rc1.**No license information found**
@@ -1413,12 +1413,12 @@ This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:57 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.2.18`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.14.0-rc1.**No license information found**
@@ -2136,12 +2136,12 @@ This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:57 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.18`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2628,12 +2628,12 @@ This report was generated on **Mon Oct 10 16:48:11 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:57 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.18`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3226,12 +3226,12 @@ This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:57 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.2.18`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3785,12 +3785,12 @@ This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:58 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.2.17`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.2.18`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.14.0-rc1.**No license information found**
@@ -4503,4 +4503,4 @@ This report was generated on **Mon Oct 10 16:48:12 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 10 16:48:13 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 10 18:55:58 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.2.17</version>
+<version>0.2.18</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/tests/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -1,6 +1,3 @@
-import org.gradle.api.Project
-import org.gradle.api.Task
-
 /*
  * Copyright 2022, TeamDev. All rights reserved.
  *
@@ -27,6 +24,9 @@ import org.gradle.api.Task
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.gradle.api.Project
+import org.gradle.api.Task
+
 /**
  * Configures the dependencies between third-party Gradle tasks
  * and those defined via ProtoData and Spine Model Compiler.
@@ -35,6 +35,7 @@ import org.gradle.api.Task
  * usage of Spine-specific task output by other tasks,
  * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
  */
+@Suppress("unused")
 fun Project.configureTaskDependencies() {
 
     /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,4 +34,4 @@ val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.101")
 val devProtoDataVersion: String by extra("0.2.16")
 
 // The version of ProtoData being developed.
-val protoDataVersion: String by extra("0.2.17")
+val protoDataVersion: String by extra("0.2.18")


### PR DESCRIPTION
This PR bumps version to `0.2.18` to trigger publishing to fix the missing `pom.xml` file for the previously published version.