### PR TITLE
Fix Gradle config for `new-gradle-proto-plugin`

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -57,12 +57,12 @@ dependencies {
 /**
  * Force `generated` directory and Kotlin code generation.
  */
-protobuf {
-//    generatedFilesBaseDir = "$projectDir/generated"
-    generateProtoTasks.all().configureEach {
-        builtins.maybeCreate("kotlin")
-    }
-}
+//protobuf {
+////    generatedFilesBaseDir = "$projectDir/generated"
+//    generateProtoTasks.all().configureEach {
+//        builtins.maybeCreate("kotlin")
+//    }
+//}
 
 idea {
     module {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -57,12 +57,11 @@ dependencies {
 /**
  * Force `generated` directory and Kotlin code generation.
  */
-//protobuf {
-////    generatedFilesBaseDir = "$projectDir/generated"
-//    generateProtoTasks.all().configureEach {
-//        builtins.maybeCreate("kotlin")
-//    }
-//}
+protobuf {
+    generateProtoTasks.all().configureEach {
+        builtins.maybeCreate("kotlin")
+    }
+}
 
 idea {
     module {

--- a/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
@@ -28,13 +28,11 @@
 
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine.McJava
-import io.spine.internal.gradle.protobuf.setupKotlinCompile
-import io.spine.internal.gradle.protobuf.excludeProtocOutput
 
-plugins {
-    id("java-library")
-    id("com.google.protobuf")
-}
+//plugins {
+//    id("java-library")
+//    id("com.google.protobuf")
+//}
 
 /**
  * The dependency onto Spine Validation causes the circular dependency in this Gradle project.
@@ -50,14 +48,14 @@ apply {
 dependencies {
     Protobuf.libs.forEach { "api"(it) }
 }
-
-protobuf {
-    configurations.excludeProtobufLite()
-    protoc {
-        artifact = Protobuf.compiler
-    }
-    generateProtoTasks.all().configureEach {
-        excludeProtocOutput()
-        setupKotlinCompile()
-    }
-}
+//
+//protobuf {
+//    configurations.excludeProtobufLite()
+//    protoc {
+//        artifact = Protobuf.compiler
+//    }
+//    generateProtoTasks.all().configureEach {
+//        excludeProtocOutput()
+//        setupKotlinCompile()
+//    }
+//}

--- a/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
+++ b/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
@@ -24,21 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.internal.dependency.Protobuf
-import io.spine.internal.gradle.protobuf.setup
-
-plugins {
-    id("java-library")
-    id("com.google.protobuf")
-}
-
-// For generating test fixtures. See `src/test/proto`.
-protobuf {
-    configurations.excludeProtobufLite()
-    protoc {
-        artifact = Protobuf.compiler
-    }
-    generateProtoTasks.all().configureEach {
-        setup()
-    }
-}
+//import io.spine.internal.dependency.Protobuf
+//import io.spine.internal.gradle.protobuf.setup
+//
+//plugins {
+//    id("java-library")
+//    id("com.google.protobuf")
+//}
+//
+//// For generating test fixtures. See `src/test/proto`.
+//protobuf {
+//    configurations.excludeProtobufLite()
+//    protoc {
+//        artifact = Protobuf.compiler
+//    }
+//    generateProtoTasks.all().configureEach {
+//        setup()
+//    }
+//}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -63,7 +63,7 @@ object Spine {
         const val mc = "2.0.0-SNAPSHOT.130"
 
         /** The version of [McJava]. */
-        const val mcJava = "2.0.0-SNAPSHOT.132"
+        const val mcJava = "2.0.0-SNAPSHOT.147"
 
         /** The version of [Spine.baseTypes]. */
         const val baseTypes = "2.0.0-SNAPSHOT.120"

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import Module_gradle.Module
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.JUnit
@@ -35,19 +36,8 @@ import io.spine.internal.gradle.javac.configureJavac
 import io.spine.internal.gradle.kotlin.applyJvmToolchain
 import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
 import io.spine.internal.gradle.report.license.LicenseReporter
-import org.gradle.api.Project
-import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.getting
 import org.gradle.kotlin.dsl.invoke
-import org.gradle.kotlin.dsl.kotlin
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -146,29 +136,6 @@ fun Module.applyGeneratedDirectories() {
     val generatedTestKotlin = "$generatedTest/kotlin"
     val generatedTestGrpc = "$generatedTest/grpc"
     val generatedTestSpine = "$generatedTest/spine"
-
-    sourceSets {
-        main {
-            java.srcDirs(
-                generatedJava,
-                generatedGrpc,
-                generatedSpine,
-            )
-            kotlin.srcDirs(
-                generatedKotlin,
-            )
-        }
-        test {
-            java.srcDirs(
-                generatedTestJava,
-                generatedTestGrpc,
-                generatedTestSpine,
-            )
-            kotlin.srcDirs(
-                generatedTestKotlin,
-            )
-        }
-    }
 
     idea {
         module {

--- a/codegen/java/build.gradle.kts
+++ b/codegen/java/build.gradle.kts
@@ -27,7 +27,6 @@
 import io.spine.internal.dependency.JavaPoet
 import io.spine.internal.dependency.JavaX
 import io.spine.internal.dependency.Spine
-import org.gradle.api.file.DuplicatesStrategy.INCLUDE
 
 plugins {
     `build-proto-model`
@@ -45,16 +44,16 @@ dependencies {
 }
 
 // Allows test suites to fetch generated Java files as resources.
-protobuf {
-    generateProtoTasks {
-        ofSourceSet("test").forEach { task ->
-            tasks.processTestResources {
-                from(task.outputs)
-                duplicatesStrategy = INCLUDE
-            }
-        }
-    }
-}
+//protobuf {
+//    generateProtoTasks {
+//        ofSourceSet("test").forEach { task ->
+//            tasks.processTestResources {
+//                from(task.outputs)
+//                duplicatesStrategy = INCLUDE
+//            }
+//        }
+//    }
+//}
 
 // For some reason, `validation-runtime` dependency appears on both compile and runtime classpaths.
 // This expression explicitly excludes this dependency from the list.

--- a/license-report.md
+++ b/license-report.md
@@ -908,7 +908,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:52:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:10 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1824,7 +1824,7 @@ This report was generated on **Sun May 21 23:52:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:52:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:11 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2697,7 +2697,7 @@ This report was generated on **Sun May 21 23:52:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:13 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3600,7 +3600,7 @@ This report was generated on **Sun May 21 23:53:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:14 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4499,7 +4499,7 @@ This report was generated on **Sun May 21 23:53:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:15 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5285,7 +5285,7 @@ This report was generated on **Sun May 21 23:53:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:16 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6241,7 +6241,7 @@ This report was generated on **Sun May 21 23:53:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:17 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6992,7 +6992,7 @@ This report was generated on **Sun May 21 23:53:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:18 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7879,4 +7879,4 @@ This report was generated on **Sun May 21 23:53:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 21 23:53:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 22 16:00:19 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -30,8 +30,6 @@ import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Truth
 import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
-import io.spine.internal.gradle.protobuf.excludeProtocOutput
-import io.spine.internal.gradle.protobuf.setupKotlinCompile
 import io.spine.internal.gradle.standardToSpineSdk
 import io.spine.internal.gradle.testing.configureLogging
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -76,10 +74,10 @@ subprojects {
         protoc {
             artifact = Protobuf.compiler
         }
-        generateProtoTasks.all().configureEach {
-            excludeProtocOutput()
-            setupKotlinCompile()
-        }
+//        generateProtoTasks.all().configureEach {
+//            excludeProtocOutput()
+//            setupKotlinCompile()
+//        }
     }
 
     tasks.withType<KotlinCompile> {


### PR DESCRIPTION
In this PR we fix the Gradle configuration issues in `new-gradle-proto-plugin` that lead to duplicate classes.

Long story short, we also needed to bump `mc-java` along with `ProtoData`.