### PR TITLE
Restore binary backward compatibility

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -45,6 +45,38 @@ import io.spine.protodata.CallCardinality.SERVER_STREAMING
 import io.spine.protodata.CallCardinality.UNARY
 
 /**
+ * Obtains the type URl of the type.
+ *
+ * A type URL contains the type URL prefix and the qualified name of the type separated by
+ * the slash (`/`) symbol. See the docs of `google.protobuf.Any.type_url` for more info.
+ *
+ * @see MessageType.qualifiedName
+ * @see TypeName.typeUrl
+ */
+@Deprecated(
+    message = "Replaced with a Kotlin property (or a Java-style getter).",
+    replaceWith = ReplaceWith("typeUrl"),
+    level = DeprecationLevel.HIDDEN
+)
+public fun MessageType.typeUrl(): String = typeUrl
+
+/**
+ * Obtains the type URl of the type.
+ *
+ * A type URL contains the type URL prefix and the qualified name of the type separated by
+ * the slash (`/`) symbol. See the docs of `google.protobuf.Any.type_url` for more info.
+ *
+ * @see MessageType.qualifiedName
+ * @see TypeName.typeUrl
+ */
+@Deprecated(
+    message = "Replaced with a Kotlin property (or a Java-style getter).",
+    replaceWith = ReplaceWith("typeUrl"),
+    level = DeprecationLevel.HIDDEN
+)
+public fun EnumType.typeUrl(): String = typeUrl
+
+/**
  * Obtains the package and the name of the type.
  */
 public fun MessageType.qualifiedName(): String = name.qualifiedName()
@@ -60,6 +92,47 @@ public fun TypeNameOrBuilder.qualifiedName(): String {
     }
     return names.filter { it.isNotEmpty() }.joinToString(separator = ".")
 }
+
+/**
+ * Obtains the type URL from this `TypeName`.
+ *
+ * A type URL contains the type URL prefix and the qualified name of the type separated by
+ * the slash (`/`) symbol. See the docs of `google.protobuf.Any.type_url` for more info.
+ *
+ * @see TypeName.qualifiedName
+ * @see MessageType.typeUrl
+ */
+@Deprecated(
+    message = "Replaced with a Kotlin property (or a Java-style getter).",
+    replaceWith = ReplaceWith("typeUrl"),
+    level = DeprecationLevel.HIDDEN
+)
+public fun TypeName.typeUrl(): String = typeUrl
+
+/**
+ * Obtains the type URl from this `ServiceName`.
+ *
+ * A type URL contains the type URL prefix and the qualified name of the type separated by
+ * the slash (`/`) symbol. See the docs of `google.protobuf.Any.type_url` for more info.
+ */
+@Deprecated(
+    message = "Replaced with a Kotlin property (or a Java-style getter).",
+    replaceWith = ReplaceWith("typeUrl"),
+    level = DeprecationLevel.HIDDEN
+)
+public fun ServiceName.typeUrl(): String = typeUrl
+
+/**
+ * Obtains the type URl of this service.
+ *
+ * @see ServiceName.typeUrl
+ */
+@Deprecated(
+    message = "Replaced with a Kotlin property (or a Java-style getter).",
+    replaceWith = ReplaceWith("typeUrl"),
+    level = DeprecationLevel.HIDDEN
+)
+public fun Service.typeUrl(): String = typeUrl
 
 /**
  * Shows if this field is a `map`.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-api:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -897,12 +897,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:18 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-cli:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1802,12 +1802,12 @@ This report was generated on **Thu Mar 30 15:15:18 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:19 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:43 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2684,12 +2684,12 @@ This report was generated on **Thu Mar 30 15:15:19 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:20 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3568,12 +3568,12 @@ This report was generated on **Thu Mar 30 15:15:20 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:21 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4469,12 +4469,12 @@ This report was generated on **Thu Mar 30 15:15:21 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:22 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.7.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5260,12 +5260,12 @@ This report was generated on **Thu Mar 30 15:15:22 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:23 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6270,12 +6270,12 @@ This report was generated on **Thu Mar 30 15:15:23 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:24 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:50 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.7.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7026,12 +7026,12 @@ This report was generated on **Thu Mar 30 15:15:24 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:25 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:51 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.7.7`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.7.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -7922,4 +7922,4 @@ This report was generated on **Thu Mar 30 15:15:25 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 30 15:15:25 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 04 14:25:52 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.7.7</version>
+<version>0.7.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,5 +32,5 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.7.7")
+val protoDataVersion: String by extra("0.7.8")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.162")


### PR DESCRIPTION
In this PR we bring back a few methods removed in a previous change set.

The methods are all extension methods that were replaced by more fitting constructs. However, we still need them for backward compatibility.

Note. Only binary compatibility is guaranteed. The methods will not show up at compile-time, since the migration is fairly simple.