### PR TITLE
Fix iteration in `SourceFileSet`

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/plugin/View.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/View.kt
@@ -94,9 +94,9 @@ import io.spine.validate.ValidatingBuilder
  * Views have repositories which are responsible for storing states and for delivering correct
  * events to the correct views. See [ViewRepository] for more.
  *
- * @param I the type of the ID of the view; can be a Protobuf message, a String, an int, or a long
- * @param M the type of the view's state; must be a Protobuf message implementing [EntityState]
- * @param B the type of the view's state builder; must match `<M>`
+ * @param I the type of the ID of the view; can be a Protobuf message, a String, an int, or a long.
+ * @param M the type of the view's state; must be a Protobuf message implementing [EntityState].
+ * @param B the type of the view's state builder; must match `<M>`.
  */
 public open class View<I, M : EntityState<I>, B : ValidatingBuilder<M>> : Projection<I, M, B>()
 
@@ -133,8 +133,8 @@ public open class ViewRepository<I, V : View<I, S, *>, S : EntityState<I>>
 /**
  * A default [ViewRepository].
  *
- * A [ViewRepository] can be customized in case event routing must be adjusted. Otherwise, users
- * should use `DefaultViewRepository` by calling [ViewRepository.default].
+ * A [ViewRepository] can be customized in case event routing must be adjusted.
+ * Otherwise, users should use `DefaultViewRepository` by calling [ViewRepository.default].
  */
 internal class DefaultViewRepository(
     private val cls: Class<View<Any, EntityState<Any>, *>>

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
@@ -42,12 +42,18 @@ import kotlin.io.path.writeText
 /**
  * A file with source code.
  *
- * This file is a part of a source set. It should be treated as a part of a software module rather
- * than a file system object. One `SourceFile` may reflect multiple actual FS files. For example,
- * a `SourceFile` may be read from one location on the FS and written into another location.
+ * This file is a part of a [source set][SourceFileSet]. It should be treated as
+ * a part of a software module rather than a file system object.
+ * One `SourceFile` may reflect multiple actual files on a file system. For example,
+ * a `SourceFile` may be read from one location on the file system and written
+ * into another location.
+ *
+ * @see SourceFileSet
  */
-@Suppress("TooManyFunctions") /* Those functions constitute the primary API and
-                                         should not be represented as extensions. */
+@Suppress(
+    "TooManyFunctions"
+    /* Those functions constitute the primary API and should not be represented as extensions. */
+)
 public class SourceFile
 private constructor(
 
@@ -116,13 +122,13 @@ private constructor(
     /**
      * Deletes this file from the source set.
      *
-     * As the result of this method, the associated source file will be eventually removed from
-     * the file system.
+     * As the result of this method, the associated source file will be
+     * eventually removed from the file system.
      *
-     * If the file was created earlier (by the same or a different [Renderer]), the file will not
-     * be written to the file system.
+     * If the file was created earlier (by the same or a different [Renderer]),
+     * the file will not be written to the file system.
      *
-     * After this method, the file will no longer be accessible via associated the `SourceSet`.
+     * After this method, the file will no longer be accessible via the associated `SourceSet`.
      */
     public fun delete() {
         sources.delete(relativePath)
@@ -131,9 +137,9 @@ private constructor(
     /**
      * Changes the contents of this file to the provided [newCode].
      *
-     * **Note.** This method may overwrite the work of other [Renderer]s, as well as remove
-     * the insertion points from the file. Use with caution. Prefer using [at(InsertionPoint)][at]
-     * when possible.
+     * **Note** This method may overwrite the work of other [Renderer]s, as well
+     * as remove the insertion points from the file. Use with caution.
+     * Prefer using [at(InsertionPoint)][at] when possible.
      */
     public fun overwrite(newCode: String) {
         this.code = newCode
@@ -157,16 +163,19 @@ private constructor(
     /**
      * Writes the source code into the file on the file system.
      *
-     * It may be the case that the file is read from one directory (source) and written into another
-     * directory (target). Thus, the initial path from where the file is read may not coincide with
-     * the path from where the file is written.
+     * It may be the case that the file is read from one directory (source) and
+     * written into another directory (target). Thus, the initial path from where
+     * the file is read may not coincide with the path from where the file is written.
      *
-     * @param rootDir the directory into which the file should be written;
-     *                this file's [relativePath] is resolved upon this directory
-     * @param charset the charset to use to write the file; UTF-8 is the default
-     * @param forceWrite if `true`, this file must be written to the FS even if no changes have been
-     *                   done upon it; otherwise, the file may not be written to avoid unnecessary
-     *                   file system operations
+     * @param rootDir
+     *         the directory into which the file should be written;
+     *         this file's [relativePath] is resolved upon this directory
+     * @param charset
+     *         the charset to use to write the file; UTF-8 is the default
+     * @param forceWrite
+     *         if `true`, this file must be written to the FS even if no changes have been
+     *         done upon it; otherwise, the file may not be written to avoid unnecessary
+     *         file system operations
      */
     internal fun write(
         rootDir: Path,
@@ -185,12 +194,13 @@ private constructor(
     /**
      * Deletes this source file from the file system.
      *
-     * It may be the case that the file is read from one directory (source) and changed in another
-     * directory (target). Thus, the initial path from where the file is read may not coincide with
-     * the path from where the file is deleted.
+     * It may be the case that the file is read from one directory (source) and
+     * changed in another directory (target). Thus, the initial path from where
+     * the file is read may not coincide with the path from where the file is deleted.
      *
-     * @param rootDir the root directory where the file lies; the [relativePath] is resolved upon
-     *                this directory
+     * @param rootDir
+     *         the root directory where the file lies; the [relativePath] is resolved
+     *         upon this directory
      * @see write
      */
     internal fun rm(rootDir: Path) {

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
@@ -98,9 +98,11 @@ private constructor(
         /**
          * Constructs a file from source code.
          *
-         * @param relativePath the FS path for the file relative to the source root; the file might
-         *             not exist on the file system
-         * @param code the source code
+         * @param relativePath
+         *         the FS path for the file relative to the source root; the file might
+         *         not exist on the file system.
+         * @param code
+         *         the source code.
          */
         internal fun fromCode(relativePath: Path, code: String): SourceFile =
             SourceFile(code, relativePath, changed = true)
@@ -109,12 +111,13 @@ private constructor(
     /**
      * Creates a new fluent builder for adding code at the given [insertionPoint].
      *
-     * If the [insertionPoint] is not found in the code, no action will be performed as the result.
-     * If there are more than one instances of the same insertion point, the code will be added to
-     * all of them.
+     * If the [insertionPoint] is not found in the code, no action will be
+     * performed as the result. If there are more than one instances of
+     * the same insertion point, the code will be added to all of them.
      *
-     * Insertion points should be marked with comments of special format. The added code is always
-     * inserted after the line with the comment, and the line with the comment is preserved.
+     * Insertion points should be marked with comments of special format.
+     * The added code is always inserted after the line with the comment, and
+     * the line with the comment is preserved.
      */
     public fun at(insertionPoint: InsertionPoint): SourceAtPoint =
         SourceAtPoint(this, insertionPoint)
@@ -128,7 +131,8 @@ private constructor(
      * If the file was created earlier (by the same or a different [Renderer]),
      * the file will not be written to the file system.
      *
-     * After this method, the file will no longer be accessible via the associated `SourceSet`.
+     * After this method, the file will no longer be accessible via
+     * the associated `SourceSet`.
      */
     public fun delete() {
         sources.delete(relativePath)
@@ -167,23 +171,23 @@ private constructor(
      * written into another directory (target). Thus, the initial path from where
      * the file is read may not coincide with the path from where the file is written.
      *
-     * @param rootDir
+     * @param baseDir
      *         the directory into which the file should be written;
-     *         this file's [relativePath] is resolved upon this directory
+     *         this file's [relativePath] is resolved upon this directory.
      * @param charset
-     *         the charset to use to write the file; UTF-8 is the default
+     *         the charset to use to write the file; UTF-8 is the default.
      * @param forceWrite
      *         if `true`, this file must be written to the FS even if no changes have been
      *         done upon it; otherwise, the file may not be written to avoid unnecessary
-     *         file system operations
+     *         file system operations.
      */
     internal fun write(
-        rootDir: Path,
+        baseDir: Path,
         charset: Charset = Charsets.UTF_8,
         forceWrite: Boolean = false
     ) {
         if (changed || forceWrite) {
-            val targetPath = rootDir / relativePath
+            val targetPath = baseDir / relativePath
             targetPath.toFile()
                 .parentFile
                 .mkdirs()
@@ -200,7 +204,7 @@ private constructor(
      *
      * @param rootDir
      *         the root directory where the file lies; the [relativePath] is resolved
-     *         upon this directory
+     *         upon this directory.
      * @see write
      */
     internal fun rm(rootDir: Path) {
@@ -277,7 +281,7 @@ internal constructor(
      * Adds the given code lines at the associated insertion point.
      *
      * @param lines
-     *      code lines
+     *         the code lines.
      */
     public fun add(lines: Iterable<String>) {
         val sourceLines = file.lines()

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -49,11 +49,12 @@ import kotlin.text.Charsets.UTF_8
  *
  * The resulting files are written to the [outputRoot] directory.
  *
- * When files are [deleted][delete], they still remain in the set, but are marked as deleted.
- * Actual deletion happens when the set is [written][write].
+ * When files are [deleted][delete], they still remain in the set,
+ * but are marked as deleted. Actual deletion happens when
+ * the set is [written][write].
  *
- * The source set can be configured to perform some [actions][prepareCode] before
- * reading the files.
+ * The source set can be configured to perform some [actions][prepareCode]
+ * before reading the files.
  *
  * @see SourceFile
  */
@@ -104,7 +105,8 @@ internal constructor(
          * @param outputRoot
          *         the directory to which to write the processed files.
          *         If same as the [sourceRoot], all files **will be overwritten**.
-         *         If different from the `sourceRoot`, the files in `sourceRoot` will not be changed.
+         *         If different from the `sourceRoot`, the files in `sourceRoot`
+         *         will not be changed.
          */
         public fun from(inputRoot: Path, outputRoot: Path): SourceFileSet {
             val source = inputRoot.canonical()
@@ -120,8 +122,8 @@ internal constructor(
         }
 
         /**
-         * Creates an empty source set which can be appended with new files and written to
-         * the given target directory.
+         * Creates an empty source set which can be appended with new files and
+         * written to the given target directory.
          */
         public fun empty(target: Path): SourceFileSet {
             checkTarget(target)
@@ -201,8 +203,8 @@ internal constructor(
     /**
      * Delete the given [file] from the source set.
      *
-     * Does not delete the file from the file system. All the FS operations are performed in
-     * the [write] method.
+     * Does not delete the file from the file system. All the FS operations are
+     * performed in the [write] method.
      */
     internal fun delete(file: Path) {
         val sourceFile = file(file)
@@ -213,8 +215,8 @@ internal constructor(
     /**
      * Writes this source set to the file system.
      *
-     * The sources existing on the file system at the moment are deleted, along with the whole
-     * directory structure and the new files are written.
+     * The sources existing on the file system at the moment are deleted,
+     * along with the whole directory structure and the new files are written.
      */
     public fun write(charset: Charset = UTF_8) {
         deletedFiles.forEach {
@@ -230,8 +232,9 @@ internal constructor(
     /**
      * Applies the given [action] to all the code files which are accessed by a [Renderer].
      *
-     * When a file's code is first accessed, runs the given action. The action may change the code
-     * if necessary, for example, by adding insertion points.
+     * When a file's code is first accessed, runs the given action.
+     * The action may change the code if necessary, for example,
+     * by adding insertion points.
      */
     internal fun prepareCode(action: (SourceFile) -> Unit) {
         files.values.forEach {

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.renderer
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.collect.ImmutableSet.toImmutableSet
 import io.spine.annotation.Internal
+import io.spine.string.ti
 import io.spine.util.theOnly
 import java.nio.charset.Charset
 import java.nio.file.Files.walk
@@ -156,7 +157,11 @@ internal constructor(
     public fun file(path: Path): SourceFile {
         val found = find(path)
         require(found != null) {
-            "File not found: `$path`. Source root: `$inputRoot`. Target root: `$outputRoot`."
+            """
+            File not found: `$path`.
+            Input root: `$inputRoot`.
+            Output root: `$outputRoot`."
+            """.ti()
         }
         return found
     }

--- a/api/src/test/kotlin/io/spine/protodata/renderer/SourceFileSetSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/SourceFileSetSpec.kt
@@ -30,7 +30,6 @@ import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import java.nio.file.Path
 import java.util.*
-import java.util.Optional.empty
 import kotlin.io.path.Path
 import kotlin.io.path.div
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -43,47 +42,64 @@ import org.junit.jupiter.api.io.TempDir
 class SourceFileSetSpec {
 
     private lateinit var set: SourceFileSet
-    private lateinit var existingSourceFile: Path
-    private lateinit var existingSourceFileAbsolute: Path
+    private lateinit var existingSourceFiles: List<Path>
+    private lateinit var existingSourceFilesAbsolute: List<Path>
 
     @BeforeEach
     fun createSet(@TempDir tempDir: Path) {
-        existingSourceFile = Path("pkg/example/foo.txt")
-        existingSourceFileAbsolute = tempDir / existingSourceFile
-        existingSourceFileAbsolute.parent.toFile().mkdirs()
-        existingSourceFileAbsolute.toFile().let { textFile ->
-            textFile.createNewFile()
-            textFile.writeText("this is a non-empty file")
+        existingSourceFiles = listOf(
+            Path("pkg/example/foo.txt"),
+            Path("another/sample/bar.txt"),
+            Path("src/main/app.kt")
+        )
+        existingSourceFilesAbsolute = existingSourceFiles.map { tempDir / it }
+        existingSourceFilesAbsolute.forEach {
+            it.parent.toFile().mkdirs()
+            it.toFile().let { textFile ->
+                textFile.createNewFile()
+                textFile.writeText("this is a non-empty file")
+            }
         }
         set = SourceFileSet.from(tempDir)
     }
 
     @Test
     fun `find existing file by relative path`() {
-        val found = set.findFile(existingSourceFile)
+        val found = set.findFile(existingSourceFiles[0])
         found shouldBePresent {
-            it.relativePath shouldBe existingSourceFile
+            it.relativePath shouldBe existingSourceFiles[0]
         }
     }
 
     @Test
     fun `find existing file by absolute path`() {
-        val found = set.findFile(existingSourceFileAbsolute)
+        val found = set.findFile(existingSourceFilesAbsolute[0])
         found shouldBePresent {
-            it.relativePath shouldBe existingSourceFile
+            it.relativePath shouldBe existingSourceFiles[0]
         }
     }
 
     @Test
     fun `not find a non-existing file`() {
-        val found = set.findFile(Path("non/existing/file.txt"))
-        found shouldBe empty()
+        val found = set.find(Path("non/existing/file.txt"))
+        found shouldBe null
     }
 
     @Test
-    fun `fail when a non-existing file must be present`() {
+    fun `fail when a non-existing file is referenced`() {
         assertThrows(IllegalArgumentException::class.java) {
             set.file(Path("i/don/t/exis.txt"))
         }
+    }
+
+    @Test
+    fun `iterate over actual files`() {
+        set.size shouldBe 3
+
+        // This should delete the second file from the set.
+        set.file(existingSourceFiles[1]).delete()
+
+        set.size shouldBe 2
+        set.find(existingSourceFiles[1]) shouldBe null
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused")
 object ProtoData {
-    const val version = "0.8.2"
+    const val version = "0.8.3"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -75,7 +75,7 @@ object Spine {
         const val change = "2.0.0-SNAPSHOT.118"
 
         /** The version of [Spine.text]. */
-        const val text = "2.0.0-SNAPSHOT.3"
+        const val text = "2.0.0-SNAPSHOT.5"
 
         /** The version of [Spine.toolBase]. */
         const val toolBase = "2.0.0-SNAPSHOT.170"

--- a/license-report.md
+++ b/license-report.md
@@ -911,7 +911,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1822,7 +1822,7 @@ This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:26 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2689,7 +2689,7 @@ This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:26 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3587,7 +3587,7 @@ This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4481,7 +4481,7 @@ This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5261,7 +5261,7 @@ This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6211,7 +6211,7 @@ This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6962,7 +6962,7 @@ This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7843,4 +7843,4 @@ This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 15:43:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 21:32:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-api:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -911,12 +911,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-cli:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1822,12 +1822,12 @@ This report was generated on **Thu May 25 14:06:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:09 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2689,12 +2689,12 @@ This report was generated on **Thu May 25 14:06:03 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3587,12 +3587,12 @@ This report was generated on **Thu May 25 14:06:03 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4481,12 +4481,12 @@ This report was generated on **Thu May 25 14:06:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.8.4`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5261,12 +5261,12 @@ This report was generated on **Thu May 25 14:06:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6211,12 +6211,12 @@ This report was generated on **Thu May 25 14:06:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.8.4`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6962,12 +6962,12 @@ This report was generated on **Thu May 25 14:06:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.8.3`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.8.4`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -7843,4 +7843,4 @@ This report was generated on **Thu May 25 14:06:06 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 25 14:06:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 25 15:43:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.8.3</version>
+<version>0.8.4</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
@@ -48,7 +48,7 @@ public final class AnnotationRenderer extends JavaRenderer {
         // Don't do anything if this source file set is for a language
         // other than Java. For the root cause of this please see this issue:
         // https://github.com/SpineEventEngine/ProtoData/issues/90
-         if (!sources.sourceRoot().endsWith("java")) {
+         if (!sources.inputRoot().endsWith("java")) {
              return;
          }
         Set<Annotated> annotatedFields = select(Annotated.class).all();

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
@@ -45,32 +45,20 @@ public final class AnnotationRenderer extends JavaRenderer {
 
     @Override
     protected void render(SourceFileSet sources) {
-        //TODO:2022-10-18:alexander.yevsyukov: Use `sourceRoot` when it's public and
-        // remove `findFile()` check in the `renderFor()` method below.
-        //
-        // if (!sources.sourceRoot.endsWith("java")) {
-        //     return;
-        // }
-        //
-        // For the root cause of this please see this issue:
+        // Don't do anything if this source file set is for a language
+        // other than Java. For the root cause of this please see this issue:
         // https://github.com/SpineEventEngine/ProtoData/issues/90
-        //
+         if (!sources.sourceRoot().endsWith("java")) {
+             return;
+         }
         Set<Annotated> annotatedFields = select(Annotated.class).all();
-        annotatedFields.forEach(
-                field -> renderFor(field, sources)
-        );
+        annotatedFields.forEach(field -> renderFor(field, sources));
     }
 
     private void renderFor(Annotated field, SourceFileSet sourceSet) {
         FieldId id = field.getId();
         FieldGetter getter = new FieldGetter(id);
         Path path = javaFileOf(id.getType(), id.getFile());
-
-        // If there are no Java files, we deal with another language.
-        // Have this workaround until we get access to the `sourceRoot` property.
-        if (sourceSet.findFile(path).isEmpty()) {
-            return;
-        }
 
         sourceSet.file(path)
                  .at(getter)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.8.3")
+val protoDataVersion: String by extra("0.8.4")


### PR DESCRIPTION
This PR improves the `SourceFileSet` class as follows:
  * Fixes the iteration by delegating to the values of the enclosed  map  called `files`.
  * Renames the `sourceRoot` and `targetRoot` properties to `inputRoot` and `outputRoot` to avoid the repeated usage of the word “source” in the context of this class.
  * Adds custom getter methods for `inputRoot` and `outputRoot` properties.
  * Adds `find()` method.
  * Addresses TODO in `AnnotationRenderer` test fixture.
  * Improves documentation.