### PR TITLE
Partially fix copying subdirectories from `generated-proto`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -28,17 +28,24 @@ package io.spine.internal.dependency
 
 // https://github.com/JetBrains/kotlin
 // https://github.com/Kotlin
+@Suppress("unused")
 object Kotlin {
+
     /**
-    * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
-    */
+     * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
+     */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.7.20"
-    const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
-    const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
-    const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
-    const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
-    const val gradlePluginApi = "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$version"
-    const val gradlePluginLib = "org.jetbrains.kotlin:kotlin-gradle-plugin:${version}"
-    const val testJUnit5     = "org.jetbrains.kotlin:kotlin-test-junit5:$version"
+    const val version = "1.7.20"
+
+    private const val group = "org.jetbrains.kotlin"
+
+    const val stdLib       = "${group}:kotlin-stdlib:${version}"
+    const val stdLibCommon = "${group}:kotlin-stdlib-common:${version}"
+    const val stdLibJdk8   = "${group}:kotlin-stdlib-jdk8:${version}"
+
+    const val reflect    = "${group}:kotlin-reflect:${version}"
+    const val testJUnit5 = "${group}:kotlin-test-junit5:$version"
+
+    const val gradlePluginApi = "${group}:kotlin-gradle-plugin-api:$version"
+    const val gradlePluginLib = "${group}:kotlin-gradle-plugin:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -64,7 +64,7 @@ class Spine(p: ExtensionAware) {
         const val protoData = "0.3.0"
 
         /**
-         * The default version  of `base` to use.
+         * The default version of `base` to use.
          * @see [Spine.base]
          */
         const val base = "2.0.0-SNAPSHOT.130"
@@ -179,7 +179,7 @@ class Spine(p: ExtensionAware) {
 
     /**
      *  Does not allow re-definition via a project property.
-     *  Please change [DefaultVersion.javadocTools].                     ˚
+     *  Please change [DefaultVersion.javadocTools].
      */
     val javadocTools = "$toolsGroup::${DefaultVersion.javadocTools}"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.121"
+        const val toolBase = "2.0.0-SNAPSHOT.130"
 
         /**
          * The version of `validation` to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -51,7 +51,6 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolutionStrategy
-import org.gradle.api.artifacts.dsl.RepositoryHandler
 
 /**
  * The function to be used in `buildscript` when a fully-qualified call must be made.
@@ -134,6 +133,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     )
 }
 
+@Suppress("unused")
 fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     fun excludeProtoLite(configurationName: String) {
@@ -147,31 +147,4 @@ fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     excludeProtoLite("runtimeOnly")
     excludeProtoLite("testRuntimeOnly")
-}
-
-@Suppress("unused")
-object DependencyResolution {
-    @Deprecated(
-        "Please use `configurations.forceVersions()`.",
-        ReplaceWith("configurations.forceVersions()")
-    )
-    fun forceConfiguration(configurations: ConfigurationContainer) {
-        configurations.forceVersions()
-    }
-
-    @Deprecated(
-        "Please use `configurations.excludeProtobufLite()`.",
-        ReplaceWith("configurations.excludeProtobufLite()")
-    )
-    fun excludeProtobufLite(configurations: ConfigurationContainer) {
-        configurations.excludeProtobufLite()
-    }
-
-    @Deprecated(
-        "Please use `applyStandard(repositories)` instead.",
-        replaceWith = ReplaceWith("applyStandard(repositories)")
-    )
-    fun defaultRepositories(repositories: RepositoryHandler) {
-        repositories.standardToSpineSdk()
-    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("TooManyFunctions") // Deprecated functions will be kept for a while.
+
 package io.spine.internal.gradle
 
 import io.spine.internal.gradle.publish.CloudRepo

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -54,7 +54,7 @@ open class RunGradle : DefaultTask() {
          */
         private const val BUILD_TIMEOUT_MINUTES: Long = 10
     }
-    
+
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
@@ -43,7 +43,15 @@ import org.gradle.kotlin.dsl.listProperty
 /**
  * Default subdirectories under a generated source set.
  */
-private val defaultSubdirectories = listOf("java", "kotlin")
+private val defaultSubdirectories = listOf(
+    "java",
+    "kotlin",
+    "grpc",
+    "js",
+    "dart",
+    "spine",
+    "protodata"
+)
 
 /**
  * The default name of the output directory of ProtoData placed under the project root.
@@ -134,23 +142,28 @@ public class Extension(internal val project: Project): CodegenSettings {
     }
 
     /**
-     * Obtains the source directory for the given source set.
+     * Obtains the source directories for the given source set.
      *
      * @see srcBaseDir for the rules for the source dir construction
      */
-    internal fun sourceDir(sourceSet: SourceSet): Provider<List<Directory>> =
+    internal fun sourceDirs(sourceSet: SourceSet): Provider<List<Directory>> =
         compileDir(sourceSet, srcBaseDirProperty)
 
     /**
-     * Obtains the target directory for code generation.
+     * Obtains the target directories for code generation.
      *
      * @see targetBaseDir for the rules for the target dir construction
      */
-    internal fun targetDir(sourceSet: SourceSet): Provider<List<Directory>> =
+    internal fun targetDirs(sourceSet: SourceSet): Provider<List<Directory>> =
         compileDir(sourceSet, targetBaseDirProperty)
 
-    private fun compileDir(sourceSet: SourceSet, base: DirectoryProperty): Provider<List<Directory>> {
+    private fun compileDir(
+        sourceSet: SourceSet,
+        base: DirectoryProperty
+    ): Provider<List<Directory>> {
         val sourceSetDir = base.dir(sourceSet.name)
-        return sourceSetDir.map { root -> subDirs.map { root.dir(it) } }
+        return sourceSetDir.map { root: Directory ->
+            subDirs.map { root.dir(it) }
+        }
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -69,42 +69,6 @@ public abstract class LaunchProtoData : JavaExec() {
     internal lateinit var requestFile: Provider<RegularFile>
 
     /**
-     * The path to the directory with the generated source code.
-     *
-     * May not be available, if `protoc` built-ins were turned off, resulting in no source code
-     * being generated. In such a mode `protoc` worked only generating descriptor set files.
-     *
-     * This property is deprecated. [sources] should be used instead of it. Accessing this property
-     * delegates to [sources].
-     */
-    @get:InputDirectory
-    @get:Optional
-    @Deprecated("Use `sources` instead.")
-    internal var source: Provider<Directory>
-        set(value) {
-            sources = value.map { listOf(it) }
-        }
-        get() {
-            return sources.map { it.first() }
-        }
-
-    /**
-     * The path to the directory with the processed source code.
-     *
-     * This property is deprecated. [targets] should be used instead of it. Accessing this property
-     * delegates to [targets].
-     */
-    @get:OutputDirectory
-    @Deprecated("Use `targets` instead.")
-    internal var target: Provider<Directory>
-        set(value) {
-            targets = value.map { listOf(it) }
-        }
-        get() {
-            return targets.map { it.first() }
-        }
-
-    /**
      * The paths to the directories with the generated source code.
      *
      * May not be available, if `protoc` built-ins were turned off, resulting in no source code
@@ -172,8 +136,8 @@ public abstract class LaunchProtoData : JavaExec() {
 
             yield("--ignore-missing")
         }.asIterable()
-        if (logger.isDebugEnabled) {
-            logger.debug("ProtoData command for ${path}: ${command.joinToString(separator = " ")}")
+        if (logger.isInfoEnabled) {
+            logger.info("ProtoData command for `${path}`: ${command.joinToString(separator = " ")}")
         }
         classpath(protoDataConfig)
         classpath(userClasspathConfig)

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -167,8 +167,8 @@ private fun Project.createLaunchTask(ext: Extension, sourceSet: SourceSet): Laun
         plugins = ext.plugins
         optionProviders = ext.optionProviders
         requestFile = ext.requestFile(sourceSet)
-        sources = ext.sourceDir(sourceSet)
-        targets = ext.targetDir(sourceSet)
+        sources = ext.sourceDirs(sourceSet)
+        targets = ext.targetDirs(sourceSet)
         protoDataConfig = artifactConfig
         userClasspathConfig = userCpConfig
         project.afterEvaluate {
@@ -187,7 +187,7 @@ private fun Project.createCleanTask(ext: Extension, sourceSet: SourceSet) {
     val project = this
     val taskName = CleanTask.nameFor(sourceSet)
     tasks.create<Delete>(taskName) {
-        delete(ext.targetDir(sourceSet))
+        delete(ext.targetDirs(sourceSet))
 
         tasks.getByName("clean").dependsOn(this)
         val launchTask = LaunchTask.get(project, sourceSet)
@@ -288,8 +288,8 @@ private fun Project.configureSourceSets(extension: Extension) {
 }
 
 private fun Extension.configureSourceSet(sourceSet: SourceSet) {
-    val sourceDirs = sourceDir(sourceSet).getOrElse(listOf())
-    val targetDirs = targetDir(sourceSet).get()
+    val sourceDirs = sourceDirs(sourceSet).getOrElse(listOf())
+    val targetDirs = targetDirs(sourceSet).get()
 
     sourceSet.java.srcDir(targetDirs)
 

--- a/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ExtensionSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ExtensionSpec.kt
@@ -40,10 +40,12 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-class `Plugin extension should` {
+@DisplayName("Plugin extension should")
+class ExtensionSpec {
 
     private lateinit var project: Project
     private lateinit var extension: Extension
@@ -106,7 +108,7 @@ class `Plugin extension should` {
         extension.subDirs = listOf(subDir)
 
         val sourceSet = project.sourceSets.getByName(MAIN_SOURCE_SET_NAME)
-        val sourceDir = extension.sourceDir(sourceSet)
+        val sourceDir = extension.sourceDirs(sourceSet)
         assertThat(sourceDir.get().first().asFile.toPath())
             .isEqualTo(project.projectDir.toPath() / basePath / MAIN_SOURCE_SET_NAME / subDir)
     }
@@ -120,7 +122,7 @@ class `Plugin extension should` {
         extension.subDirs = listOf(subDir)
 
         val sourceSet = project.sourceSets.getByName(MAIN_SOURCE_SET_NAME)
-        val targetDirs = extension.targetDir(sourceSet)
+        val targetDirs = extension.targetDirs(sourceSet)
         assertThat(targetDirs.get().first().asFile.toPath())
             .isEqualTo(project.projectDir.toPath() / basePath / MAIN_SOURCE_SET_NAME / subDir)
     }
@@ -139,7 +141,7 @@ class `Plugin extension should` {
         val absolutePath = transforming<Directory, Path>({ it.asFile.toPath() }, "absolute path")
 
         val sourceMain = project.projectDir.toPath() / srcBasePath / MAIN_SOURCE_SET_NAME
-        val sourceDirs = extension.sourceDir(project.sourceSets.getByName(MAIN_SOURCE_SET_NAME))
+        val sourceDirs = extension.sourceDirs(project.sourceSets.getByName(MAIN_SOURCE_SET_NAME))
         assertThat(sourceDirs.get())
             .comparingElementsUsing(absolutePath)
             .containsExactly(
@@ -148,7 +150,7 @@ class `Plugin extension should` {
             )
 
         val targetMain = project.projectDir.toPath() / targetBasePath / MAIN_SOURCE_SET_NAME
-        val targetDirs = extension.targetDir(project.sourceSets.getByName(MAIN_SOURCE_SET_NAME))
+        val targetDirs = extension.targetDirs(project.sourceSets.getByName(MAIN_SOURCE_SET_NAME))
         assertThat(targetDirs.get())
             .comparingElementsUsing(absolutePath)
             .containsExactly(

--- a/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
@@ -37,10 +37,12 @@ import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
 import org.gradle.kotlin.dsl.apply
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-class `ProtoData plugin should` {
+@DisplayName("Plugin configuration should")
+class ProjectConfigSpec {
 
     companion object {
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.4.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -701,12 +701,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.4.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1385,12 +1385,12 @@ This report was generated on **Fri Nov 11 12:22:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.4.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2086,12 +2086,12 @@ This report was generated on **Fri Nov 11 12:22:06 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.4.3`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -2575,12 +2575,12 @@ This report was generated on **Fri Nov 11 12:22:06 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.4.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3247,12 +3247,12 @@ This report was generated on **Fri Nov 11 12:22:07 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.4.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3789,12 +3789,12 @@ This report was generated on **Fri Nov 11 12:22:07 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:08 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.4.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.4.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4485,4 +4485,4 @@ This report was generated on **Fri Nov 11 12:22:08 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 11 12:22:08 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 12 22:20:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -701,7 +701,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:44 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1385,7 +1385,7 @@ This report was generated on **Sun Nov 13 14:49:44 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2086,7 +2086,7 @@ This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2575,7 +2575,7 @@ This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3247,7 +3247,7 @@ This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3789,7 +3789,7 @@ This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4485,4 +4485,4 @@ This report was generated on **Sun Nov 13 14:49:47 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 13 14:49:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 14 16:47:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -701,7 +701,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:44 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1385,7 +1385,7 @@ This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2086,7 +2086,7 @@ This report was generated on **Sat Nov 12 22:20:00 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2575,7 +2575,7 @@ This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3247,7 +3247,7 @@ This report was generated on **Sat Nov 12 22:20:01 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3789,7 +3789,7 @@ This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4485,4 +4485,4 @@ This report was generated on **Sat Nov 12 22:20:02 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 12 22:20:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 13 14:49:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.4.0</version>
+<version>0.4.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.130</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -229,12 +229,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.130</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.130</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -28,17 +28,24 @@ package io.spine.internal.dependency
 
 // https://github.com/JetBrains/kotlin
 // https://github.com/Kotlin
+@Suppress("unused")
 object Kotlin {
+
     /**
-    * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
-    */
+     * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
+     */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.7.20"
-    const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
-    const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
-    const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
-    const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
-    const val gradlePluginApi = "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$version"
-    const val gradlePluginLib = "org.jetbrains.kotlin:kotlin-gradle-plugin:${version}"
-    const val testJUnit5     = "org.jetbrains.kotlin:kotlin-test-junit5:$version"
+    const val version = "1.7.20"
+
+    private const val group = "org.jetbrains.kotlin"
+
+    const val stdLib       = "${group}:kotlin-stdlib:${version}"
+    const val stdLibCommon = "${group}:kotlin-stdlib-common:${version}"
+    const val stdLibJdk8   = "${group}:kotlin-stdlib-jdk8:${version}"
+
+    const val reflect    = "${group}:kotlin-reflect:${version}"
+    const val testJUnit5 = "${group}:kotlin-test-junit5:$version"
+
+    const val gradlePluginApi = "${group}:kotlin-gradle-plugin-api:$version"
+    const val gradlePluginLib = "${group}:kotlin-gradle-plugin:${version}"
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -64,7 +64,7 @@ class Spine(p: ExtensionAware) {
         const val protoData = "0.3.0"
 
         /**
-         * The default version  of `base` to use.
+         * The default version of `base` to use.
          * @see [Spine.base]
          */
         const val base = "2.0.0-SNAPSHOT.130"
@@ -179,7 +179,7 @@ class Spine(p: ExtensionAware) {
 
     /**
      *  Does not allow re-definition via a project property.
-     *  Please change [DefaultVersion.javadocTools].                     ˚
+     *  Please change [DefaultVersion.javadocTools].
      */
     val javadocTools = "$toolsGroup::${DefaultVersion.javadocTools}"
 

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.121"
+        const val toolBase = "2.0.0-SNAPSHOT.130"
 
         /**
          * The version of `validation` to use.

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -51,7 +51,6 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolutionStrategy
-import org.gradle.api.artifacts.dsl.RepositoryHandler
 
 /**
  * The function to be used in `buildscript` when a fully-qualified call must be made.
@@ -134,6 +133,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     )
 }
 
+@Suppress("unused")
 fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     fun excludeProtoLite(configurationName: String) {
@@ -147,31 +147,4 @@ fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     excludeProtoLite("runtimeOnly")
     excludeProtoLite("testRuntimeOnly")
-}
-
-@Suppress("unused")
-object DependencyResolution {
-    @Deprecated(
-        "Please use `configurations.forceVersions()`.",
-        ReplaceWith("configurations.forceVersions()")
-    )
-    fun forceConfiguration(configurations: ConfigurationContainer) {
-        configurations.forceVersions()
-    }
-
-    @Deprecated(
-        "Please use `configurations.excludeProtobufLite()`.",
-        ReplaceWith("configurations.excludeProtobufLite()")
-    )
-    fun excludeProtobufLite(configurations: ConfigurationContainer) {
-        configurations.excludeProtobufLite()
-    }
-
-    @Deprecated(
-        "Please use `applyStandard(repositories)` instead.",
-        replaceWith = ReplaceWith("applyStandard(repositories)")
-    )
-    fun defaultRepositories(repositories: RepositoryHandler) {
-        repositories.standardToSpineSdk()
-    }
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("TooManyFunctions") // Deprecated functions will be kept for a while.
+
 package io.spine.internal.gradle
 
 import io.spine.internal.gradle.publish.CloudRepo

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -54,7 +54,7 @@ open class RunGradle : DefaultTask() {
          */
         private const val BUILD_TIMEOUT_MINUTES: Long = 10
     }
-    
+
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.4.0")
+val protoDataVersion: String by extra("0.4.3")


### PR DESCRIPTION
This PR [partially](#100) addresses #94 by extending the list of pre-defined directory names. 

[More work](#110) is needed to fix it for good.


