### PR TITLE
Trigger publishing

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -69,7 +69,7 @@ val nl: String = System.lineSeparator()
 /**
  * Prints output directories produced by `launchProtoData` tasks with
  * corresponding number of files in those directories.
- */
+
 val launchProtoDataMain: Task by tasks.getting {
     doLast {
         println("***** `launchProtoDataMain.output`:")
@@ -80,10 +80,11 @@ val launchProtoDataMain: Task by tasks.getting {
         println("*************************")
     }
 }
+ */
 
 /**
  * Prints input of `compileKotlin` tasks of this module.
- */
+
 val compileKotlin: Task by tasks.getting {
     doFirst {
         println()
@@ -93,3 +94,4 @@ val compileKotlin: Task by tasks.getting {
         println(inputs.files.joinToString(separator = nl))
     }
 }
+ */

--- a/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/config/ConfigView.kt
@@ -60,7 +60,7 @@ internal class ConfigView : View<ConfigId, Config, Config.Builder>() {
         private val theId = setOf(
             /* Use the below code instead of Java API, when the mystery with KotlinCompile
                not being able to see the generated Kotlin proto code as its input is solved. */
-//             configId { value = "configuration_instance" }
+            // configId { value = "configuration_instance" }
             ConfigId.newBuilder().setValue("configuration_instance").build()
         )
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-cli:0.2.23`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -695,12 +695,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:22 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:43 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.2.23`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1373,12 +1373,12 @@ This report was generated on **Sat Oct 29 20:00:22 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:23 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:43 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.2.23`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2068,12 +2068,12 @@ This report was generated on **Sat Oct 29 20:00:23 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:23 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:43 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.2.23`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2552,12 +2552,12 @@ This report was generated on **Sat Oct 29 20:00:23 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:44 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.2.23`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3219,12 +3219,12 @@ This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:44 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.2.23`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3756,12 +3756,12 @@ This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:45 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.2.22`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.2.23`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4447,4 +4447,4 @@ This report was generated on **Sat Oct 29 20:00:24 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 29 20:00:25 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 29 20:48:45 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.2.22</version>
+<version>0.2.23</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.2.22")
+val protoDataVersion: String by extra("0.3.0")


### PR DESCRIPTION
The purpose of this PR is to trigger publishing to Gradle Plugin portal because POM for `0.2.22` is not available even though the `publish` workflow [did not produce any errors](https://github.com/SpineEventEngine/ProtoData/actions/runs/3352315178/jobs/5554381191).

Also the diagnostic output of `compileKotlin` task of the `compiler` subproject was turned off.