### PR TITLE
Add helper extension functions for working with `Plugin`

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -142,7 +142,15 @@ private fun Plugin.checkNoViewRepoDuplication(repos: MutableList<ViewRepository<
 }
 
 /**
- * Adds the specified view class to this `MutableSet`.
+ * Adds the specified view class to this `MutableSet` which represents a set of views
+ * exposed by a `Plugin`.
+ *
+ * Usage scenario:
+ * ```kotlin
+ * override fun views(): Set<Class<out View<*, *, *>>> = buildSet {
+ *     add(MyView::class)
+ * }
+ * ```
  */
 public fun MutableSet<Class<out View<*,  *, *>>>.add(view: KClass<out View<*, *, *>>) {
     add(view.java)
@@ -154,6 +162,9 @@ public fun MutableSet<Class<out View<*,  *, *>>>.add(view: KClass<out View<*, *,
  * A default repository instance will be created for this class.
  * This instance will be added to the repository registration list for
  * the bounded context being built.
+ *
+ * @param I the type of entity identifiers.
+ * @param E the type of entities.
  */
 public inline fun <reified I, reified E : Entity<I, *>>
         BoundedContextBuilder.add(entity: KClass<out E>) {

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -150,6 +150,10 @@ public fun MutableSet<Class<out View<*,  *, *>>>.add(view: KClass<out View<*, *,
 
 /**
  * Adds specified entity class to this `BoundedContextBuilder`.
+ *
+ * A default repository instance will be created for this class.
+ * This instance will be added to the repository registration list for
+ * the bounded context being built.
  */
 public inline fun <reified I, reified E : Entity<I, *>>
         BoundedContextBuilder.add(entity: KClass<out E>) {

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -29,6 +29,8 @@ package io.spine.protodata.plugin
 import io.spine.annotation.Internal
 import io.spine.protodata.ConfigurationError
 import io.spine.server.BoundedContextBuilder
+import io.spine.server.entity.Entity
+import kotlin.reflect.KClass
 
 /**
  * A plugin into the code generation process.
@@ -90,15 +92,7 @@ public interface Plugin {
     ReplaceWith("this.applyTo(context)")
 )
 public fun BoundedContextBuilder.apply(plugin: Plugin) {
-    val repos = plugin.viewRepositories().toMutableList()
-    val defaultRepos = plugin.views().map { ViewRepository.default(it) }
-    repos.addAll(defaultRepos)
-    plugin.checkNoViewRepoDuplication(repos)
-    repos.forEach(this::add)
-    plugin.policies().forEach {
-        addEventDispatcher(it)
-    }
-    plugin.extend(this)
+    plugin.applyTo(this)
 }
 
 /**
@@ -145,4 +139,19 @@ private fun Plugin.checkNoViewRepoDuplication(repos: MutableList<ViewRepository<
                     " Please submit either a repository OR a class of the view."
         )
     }
+}
+
+/**
+ * Adds the specified view class to this `MutableSet`.
+ */
+public fun MutableSet<Class<out View<*,  *, *>>>.add(view: KClass<out View<*, *, *>>) {
+    add(view.java)
+}
+
+/**
+ * Adds specified entity class to this `BoundedContextBuilder`.
+ */
+public inline fun <reified I, reified E : Entity<I, *>>
+        BoundedContextBuilder.add(entity: KClass<out E>) {
+    add(entity.java)
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-api:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -984,12 +984,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:23:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-cli:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -1990,12 +1990,12 @@ This report was generated on **Fri Jul 28 23:23:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:23:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -2944,12 +2944,12 @@ This report was generated on **Fri Jul 28 23:23:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:23:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -3932,12 +3932,12 @@ This report was generated on **Fri Jul 28 23:23:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -4895,12 +4895,12 @@ This report was generated on **Fri Jul 28 23:24:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.9.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5751,12 +5751,12 @@ This report was generated on **Fri Jul 28 23:24:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -6855,12 +6855,12 @@ This report was generated on **Fri Jul 28 23:24:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:15 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.9.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7666,12 +7666,12 @@ This report was generated on **Fri Jul 28 23:24:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:15 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.9.8`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.9.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -8634,4 +8634,4 @@ This report was generated on **Fri Jul 28 23:24:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 28 23:24:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jul 30 14:38:16 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.9.8</version>
+<version>0.9.9</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.9.8")
+val protoDataVersion: String by extra("0.9.9")


### PR DESCRIPTION
This PR adds convenience extension functions for exposing guts of a `Plugin`. The main idea is to start reducing dependency on Java by little steps here and there.

Other changes:
  * Deprecated `BoundedContextBuilder.apply(Plugin)` now redirects to its replacement. It was omitted in the previous PR.
