### PR TITLE
Support Protobuf Gradle plugin v0.9.2

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/protodata/gradle/plugin/PluginSpec.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.gradle.plugin
 
-import com.google.common.truth.Truth.assertThat
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.gradle.Names.GRADLE_PLUGIN_ID
 import io.spine.testing.SlowTest
@@ -66,7 +65,7 @@ class PluginSpec {
     @BeforeEach
     fun prepareDir(@TempDir projectDir: File) {
         this.projectDir = projectDir
-        generatedProtoDir = projectDir.resolve("build/generated-proto")
+        generatedProtoDir = projectDir.resolve("build/generated/source/proto")
         generatedDir = projectDir.resolve("generated")
         generatedMainDir = generatedDir.resolve("main")
         generatedJavaDir = generatedMainDir.resolve("java")
@@ -144,7 +143,7 @@ class PluginSpec {
     }
 
     @Test
-    fun `copy 'grpc' directory from 'generated-proto' to 'generated'`() {
+    fun `copy 'grpc' directory from Protobuf's default dir to 'generated'`() {
         createProject("copy-grpc")
 
         val result = project.executeTask(build)

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -236,7 +236,6 @@ private fun Project.hasJavaOrKotlin(): Boolean {
 private fun Project.configureProtobufPlugin(protocPlugin: ProtocPluginArtifact, ext: Extension) {
     val protobuf = this.protobufGradlePluginAdapter
     protobuf.run {
-        generatedFilesBaseDir = "$buildDir/generated-proto/"
         plugins {
             it.create(PROTODATA_PROTOC_PLUGIN) {
                 it.artifact = protocPlugin.coordinates

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-api:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -897,12 +897,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:21 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:33 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-cli:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1802,12 +1802,12 @@ This report was generated on **Mon Apr 10 12:56:21 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:22 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:34 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2684,12 +2684,12 @@ This report was generated on **Mon Apr 10 12:56:22 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:23 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:35 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3568,12 +3568,12 @@ This report was generated on **Mon Apr 10 12:56:23 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:24 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:36 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4469,12 +4469,12 @@ This report was generated on **Mon Apr 10 12:56:24 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:25 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.8.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5260,12 +5260,12 @@ This report was generated on **Mon Apr 10 12:56:25 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:26 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:38 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6270,12 +6270,12 @@ This report was generated on **Mon Apr 10 12:56:26 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:29 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.8.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7026,12 +7026,12 @@ This report was generated on **Mon Apr 10 12:56:29 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:29 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.7.9`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.8.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -7922,4 +7922,4 @@ This report was generated on **Mon Apr 10 12:56:29 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 10 12:56:30 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 10 17:12:40 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.7.9</version>
+<version>0.8.0</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,5 +32,5 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.7.9")
+val protoDataVersion: String by extra("0.8.0")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.162")


### PR DESCRIPTION
In this PR we make a change necessary for the ProtoData Gradle plugin to work with the Protobuf Gradle plugin of version 0.9.2.

Previously, we overrode `generatedBaseDir`, which resulted in the Proto-generated files being added to compile classpath twice. Now, we rely on the default value, thus skipping extra file copying operations and ensuring only one version of the generated files exists.

The ProtoData Gradle plugin will still modify the `compileKotlin` and `compileJava` tasks' classpath. With this change, the mechanism will work just fine again.

ProtoData itself does not yet use the new version of the plugin yet. We'll be able to migrate it after the `mc-java` is migrated.