### PR TITLE
Migrate to Protobuf Gradle Plugin v0.9.1

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -24,8 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.protobuf
 import io.spine.internal.dependency.Jackson
 import io.spine.internal.dependency.Spine
 
@@ -61,10 +59,8 @@ dependencies {
  */
 protobuf {
     generatedFilesBaseDir = "$projectDir/generated"
-    generateProtoTasks {
-        for (task in all()) {
-            task.builtins.maybeCreate("kotlin")
-        }
+    generateProtoTasks.all().configureEach {
+        builtins.maybeCreate("kotlin")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,6 @@
 
 @file:Suppress("RemoveRedundantQualifierName")
 
-import Build_gradle.Subproject
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.JUnit
@@ -115,15 +112,6 @@ object BuildSettings {
     private const val JAVA_VERSION = 11
 
     val javaVersion = JavaLanguageVersion.of(JAVA_VERSION)
-
-    /**
-     * Temporarily use this version, since 3.21.x is known to provide
-     * a broken `protoc-gen-js` artifact and Kotlin code without access modifiers.
-     *
-     * See https://github.com/protocolbuffers/protobuf-javascript/issues/127.
-     *     https://github.com/protocolbuffers/protobuf/issues/10593
-     */
-    const val protocArtifact = "com.google.protobuf:protoc:3.19.6"
 }
 
 subprojects {
@@ -137,8 +125,6 @@ subprojects {
     
     setupTests()
     configureJavadoc()
-
-    configureProtoc(BuildSettings.protocArtifact)
 
     val generated = "$projectDir/generated"
     applyGeneratedDirectories(generated)
@@ -326,21 +312,5 @@ fun Subproject.configureJavadoc() {
         from(dokkaJavadoc.outputDirectory)
         archiveClassifier.set("javadoc")
         dependsOn(dokkaJavadoc)
-    }
-}
-
-fun Subproject.configureProtoc(protocArtifact: String) {
-    protobuf {
-        protoc {
-            // Temporarily use this version, since 3.21.x is known to provide
-            // a broken `protoc-gen-js` artifact.
-            // See https://github.com/protocolbuffers/protobuf-javascript/issues/127.
-            //
-            // Once it is addressed, this artifact should be `Protobuf.compiler`.
-            //
-            // Also, this fixes the explicit API more for the generated Kotlin code.
-            //
-            artifact = protocArtifact
-        }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -90,7 +90,7 @@ val errorPronePluginVersion = "3.0.1"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.8.19"
+val protobufPluginVersion = "0.9.1"
 
 /**
  * The version of Dokka Gradle Plugins.

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -151,15 +151,15 @@ fun Project.configureTaskDependencies() {
     }
 
     afterEvaluate {
-        "compileKotlin".dependOn("launchProtoData")
-        "compileTestKotlin".dependOn("launchTestProtoData")
+        "compileKotlin".dependOn("launchProtoDataMain")
+        "compileTestKotlin".dependOn("launchProtoDataTest")
         "sourcesJar".dependOn("generateProto")
-        "sourcesJar".dependOn("launchProtoData")
+        "sourcesJar".dependOn("launchProtoDataMain")
         "sourcesJar".dependOn("createVersionFile")
         "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
-        "dokkaHtml".dependOn("launchProtoData")
-        "dokkaJavadoc".dependOn("launchProtoData")
+        "dokkaHtml".dependOn("launchProtoDataMain")
+        "dokkaJavadoc".dependOn("launchProtoDataMain")
         "publishPluginJar".dependOn("createVersionFile")
     }
 }

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -127,7 +127,7 @@ val PluginDependenciesSpec.`gradle-doctor`: PluginDependencySpec
  *
  * It is required in order to avoid warnings in build logs, detecting the undeclared
  * usage of Spine-specific task output by other tasks,
- * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
+ * e.g. the output of `launchProtoData` is used by `compileKotlin`.
  */
 @Suppress("unused")
 fun Project.configureTaskDependencies() {
@@ -151,15 +151,15 @@ fun Project.configureTaskDependencies() {
     }
 
     afterEvaluate {
-        "compileKotlin".dependOn("launchProtoDataMain")
-        "compileTestKotlin".dependOn("launchProtoDataTest")
+        "compileKotlin".dependOn("launchProtoData")
+        "compileTestKotlin".dependOn("launchTestProtoData")
         "sourcesJar".dependOn("generateProto")
-        "sourcesJar".dependOn("launchProtoDataMain")
+        "sourcesJar".dependOn("launchProtoData")
         "sourcesJar".dependOn("createVersionFile")
         "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
-        "dokkaHtml".dependOn("launchProtoDataMain")
-        "dokkaJavadoc".dependOn("launchProtoDataMain")
+        "dokkaHtml".dependOn("launchProtoData")
+        "dokkaJavadoc".dependOn("launchProtoData")
         "publishPluginJar".dependOn("createVersionFile")
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -46,7 +46,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.8.19"
+        const val version = "0.9.1"
         const val id = "com.google.protobuf"
         const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,7 +61,7 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.5.3"
+        const val protoData = "0.5.4"
 
         /**
          * The default version of `base` to use.
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.152"
+        const val toolBase = "2.0.0-SNAPSHOT.154"
 
         /**
          * The version of `validation` to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -85,7 +85,7 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.121"
+        const val mcJava = "2.0.0-SNAPSHOT.123"
 
         /**
          * The version of `base-types` to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
@@ -26,10 +26,8 @@
 
 package io.spine.internal.gradle.dart.plugin
 
-import com.google.protobuf.gradle.builtins
 import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
+import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.remove
 import io.spine.internal.dependency.Protobuf
 
@@ -42,9 +40,10 @@ fun DartPlugins.protobuf() {
 
     plugins.apply(Protobuf.GradlePlugin.id)
 
-    project.protobuf {
-        generateProtoTasks.all().forEach { task ->
-            task.apply {
+    val protobufExtension = project.extensions.getByType(ProtobufExtension::class.java)
+    protobufExtension.apply {
+        generateProtoTasks.all().configureEach {
+            apply {
                 plugins { id("dart") }
                 builtins { remove("java") }
             }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Protobuf.kt
@@ -26,11 +26,8 @@
 
 package io.spine.internal.gradle.javascript.plugin
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
+import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.remove
 import io.spine.internal.dependency.Protobuf
 
@@ -50,7 +47,8 @@ fun JsPlugins.protobuf() {
         apply(Protobuf.GradlePlugin.id)
     }
 
-    project.protobuf {
+    val protobufExt = project.extensions.getByType(ProtobufExtension::class.java)
+    protobufExt.apply {
 
         generatedFilesBaseDir = projectDir.path
 

--- a/codegen/java/build.gradle.kts
+++ b/codegen/java/build.gradle.kts
@@ -24,9 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.ofSourceSet
-import com.google.protobuf.gradle.protobuf
 import io.spine.internal.dependency.JavaPoet
 import io.spine.internal.dependency.JavaX
 import org.gradle.api.file.DuplicatesStrategy.INCLUDE

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -72,9 +72,9 @@ val nl: String = System.lineSeparator()
  * Prints output directories produced by `launchProtoData` tasks with
  * corresponding number of files in those directories.
 
-val launchProtoDataMain: Task by tasks.getting {
+val launchProtoData: Task by tasks.getting {
     doLast {
-        println("***** `launchProtoDataMain.output`:")
+        println("***** `launchProtoData.output`:")
         outputs.files.forEach { dir ->
             val fileCount = project.fileTree(dir).count()
             println("$dir $fileCount files.")

--- a/gradle-api/build.gradle.kts
+++ b/gradle-api/build.gradle.kts
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import io.spine.internal.dependency.Spine
+
 plugins {
     `detekt-code-analysis`
     jacoco
@@ -31,4 +33,8 @@ plugins {
 
 dependencies {
     compileOnly(gradleApi())
+    val spine = Spine(project)
+    implementation(spine.toolBase)
+    testImplementation(gradleApi())
+    testImplementation(spine.pluginTestlib)
 }

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/LaunchTask.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/LaunchTask.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.gradle
 
+import io.spine.tools.code.SourceSetName
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.SourceSet
@@ -35,12 +36,13 @@ import org.gradle.api.tasks.SourceSet
  */
 public object LaunchTask {
 
-    private const val prefix: String = "launchProtoData"
-
     /**
      * Obtains a name of the task for the given source set.
      */
-    public fun nameFor(sourceSet: SourceSet): String = "$prefix${sourceSet.capitalizedName}"
+    public fun nameFor(sourceSet: SourceSet): String {
+        val sourceSetName = SourceSetName(sourceSet.name)
+        return "launch${sourceSetName.toInfix()}ProtoData"
+    }
 
     /**
      * Obtains an instance of the task in the given project for the specified source set.

--- a/gradle-api/src/test/kotlin/io/spine/protodata/gradle/plugin/LaunchTaskSpec.kt
+++ b/gradle-api/src/test/kotlin/io/spine/protodata/gradle/plugin/LaunchTaskSpec.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.gradle.plugin
+
+import groovy.lang.Closure
+import io.kotest.matchers.shouldBe
+import io.spine.protodata.gradle.LaunchTask
+import org.gradle.api.Action
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetOutput
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`LaunchTask` should")
+class LaunchTaskSpec {
+
+    @Test
+    fun `provide a task name for a source set`() {
+        LaunchTask.nameFor(mainSourceSet) shouldBe "launchProtoData"
+        LaunchTask.nameFor(testSourceSet) shouldBe "launchTestProtoData"
+        LaunchTask.nameFor(functionalTestsSourceSet) shouldBe "launchFunctionalTestsProtoData"
+    }
+}
+
+val mainSourceSet = StubSourceSet(SourceSet.MAIN_SOURCE_SET_NAME)
+val testSourceSet = StubSourceSet(SourceSet.TEST_SOURCE_SET_NAME)
+val functionalTestsSourceSet = StubSourceSet("functionalTests")
+
+class StubSourceSet(private val name: String) : SourceSet {
+
+    override fun getName(): String = name
+
+    private fun stubMethod(): Nothing = throw NotImplementedError(
+        "Stub method called. If you need this method for your tests, please create" +
+                " a class derived from ${this::class.qualifiedName} and override the method."
+    )
+
+    override fun getExtensions(): ExtensionContainer = stubMethod()
+
+    override fun getCompileClasspath(): FileCollection = stubMethod()
+
+    override fun setCompileClasspath(classpath: FileCollection): Unit = stubMethod()
+
+    override fun getAnnotationProcessorPath(): FileCollection = stubMethod()
+
+    override fun setAnnotationProcessorPath(annotationProcessorPath: FileCollection): Unit =
+        stubMethod()
+
+    override fun getRuntimeClasspath(): FileCollection = stubMethod()
+
+    override fun setRuntimeClasspath(classpath: FileCollection): Unit = stubMethod()
+
+    override fun getOutput(): SourceSetOutput = stubMethod()
+
+    override fun compiledBy(vararg taskPaths: Any?): SourceSet = stubMethod()
+
+    override fun getResources(): SourceDirectorySet = stubMethod()
+
+    override fun resources(configureClosure: Closure<*>?): SourceSet = stubMethod()
+
+    override fun resources(configureAction: Action<in SourceDirectorySet>): SourceSet =
+        stubMethod()
+
+    override fun getJava(): SourceDirectorySet = stubMethod()
+
+    override fun java(configureClosure: Closure<*>?): SourceSet = stubMethod()
+
+    override fun java(configureAction: Action<in SourceDirectorySet>): SourceSet = stubMethod()
+
+    override fun getAllJava(): SourceDirectorySet = stubMethod()
+
+    override fun getAllSource(): SourceDirectorySet = stubMethod()
+
+    override fun getClassesTaskName(): String = stubMethod()
+
+    override fun getProcessResourcesTaskName(): String = stubMethod()
+
+    override fun getCompileJavaTaskName(): String = stubMethod()
+
+    override fun getCompileTaskName(language: String): String = stubMethod()
+
+    override fun getJavadocTaskName(): String = stubMethod()
+
+    override fun getJarTaskName(): String = stubMethod()
+
+    override fun getJavadocJarTaskName(): String = stubMethod()
+
+    override fun getSourcesJarTaskName(): String = stubMethod()
+
+    override fun getTaskName(verb: String?, target: String?): String = stubMethod()
+
+    override fun getCompileOnlyConfigurationName(): String = stubMethod()
+
+    override fun getCompileOnlyApiConfigurationName(): String = stubMethod()
+
+    override fun getCompileClasspathConfigurationName(): String = stubMethod()
+
+    override fun getAnnotationProcessorConfigurationName(): String = stubMethod()
+
+    override fun getApiConfigurationName(): String = stubMethod()
+
+    override fun getImplementationConfigurationName(): String = stubMethod()
+
+    override fun getApiElementsConfigurationName(): String = stubMethod()
+
+    override fun getRuntimeOnlyConfigurationName(): String = stubMethod()
+
+    override fun getRuntimeClasspathConfigurationName(): String = stubMethod()
+
+    override fun getRuntimeElementsConfigurationName(): String = stubMethod()
+
+    override fun getJavadocElementsConfigurationName(): String = stubMethod()
+
+    override fun getSourcesElementsConfigurationName(): String = stubMethod()
+}

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -89,8 +89,8 @@ For each source set in the project, the plugin generates a distinct task launchi
 Each task only processes the sources of the associated source set. This allows users to apply
 ProtoData to production and test code alike.
 
-To reference a specific task by name, use the following format: `launchProtoData<source set name>`,
-for example, `launchProtoDataMain`, `launchProtoDataTest`, `launchProtoDataIntegrationTest`, etc.
+To reference a specific task by name, use the following format: `launch<source set name>ProtoData`,
+for example, `launchProtoData`, `launchTestProtoData`, `launchIntegrationTestProtoData`, etc.
 
 To find all the tasks in a Gradle script, use the `LaunchProtoData` task type. For example:
 ```kotlin

--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
@@ -100,7 +100,8 @@ class PluginSpec {
     fun `produce 'java' and 'kotlin' directories under 'generated'`() {
         createProject("java-kotlin-test")
         val result = project.executeTask(build)
-        assertThat(result[build]).isEqualTo(SUCCESS)
+
+        result[build] shouldBe SUCCESS
         assertExists(generatedJavaDir)
         assertExists(generatedKotlinDir)
     }
@@ -109,7 +110,8 @@ class PluginSpec {
     fun `configure Kotlin compilation`() {
         createProject("kotlin-test")
         val result = project.executeTask(build)
-        assertThat(result[build]).isEqualTo(SUCCESS)
+
+        result[build] shouldBe SUCCESS
         assertExists(generatedKotlinDir)
     }
 
@@ -117,7 +119,8 @@ class PluginSpec {
     fun `produce Kotlin code for 'java-library' with 'kotlin(jvm)'`() {
         createProject("java-library-kotlin-jvm")
         val result = project.executeTask(build)
-        assertThat(result[build]).isEqualTo(SUCCESS)
+
+        result[build] shouldBe SUCCESS
         assertExists(generatedKotlinDir)
     }
 
@@ -126,6 +129,7 @@ class PluginSpec {
     fun `add 'kotlin' built-in only' if 'java' plugin or Kotlin compile tasks are present`() {
         createProject("android-library")  // could be in native code
         launchAndExpectResult(SUCCESS)
+
         assertDoesNotExist(generatedJavaDir)
         assertDoesNotExist(generatedKotlinDir)
     }
@@ -134,7 +138,8 @@ class PluginSpec {
     fun `support custom source sets`() {
         createProject("with-functional-test")
         val result = project.executeTask(build)
-        assertThat(result[build]).isEqualTo(SUCCESS)
+
+        result[build] shouldBe SUCCESS
         assertExists(generatedKotlinDir)
     }
 
@@ -143,7 +148,7 @@ class PluginSpec {
         createProject("copy-grpc")
 
         val result = project.executeTask(build)
-        assertThat(result[build]).isEqualTo(SUCCESS)
+        result[build] shouldBe SUCCESS
 
         printFilteredBuildOutput(projectDir, result)
 
@@ -171,8 +176,9 @@ class PluginSpec {
 
     private fun launchAndExpectResult(expected: TaskOutcome) {
         val result = launch()
+
         val outcome = result[launchProtoData]
-         outcome shouldBe expected
+        outcome shouldBe expected
     }
 
     private fun launch(): BuildResult =

--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.io.TempDir
 @DisplayName("ProtoData Gradle plugin should")
 class PluginSpec {
 
-    private val launchProtoData: TaskName = TaskName.of("launchProtoDataMain")
+    private val launchProtoData: TaskName = TaskName.of("launchProtoData")
 
     private lateinit var project: GradleProject
     private lateinit var projectDir: File

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.gradle.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -24,10 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.id
 import io.spine.internal.gradle.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.gradle.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.gradle.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.standardToSpineSdk
 import org.gradle.api.plugins.jvm.JvmTestSuite

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -180,7 +180,10 @@ private fun Project.createLaunchTask(sourceSet: SourceSet, ext: Extension): Laun
             val requestFile = requestFile.get().asFile
             val requestFileExists = requestFile.exists()
             if (!requestFileExists) {
-                project.logger.warn("Request file `$requestFile` does not exist.")
+                project.logger.warn(
+                    "The task ${it.name} was skipped because" +
+                            " the request file `$requestFile` was not created by ProtoData."
+                )
             }
             requestFileExists
         }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -41,6 +41,7 @@ import io.spine.protodata.gradle.Names.PROTODATA_PROTOC_PLUGIN
 import io.spine.protodata.gradle.Names.USER_CLASSPATH_CONFIGURATION_NAME
 import io.spine.protodata.gradle.ProtocPluginArtifact
 import io.spine.tools.code.manifest.Version
+import io.spine.tools.gradle.project.sourceSets
 import io.spine.tools.gradle.protobuf.protobufGradlePluginAdapter
 import java.io.File
 import org.gradle.api.Project

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -177,22 +177,15 @@ private fun Project.createLaunchTask(sourceSet: SourceSet, ext: Extension): Laun
         }
         setPreLaunchCleanup()
         onlyIf {
-            val requestFile = requestFile.get().asFile
-            val requestFileExists = requestFile.exists()
-            if (!requestFileExists) {
-                project.logger.warn(
-                    "The task ${it.name} was skipped because" +
-                            " the request file `$requestFile` was not created by ProtoData."
-                )
-            }
-            requestFileExists
+            checkRequestFile(sourceSet)
         }
         dependsOn(
             artifactConfig.buildDependencies,
             userCpConfig.buildDependencies
         )
-        javaCompileFor(sourceSet)?.dependsOn(this)
-        kotlinCompileFor(sourceSet)?.dependsOn(this)
+        val launchTask = this
+        javaCompileFor(sourceSet)?.dependsOn(launchTask)
+        kotlinCompileFor(sourceSet)?.dependsOn(launchTask)
     }
     return result
 }
@@ -260,7 +253,7 @@ private fun Project.configureProtoTask(task: GenerateProtoTask, ext: Extension) 
         task.builtins.maybeCreate("kotlin")
     }
     val sourceSet = task.sourceSet
-    task.getPlugins().run {
+    task.plugins.run {
         create(PROTODATA_PROTOC_PLUGIN) {
             val requestFile = ext.requestFile(sourceSet)
             val path = requestFile.get().asFile.absolutePath

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExtensions.kt
@@ -27,19 +27,9 @@
 package io.spine.protodata.gradle.plugin
 
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
-
-/**
- * The [sourceSets][SourceSetContainer] of this project.
- */
-internal val Project.sourceSets: SourceSetContainer
-    get() = extensions.getByType<JavaPluginExtension>().sourceSets
 
 /**
  * Attempts to obtain the Java compilation Gradle task for the given source set.

--- a/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ExtensionSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ExtensionSpec.kt
@@ -30,6 +30,7 @@ import com.google.common.truth.Correspondence.transforming
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufPlugin
 import io.spine.protodata.gradle.CodegenSettings
+import io.spine.tools.gradle.project.sourceSets
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.div
@@ -61,7 +62,7 @@ class ExtensionSpec {
             sourceSets.maybeCreate(MAIN_SOURCE_SET_NAME)
             apply<ProtobufPlugin>()
             apply<Plugin>()
-            
+
             extension = extensions.getByType<CodegenSettings>() as Extension
         }
     }

--- a/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
@@ -74,7 +74,7 @@ class ProjectConfigSpec {
         println(project.tasks.map { it.name })
         assertThat(project.tasks)
             .comparingElementsUsing(taskNames)
-            .containsAtLeast("launchProtoDataMain", "launchProtoDataTest")
+            .containsAtLeast("launchProtoData", "launchTestProtoData")
     }
 
     @Test
@@ -91,7 +91,7 @@ class ProjectConfigSpec {
         val task = project.tasks.getByName("compileJava")
         assertThat(task.dependsOn)
             .comparingElementsUsing(taskNames)
-            .contains("launchProtoDataMain")
+            .contains("launchProtoData")
     }
 }
 

--- a/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/protodata/gradle/plugin/ProjectConfigSpec.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.gradle.plugin
 import com.google.common.truth.Correspondence
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufPlugin
+import io.spine.tools.gradle.project.sourceSets
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/license-report.md
+++ b/license-report.md
@@ -893,7 +893,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:08 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1787,7 +1787,7 @@ This report was generated on **Fri Jan 13 20:48:08 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2641,7 +2641,7 @@ This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3521,7 +3521,7 @@ This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4418,7 +4418,7 @@ This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5178,7 +5178,7 @@ This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6132,7 +6132,7 @@ This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6861,7 +6861,7 @@ This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7745,4 +7745,4 @@ This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:00:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -893,7 +893,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:18 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1787,7 +1787,7 @@ This report was generated on **Tue Jan 03 11:24:18 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:19 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2646,7 +2646,7 @@ This report was generated on **Tue Jan 03 11:24:19 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3526,7 +3526,7 @@ This report was generated on **Tue Jan 03 11:24:20 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4423,7 +4423,7 @@ This report was generated on **Tue Jan 03 11:24:20 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5108,7 +5108,7 @@ This report was generated on **Tue Jan 03 11:24:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6075,7 +6075,7 @@ This report was generated on **Tue Jan 03 11:24:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6809,7 +6809,7 @@ This report was generated on **Tue Jan 03 11:24:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7693,4 +7693,4 @@ This report was generated on **Tue Jan 03 11:24:31 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 11:24:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 14:12:36 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-api:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -893,12 +893,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-cli:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1787,12 +1787,12 @@ This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2122,11 +2122,6 @@ This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.11.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.11.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2646,12 +2641,12 @@ This report was generated on **Thu Jan 12 14:12:33 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3526,12 +3521,12 @@ This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4423,12 +4418,12 @@ This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.5.5`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4597,11 +4592,6 @@ This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.11.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.11.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5108,12 +5098,12 @@ This report was generated on **Thu Jan 12 14:12:34 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -5427,7 +5417,7 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.gradle. **Name** : osdetector-gradle-plugin. **Version** : 1.7.0.
+1.  **Group** : com.google.gradle. **Name** : osdetector-gradle-plugin. **Version** : 1.7.1.
      * **Project URL:** [https://github.com/google/osdetector-gradle-plugin](https://github.com/google/osdetector-gradle-plugin)
      * **License:** [Apache License 2.0](http://opensource.org/licenses/Apache-2.0)
 
@@ -5453,10 +5443,6 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.8.19.
-     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
-     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
-
 1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.9.1.
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
@@ -5475,11 +5461,6 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.11.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.11.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5500,10 +5481,6 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.6.
-     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -6075,12 +6052,12 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.5.5`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6294,11 +6271,6 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.11.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.11.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6809,12 +6781,12 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.5.4`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.5.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -7693,4 +7665,4 @@ This report was generated on **Thu Jan 12 14:12:35 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 14:12:36 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 19:04:25 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -893,7 +893,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:08 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1787,7 +1787,7 @@ This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2641,7 +2641,7 @@ This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3521,7 +3521,7 @@ This report was generated on **Fri Jan 13 19:04:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4418,7 +4418,7 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4426,9 +4426,76 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
 # Dependencies of `io.spine.protodata:protodata-gradle-api:0.5.5`
 
 ## Runtime
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.11.0.
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 31.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 1.3.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.11.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.11.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.11.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.71.**No license information found**
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.7.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.7.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -4578,6 +4645,10 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.9.1.
+     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
+     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
@@ -4608,6 +4679,10 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
 1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 2.7.0.
      * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
      * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -4765,6 +4840,7 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.71.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -4797,6 +4873,10 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.13.0.
@@ -5098,7 +5178,7 @@ This report was generated on **Fri Jan 13 19:04:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6052,7 +6132,7 @@ This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6781,7 +6861,7 @@ This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7665,4 +7745,4 @@ This report was generated on **Fri Jan 13 19:04:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 13 19:04:25 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 20:48:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-api:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -893,12 +893,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-cli:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1787,12 +1787,12 @@ This report was generated on **Sat Jan 14 00:00:48 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2641,12 +2641,12 @@ This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3521,12 +3521,12 @@ This report was generated on **Sat Jan 14 00:00:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4418,12 +4418,12 @@ This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.6.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5178,12 +5178,12 @@ This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:13 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6132,12 +6132,12 @@ This report was generated on **Sat Jan 14 00:00:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:13 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.6.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6861,12 +6861,12 @@ This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:13 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.5.5`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.6.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -7745,4 +7745,4 @@ This report was generated on **Sat Jan 14 00:00:51 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 14 00:00:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 14 00:17:14 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
+    <artifactId>spine-plugin-testlib</artifactId>
+    <version>2.0.0-SNAPSHOT.154</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
     <version>2.0.0-SNAPSHOT.122</version>
     <scope>test</scope>
@@ -240,11 +246,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.154</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-plugin-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.154</version>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.152</version>
+    <version>2.0.0-SNAPSHOT.154</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -240,12 +240,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.152</version>
+    <version>2.0.0-SNAPSHOT.154</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.152</version>
+    <version>2.0.0-SNAPSHOT.154</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.5.5</version>
+<version>0.6.0</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.5.4</version>
+<version>0.5.5</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -198,13 +198,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-gradle-plugin</artifactId>
-    <version>0.8.19</version>
+    <version>0.9.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.19.6</version>
+    <version>3.21.11</version>
   </dependency>
   <dependency>
     <groupId>io.gitlab.arturbosch.detekt</groupId>
@@ -219,23 +219,23 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.123</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.123</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/test-env/build.gradle.kts
+++ b/test-env/build.gradle.kts
@@ -24,9 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
 import io.spine.internal.dependency.Grpc
 
 plugins {

--- a/tests/buildSrc/build.gradle.kts
+++ b/tests/buildSrc/build.gradle.kts
@@ -90,7 +90,7 @@ val errorPronePluginVersion = "3.0.1"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.8.19"
+val protobufPluginVersion = "0.9.1"
 
 /**
  * The version of Dokka Gradle Plugins.

--- a/tests/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/tests/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -151,15 +151,15 @@ fun Project.configureTaskDependencies() {
     }
 
     afterEvaluate {
-        "compileKotlin".dependOn("launchProtoData")
-        "compileTestKotlin".dependOn("launchTestProtoData")
+        "compileKotlin".dependOn("launchProtoDataMain")
+        "compileTestKotlin".dependOn("launchProtoDataTest")
         "sourcesJar".dependOn("generateProto")
-        "sourcesJar".dependOn("launchProtoData")
+        "sourcesJar".dependOn("launchProtoDataMain")
         "sourcesJar".dependOn("createVersionFile")
         "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
-        "dokkaHtml".dependOn("launchProtoData")
-        "dokkaJavadoc".dependOn("launchProtoData")
+        "dokkaHtml".dependOn("launchProtoDataMain")
+        "dokkaJavadoc".dependOn("launchProtoDataMain")
         "publishPluginJar".dependOn("createVersionFile")
     }
 }

--- a/tests/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/tests/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -127,7 +127,7 @@ val PluginDependenciesSpec.`gradle-doctor`: PluginDependencySpec
  *
  * It is required in order to avoid warnings in build logs, detecting the undeclared
  * usage of Spine-specific task output by other tasks,
- * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
+ * e.g. the output of `launchProtoData` is used by `compileKotlin`.
  */
 @Suppress("unused")
 fun Project.configureTaskDependencies() {
@@ -151,15 +151,15 @@ fun Project.configureTaskDependencies() {
     }
 
     afterEvaluate {
-        "compileKotlin".dependOn("launchProtoDataMain")
-        "compileTestKotlin".dependOn("launchProtoDataTest")
+        "compileKotlin".dependOn("launchProtoData")
+        "compileTestKotlin".dependOn("launchTestProtoData")
         "sourcesJar".dependOn("generateProto")
-        "sourcesJar".dependOn("launchProtoDataMain")
+        "sourcesJar".dependOn("launchProtoData")
         "sourcesJar".dependOn("createVersionFile")
         "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
-        "dokkaHtml".dependOn("launchProtoDataMain")
-        "dokkaJavadoc".dependOn("launchProtoDataMain")
+        "dokkaHtml".dependOn("launchProtoData")
+        "dokkaJavadoc".dependOn("launchProtoData")
         "publishPluginJar".dependOn("createVersionFile")
     }
 }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -46,7 +46,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.8.19"
+        const val version = "0.9.1"
         const val id = "com.google.protobuf"
         const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,7 +61,7 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.5.3"
+        const val protoData = "0.5.4"
 
         /**
          * The default version of `base` to use.
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.152"
+        const val toolBase = "2.0.0-SNAPSHOT.154"
 
         /**
          * The version of `validation` to use.

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -85,7 +85,7 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.121"
+        const val mcJava = "2.0.0-SNAPSHOT.123"
 
         /**
          * The version of `base-types` to use.

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
@@ -26,10 +26,8 @@
 
 package io.spine.internal.gradle.dart.plugin
 
-import com.google.protobuf.gradle.builtins
 import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
+import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.remove
 import io.spine.internal.dependency.Protobuf
 
@@ -42,9 +40,10 @@ fun DartPlugins.protobuf() {
 
     plugins.apply(Protobuf.GradlePlugin.id)
 
-    project.protobuf {
-        generateProtoTasks.all().forEach { task ->
-            task.apply {
+    val protobufExtension = project.extensions.getByType(ProtobufExtension::class.java)
+    protobufExtension.apply {
+        generateProtoTasks.all().configureEach {
+            apply {
                 plugins { id("dart") }
                 builtins { remove("java") }
             }

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Protobuf.kt
@@ -26,11 +26,8 @@
 
 package io.spine.internal.gradle.javascript.plugin
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
+import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.remove
 import io.spine.internal.dependency.Protobuf
 
@@ -50,7 +47,8 @@ fun JsPlugins.protobuf() {
         apply(Protobuf.GradlePlugin.id)
     }
 
-    project.protobuf {
+    val protobufExt = project.extensions.getByType(ProtobufExtension::class.java)
+    protobufExt.apply {
 
         generatedFilesBaseDir = projectDir.path
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.5.5")
+val protoDataVersion: String by extra("0.6.0")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.5.4")
+val protoDataVersion: String by extra("0.5.5")


### PR DESCRIPTION
This PR migrates ProtoData to be built and use Protobuf Gradle Plugin v0.9.1.

Other notable changes:
  * The names of the `LaunchProtoData` are now calculated using standard Gradle conventions via infix form like `launchProtoData` for the `main` source set and `launchSourceSetNameProtoData` for the rest.
  
     The `BuildExtensions.kt` files under `buildSrc` will be adjusted correspondingly in `config` after sub-projects depending on ProtoData will be migrated to the version introduced by this PR (`0.6.0`).
     
  * The `Project.sourceSets` extension property introduced in the `io.spine.protodata.gradle.plugin` package was removed in favor of the similar property from the `io.spine.tools.gradle.project` package of `tool-base`.
