### PR TITLE
Improve type names and extensions

### DIFF
--- a/api/src/main/java/io/spine/protodata/Constants.java
+++ b/api/src/main/java/io/spine/protodata/Constants.java
@@ -26,6 +26,9 @@
 
 package io.spine.protodata;
 
+/**
+ * Main constants of the ProtoData SDK.
+ */
 public final class Constants {
 
     /**
@@ -39,7 +42,7 @@ public final class Constants {
     public static final String LOGGING_PREFIX = '[' + LOGGING_DOMAIN + "] ";
 
     /**
-     * The name of the main class of the ProtoData command-line application.
+     * The name of the ProtoData command-line application main class.
      */
     public static final String CLI_APP_CLASS = "io.spine.protodata.cli.app.MainKt";
 

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -118,7 +118,7 @@ public val Field.isPartOfOneof: Boolean
     get() = hasOneofName()
 
 /**
- * Obtains the name of the field which includes a qualified name of the type which declares it.
+ * The field name containing a qualified name of the declaring type.
  */
 public val Field.qualifiedName: String
     get() = "${declaringType.qualifiedName}.${name.value}"

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -48,7 +48,7 @@ import io.spine.protodata.CallCardinality.UNARY
  * Obtains a name of this Protobuf file without the extension.
  */
 public fun ProtoFileHeader.nameWithoutExtension(): String {
-    val name = file.value.split("/").last()
+    val name = file.path.split("/").last()
     val index = name.indexOf(".")
     return if (index > 0) {
         name.substring(0, index)
@@ -190,7 +190,7 @@ public fun FieldDescriptor.name(): FieldName = fieldName { value = name }
 /**
  * Obtains the relative path to this file as a [FilePath].
  */
-public fun FileDescriptor.file(): FilePath = filePath { value = name }
+public fun FileDescriptor.file(): File = file { path = name }
 
 /**
  * Obtains the name of this service as a [ServiceName].

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -47,7 +47,7 @@ import io.spine.protodata.CallCardinality.UNARY
 /**
  * Obtains a name of this Protobuf file without the extension.
  */
-public fun File.nameWithoutExtension(): String {
+public fun ProtoFileHeader.nameWithoutExtension(): String {
     val name = path.value.split("/").last()
     val index = name.indexOf(".")
     return if (index > 0) {

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -60,19 +60,27 @@ public fun File.nameWithoutExtension(): String {
 /**
  * Obtains the package and the name of the type.
  */
-public fun MessageType.qualifiedName(): String = name.qualifiedName()
+public val MessageType.qualifiedName: String
+    get() = name.qualifiedName
 
 /**
  * Obtains the fully qualified name from this `TypeName`.
  */
-public fun TypeNameOrBuilder.qualifiedName(): String {
-    val names = buildList<String> {
-        add(packageName)
-        addAll(nestingTypeNameList)
-        add(simpleName)
+public val TypeNameOrBuilder.qualifiedName: String
+    get() {
+        val names = buildList<String> {
+            add(packageName)
+            addAll(nestingTypeNameList)
+            add(simpleName)
+        }
+        return names.filter { it.isNotEmpty() }.joinToString(separator = ".")
     }
-    return names.filter { it.isNotEmpty() }.joinToString(separator = ".")
-}
+
+/**
+ * Tells if this field is a Protobuf message.
+ */
+public val Field.isMessage: Boolean
+    get() = type.hasMessage()
 
 /**
  * Shows if this field is a `map`.
@@ -80,7 +88,8 @@ public fun TypeNameOrBuilder.qualifiedName(): String {
  * If the field is a `map`, the `Field.type` contains the type of the value, and
  * the `Field.map.key_type` contains the type the map key.
  */
-public fun Field.isMap(): Boolean = hasMap()
+public val Field.isMap: Boolean
+    get() = hasMap()
 
 /**
  * Shows if this field is a list.
@@ -89,21 +98,30 @@ public fun Field.isMap(): Boolean = hasMap()
  * treated as a repeated field for serialization reasons. We use the term "list" for repeated fields
  * which are not maps.
  */
-public fun Field.isList(): Boolean = hasList()
+public val Field.isList: Boolean
+    get() = hasList()
 
 /**
  * Shows if this field repeated.
  *
  * Can be declared in Protobuf either as a `map` or a `repeated` field.
  */
-public fun Field.isRepeated(): Boolean = isMap() || isList()
+public val Field.isRepeated: Boolean
+    get() = isMap || isList
 
 /**
  * Shows if this field is a part of a `oneof` group.
  *
  * If the field is a part of a `oneof`, the `Field.oneof_name` contains the name of that `oneof`.
  */
-public fun Field.isPartOfOneof(): Boolean = hasOneofName()
+public val Field.isPartOfOneof: Boolean
+    get() = hasOneofName()
+
+/**
+ * Obtains the name of the field which includes a qualified name of the type which declares it.
+ */
+public val Field.qualifiedName: String
+    get() = "${declaringType.qualifiedName}.${name.value}"
 
 /**
  * Looks up an option value by the [optionName].
@@ -128,9 +146,11 @@ public fun Descriptor.name(): TypeName = buildTypeName(name, file, containingTyp
  */
 public fun EnumDescriptor.name(): TypeName = buildTypeName(name, file, containingType)
 
-private fun buildTypeName(simpleName: String,
-                          file: FileDescriptor,
-                          containingDeclaration: Descriptor?): TypeName {
+private fun buildTypeName(
+    simpleName: String,
+    file: FileDescriptor,
+    containingDeclaration: Descriptor?
+): TypeName {
     val nestingNames = mutableListOf<String>()
     var parent = containingDeclaration
     while (parent != null) {
@@ -196,8 +216,8 @@ public fun PrimitiveType.asType(): Type = type { primitive = this@asType }
  *
  * The cardinality determines how many messages may flow from the client to the server and back.
  */
-public fun MethodDescriptor.cardinality(): CallCardinality =
-    when {
+public val MethodDescriptor.cardinality: CallCardinality
+    get() = when {
         !isClientStreaming && !isServerStreaming -> UNARY
         !isClientStreaming && isServerStreaming -> SERVER_STREAMING
         isClientStreaming && !isServerStreaming -> CLIENT_STREAMING
@@ -206,8 +226,15 @@ public fun MethodDescriptor.cardinality(): CallCardinality =
     }
 
 /**
+ * Tells if this type represents a Protobuf message.
+ */
+public val Type.isMessage: Boolean
+    get() = hasMessage()
+
+/**
  * Tells if this type is `google.protobuf.Any`.
  */
-public fun Type.isAny(): Boolean = (hasMessage()
-        && message.packageName.equals("google.protobuf"))
-        && message.simpleName.equals("Any")
+public val Type.isAny: Boolean
+    get() = isMessage
+            && message.packageName.equals("google.protobuf")
+            && message.simpleName.equals("Any")

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -48,7 +48,7 @@ import io.spine.protodata.CallCardinality.UNARY
  * Obtains a name of this Protobuf file without the extension.
  */
 public fun ProtoFileHeader.nameWithoutExtension(): String {
-    val name = path.value.split("/").last()
+    val name = file.value.split("/").last()
     val index = name.indexOf(".")
     return if (index > 0) {
         name.substring(0, index)
@@ -190,7 +190,7 @@ public fun FieldDescriptor.name(): FieldName = fieldName { value = name }
 /**
  * Obtains the relative path to this file as a [FilePath].
  */
-public fun FileDescriptor.path(): FilePath = filePath { value = name }
+public fun FileDescriptor.file(): FilePath = filePath { value = name }
 
 /**
  * Obtains the name of this service as a [ServiceName].

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -226,6 +226,12 @@ public val MethodDescriptor.cardinality: CallCardinality
     }
 
 /**
+ * Tells if this type is a Protobuf primitive type.
+ */
+public val Type.isPrimitive: Boolean
+    get() = hasPrimitive()
+
+/**
  * Tells if this type represents a Protobuf message.
  */
 public val Type.isMessage: Boolean

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -46,6 +46,8 @@ import io.spine.protodata.CallCardinality.UNARY
 
 /**
  * Obtains a name of this Protobuf file without the extension.
+ *
+ * @receiver the header of the Protobuf file of interest.
  */
 public fun ProtoFileHeader.nameWithoutExtension(): String {
     val name = file.path.split("/").last()

--- a/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
+++ b/api/src/main/kotlin/io/spine/protodata/AstExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,3 +204,10 @@ public fun MethodDescriptor.cardinality(): CallCardinality =
         isClientStreaming && isServerStreaming -> BIDIRECTIONAL_STREAMING
         else -> error("Unable to determine cardinality of method: `$fullName`.")
     }
+
+/**
+ * Tells if this type is `google.protobuf.Any`.
+ */
+public fun Type.isAny(): Boolean = (hasMessage()
+        && message.packageName.equals("google.protobuf"))
+        && message.simpleName.equals("Any")

--- a/api/src/main/kotlin/io/spine/protodata/FileAware.kt
+++ b/api/src/main/kotlin/io/spine/protodata/FileAware.kt
@@ -24,25 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.protodata.backend
-
-import io.spine.core.External
-import io.spine.core.Subscribe
-import io.spine.protodata.File
-import io.spine.protodata.ProtobufDependency
-import io.spine.protodata.event.DependencyDiscovered
-import io.spine.protodata.plugin.View
-import io.spine.server.entity.alter
+package io.spine.protodata
 
 /**
- * A view of a dependency Proto file.
+ * An interface for objects which are aware of the file they are associated with.
  */
-internal class DependencyView :
-    View<File, ProtobufDependency, ProtobufDependency.Builder>() {
-
-    @Subscribe
-    internal fun on(@External e: DependencyDiscovered) = alter {
-        file = e.file
-        source = e.source
-    }
+public interface FileAware {
+    public val file: File
 }

--- a/api/src/main/kotlin/io/spine/protodata/InsertionPointsView.kt
+++ b/api/src/main/kotlin/io/spine/protodata/InsertionPointsView.kt
@@ -35,7 +35,7 @@ import io.spine.server.entity.alter
 /**
  * A view of insertion points added to a single code file.
  */
-public class InsertionPointsView : View<FilePath, InsertedPoints, InsertedPoints.Builder>() {
+public class InsertionPointsView : View<File, InsertedPoints, InsertedPoints.Builder>() {
 
     @Subscribe
     internal fun on(@External e: InsertionPointPrinted) = alter {

--- a/api/src/main/kotlin/io/spine/protodata/OptionAware.kt
+++ b/api/src/main/kotlin/io/spine/protodata/OptionAware.kt
@@ -24,25 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.protodata.backend
-
-import io.spine.core.External
-import io.spine.core.Subscribe
-import io.spine.protodata.File
-import io.spine.protodata.ProtobufDependency
-import io.spine.protodata.event.DependencyDiscovered
-import io.spine.protodata.plugin.View
-import io.spine.server.entity.alter
+package io.spine.protodata
 
 /**
- * A view of a dependency Proto file.
+ * An interface for objects which have an [Option] or are associated in an option.
  */
-internal class DependencyView :
-    View<File, ProtobufDependency, ProtobufDependency.Builder>() {
-
-    @Subscribe
-    internal fun on(@External e: DependencyDiscovered) = alter {
-        file = e.file
-        source = e.source
-    }
+public interface OptionAware {
+    public val option: Option
 }

--- a/api/src/main/kotlin/io/spine/protodata/OptionAware.kt
+++ b/api/src/main/kotlin/io/spine/protodata/OptionAware.kt
@@ -27,7 +27,9 @@
 package io.spine.protodata
 
 /**
- * An interface for objects which have an [Option] or are associated in an option.
+ * An interface for objects which are associated in an [Option] instance.
+ *
+ * For example, an event on a proto field may refer to a field option and as such is option-aware.
  */
 public interface OptionAware {
     public val option: Option

--- a/api/src/main/kotlin/io/spine/protodata/TypeNameMixin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/TypeNameMixin.kt
@@ -36,5 +36,5 @@ import io.spine.annotation.Internal
 public interface TypeNameMixin : ProtoDeclarationName, TypeNameOrBuilder {
 
     override val typeUrl: String
-        get() = "$typeUrlPrefix/${qualifiedName()}"
+        get() = "$typeUrlPrefix/$qualifiedName"
 }

--- a/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ public class ProtocInsertionPoint(
      * <scope>:<qualified type name>
      * ```
      */
-    public constructor(scope: String, type: TypeName) : this("$scope:${type.qualifiedName()}")
+    public constructor(scope: String, type: TypeName) : this("$scope:${type.qualifiedName}")
 
     override fun locate(text: Text): Set<TextCoordinates> = setOf()
 

--- a/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.protodata.renderer
 
 import io.spine.core.userId
 import io.spine.protodata.event.insertionPointPrinted
-import io.spine.protodata.filePath
+import io.spine.protodata.file
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.endOfFile
 import io.spine.text.TextCoordinates
 import io.spine.text.TextCoordinates.KindCase.END_OF_TEXT
@@ -140,7 +140,7 @@ public abstract class InsertionPointPrinter<L: Language>(
 
     private fun reportPoint(sourceFile: SourceFile, pointLabel: String, comment: String) {
         val event = insertionPointPrinted {
-            file = filePath { value = sourceFile.relativePath.toString() }
+            file = file { path = sourceFile.relativePath.toString() }
             label = pointLabel
             representationInCode = comment
         }

--- a/api/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -93,14 +93,12 @@ protected constructor(
      *
      * @param S
      *         the type of the entity state.
-     * @param type
-     *         the class of the entity state.
      */
     public inline fun <reified S : EntityState<*>> select(): QueryingClient<S> =
         select(S::class.java)
 
     /**
-     * Creates a [QueryingClient] for querying entity states of the given type.
+     * Creates a [QueryingClient] for obtaining entity states of the given type.
      *
      * @param S
      *         the type of the entity state.

--- a/api/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/Renderer.kt
@@ -88,7 +88,26 @@ protected constructor(
      */
     protected abstract fun render(sources: SourceFileSet)
 
-    public final override fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> =
+    /**
+     * Creates a [QueryingClient] for obtaining entity states of the given type.
+     *
+     * @param S
+     *         the type of the entity state.
+     * @param type
+     *         the class of the entity state.
+     */
+    public inline fun <reified S : EntityState<*>> select(): QueryingClient<S> =
+        select(S::class.java)
+
+    /**
+     * Creates a [QueryingClient] for querying entity states of the given type.
+     *
+     * @param S
+     *         the type of the entity state.
+     * @param type
+     *         the class of the entity state.
+     */
+    public final override fun <S : EntityState<*>> select(type: Class<S>): QueryingClient<S> =
         _context.select(type)
 
     final override fun <T> configAs(cls: Class<T>): T = super.configAs(cls)

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.protodata.renderer
 
 import com.google.common.base.Splitter
 import io.spine.protodata.InsertedPoints
-import io.spine.protodata.filePath
+import io.spine.protodata.file
 import io.spine.server.query.select
 import io.spine.text.Text
 import io.spine.text.TextFactory.text
@@ -144,7 +144,7 @@ private constructor(
      */
     public fun atInline(insertionPoint: InsertionPoint): SourceAtPoint {
         val points = sources.querying.select<InsertedPoints>()
-            .findById(filePath { value = relativePath.toString() })
+            .findById(file { path = relativePath.toString() })
         val point = points?.pointList?.firstOrNull { it.label == insertionPoint.label }
         return if (point != null) {
             SpecificPoint(this@SourceFile, point)

--- a/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
+++ b/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
@@ -94,6 +94,6 @@ public class TypeSystem(
         }
         val types = file?.let(mapSelector)
         val type = types?.get(typeUrl)
-        return if (type != null) type to file.file else null
+        return if (type != null) type to file.header else null
     }
 }

--- a/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
+++ b/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
@@ -55,7 +55,7 @@ public class TypeSystem(
         @JvmStatic
         public fun serving(client: Querying): TypeSystem {
             val files = client.select<ProtobufSourceFile>().all()
-            val deps = client.select<ProtobufDependency>().all().map { it.file }
+            val deps = client.select<ProtobufDependency>().all().map { it.source }
             return TypeSystem(files + deps)
         }
     }

--- a/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
+++ b/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
@@ -27,7 +27,7 @@
 package io.spine.protodata.type
 
 import io.spine.protodata.EnumType
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.MessageType
 import io.spine.protodata.ProtoDeclaration
 import io.spine.protodata.ProtoDeclarationName
@@ -38,7 +38,6 @@ import io.spine.protodata.ServiceName
 import io.spine.protodata.TypeName
 import io.spine.server.query.Querying
 import io.spine.server.query.select
-import kotlin.DeprecationLevel.ERROR
 
 /**
  * A collection of known Protobuf types.
@@ -64,31 +63,31 @@ public class TypeSystem(
     /**
      * Looks up a message type by its name.
      */
-    public fun findMessage(name: TypeName): Pair<MessageType, File>? =
+    public fun findMessage(name: TypeName): Pair<MessageType, ProtoFileHeader>? =
         find(name) { it.typeMap }
 
     /**
      * Looks up an enum type by its name.
      */
-    public fun findEnum(name: TypeName): Pair<EnumType, File>? =
+    public fun findEnum(name: TypeName): Pair<EnumType, ProtoFileHeader>? =
         find(name) { it.enumTypeMap }
 
     /**
      * Looks up a message or enum type by its name.
      */
-    public fun findMessageOrEnum(name: TypeName): Pair<ProtoDeclaration, File>? =
+    public fun findMessageOrEnum(name: TypeName): Pair<ProtoDeclaration, ProtoFileHeader>? =
         findMessage(name) ?: findEnum(name)
 
     /**
      * Looks up a service by its name.
      */
-    public fun findService(name: ServiceName): Pair<Service, File>? =
+    public fun findService(name: ServiceName): Pair<Service, ProtoFileHeader>? =
         find(name) { it.serviceMap }
 
     private fun <T> find(
         name: ProtoDeclarationName,
         mapSelector: (ProtobufSourceFile) -> Map<String, T>
-    ): Pair<T, File>? {
+    ): Pair<T, ProtoFileHeader>? {
         val typeUrl = name.typeUrl
         val file = files.find {
             mapSelector(it).containsKey(typeUrl)

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -38,15 +38,14 @@ option java_multiple_files = true;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
-// A path to a file in a file system.
+// A file path on a file system.
 //
-// The Protobuf compiler only works with the Unix-style file separators (`/`), regardless of
-// the operating system. This value holds this exact format of the path.
+// The Protobuf compiler only works with the Unix-style file separator (`/`), regardless of
+// the current operating system. This value holds this exact format of the path.
 //
 message FilePath {
 
-    // The path to the file, separating directories with slash (`/`) disregarding
-    // the current operating system.
+    // The path to the file, separating directories with slash (`/`) symbol.
     string value = 1;
 }
 
@@ -98,8 +97,8 @@ message TypeName {
     //     }
     // }
     // ```
-    // `Fuzzy` is the `simple_name` of this type. And [`Project`, `Deadline`] are the nesting type
-    // names.
+    // `Fuzzy` is the `simple_name` of this type. And [`Project`, `Deadline`] are
+    // the nesting type names.
     //
     repeated string nesting_type_name = 2;
 
@@ -108,12 +107,12 @@ message TypeName {
 
     // The prefix of the type's URL.
     //
-    // A type URL has the following structure: "<type URL prefix>/<package>.<short name>". For more
-    // info, see the definition of `google.protobuf.Any.type_url`.
+    // A type URL has the following structure: "<type URL prefix>/<package>.<short name>".
+    // For more info, please see the definition of `google.protobuf.Any.type_url`.
     //
-    // Must not include a training slash ("/").
+    // Must not include a trailing slash ("/").
     //
-    string type_url_prefix = 4;
+    string type_url_prefix = 4 [(pattern).regex = "^.*[^/]$"];
 }
 
 // A Protobuf message type.

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -50,7 +50,8 @@ message FilePath {
     string value = 1;
 }
 
-// A Protobuf source file.
+// A header of the Protobuf source code file which provides basic information about the file,
+// such as file-wide options applied to the file.
 message ProtoFileHeader {
 
     // Path to the file in a file system.

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -55,7 +55,7 @@ message FilePath {
 message ProtoFileHeader {
 
     // Path to the file in a file system.
-    FilePath path = 1;
+    FilePath file = 1;
 
     // Name of the Protobuf package to which the declarations of the file belong.
     string package_name = 2;

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -517,11 +517,11 @@ message Doc {
     // The comment placed beneath above the declaration without any empty lines.
     string trailing_comment = 2;
 
-    // Comments placed above the declaration separated by at least one empty line from
-    // the declaration.
+    // Comments placed above the declaration separated by at least
+    // one empty line from the declaration.
     //
-    // This can often be a general comment, related not to the declaration itself, but rather to
-    // its context.
+    // This can often be a general comment, related not to the declaration itself,
+    // but rather to its context.
     //
     repeated string detached_comment = 3;
 }

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -38,7 +38,10 @@ option java_multiple_files = true;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
-// A file path on a file system.
+// Represents a file in an arbitrary OS.
+//
+// In most cases it is going to be a relative path.
+// In some cases it may be an absolute path.
 //
 // The Protobuf compiler only works with the Unix-style file separator (`/`), regardless of
 // the current operating system. This value holds this exact format of the path.

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -43,10 +43,10 @@ import "google/protobuf/empty.proto";
 // The Protobuf compiler only works with the Unix-style file separator (`/`), regardless of
 // the current operating system. This value holds this exact format of the path.
 //
-message FilePath {
+message File {
 
     // The path to the file, separating directories with slash (`/`) symbol.
-    string value = 1;
+    string path = 1;
 }
 
 // A header of the Protobuf source code file which provides basic information about the file,
@@ -54,7 +54,7 @@ message FilePath {
 message ProtoFileHeader {
 
     // Path to the file in a file system.
-    FilePath file = 1;
+    File file = 1;
 
     // Name of the Protobuf package to which the declarations of the file belong.
     string package_name = 2;
@@ -139,7 +139,7 @@ message MessageType {
     repeated Option option = 4;
 
     // Path to the file which declares this type.
-    FilePath file = 5;
+    File file = 5;
 
     // Name of the message type which hosts the declaration of this type.
     TypeName declared_in = 6;
@@ -170,7 +170,7 @@ message EnumType {
     repeated Option option = 2;
 
     // Path to the file which declares this type.
-    FilePath file = 3;
+    File file = 3;
 
     // The enum constants, a.k.a. values.
     //
@@ -413,7 +413,7 @@ message Service {
     Doc doc = 4;
 
     // Path to the file which declares this service.
-    FilePath file = 5;
+    File file = 5;
 }
 
 // A name of an RPC method.

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,19 +38,20 @@ option java_multiple_files = true;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
-// A path in a file system.
+// A path to a file in a file system.
+//
+// The Protobuf compiler only works with the Unix-style file separators (`/`), regardless of
+// the operating system. This value holds this exact format of the path.
+//
 message FilePath {
 
-    // The relative path from the Protobuf source directory to a file.
-    //
-    // The Protobuf compiler only works with the Unix-style file separators (`/`), regardless of
-    // the operating system. This value holds this exact format of the path.
-    //
+    // The path to the file, separating directories with slash (`/`) disregarding
+    // the current operating system.
     string value = 1;
 }
 
 // A Protobuf source file.
-message File {
+message ProtoFileHeader {
 
     // Path to the file in a file system.
     FilePath path = 1;

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -1,5 +1,5 @@
  /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,251 +38,329 @@ option java_multiple_files = true;
 import "spine/protodata/ast.proto";
 import "spine/protodata/source.proto";
 
+option (every_is).java_type = "io.spine.protodata.FileAware";
+
 // Emitted when processing of a file begins.
 message FileEntered {
 
+    // The file processing of which is started.
     File file = 1;
 
+    // The header of the file.
     ProtoFileHeader header = 2;
 }
 
 // Emitted when a file-level option is found.
 message FileOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file option of which was found.
     File file = 1;
 
+    // The discovered option.
     Option option = 2;
 }
 
 // Emitted when a file is completely discovered, including all the types, etc.
 message FileExited {
 
+    // The file processing of which is finished.
     File file = 1;
 }
 
 // Emitted when processing reaches a message type.
 message TypeEntered {
 
+    // The file in which the type is defined.
     File file = 1;
 
+    // The type processing of which is started.
     MessageType type = 2;
 }
 
 // Emitted when a message-level option is found.
 message TypeOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the type is defined.
     File file = 1;
 
+    // The type in which the option is discovered.
     TypeName type = 2;
 
+    // The discovered option.
     Option option = 3;
 }
 
 // Emitted when a message type is completely discovered, including all the fields, etc.
 message TypeExited {
 
+    // The file in which the type is defined.
     File file = 1;
 
+    // The type processing of which is finished.
     TypeName type = 2;
 }
 
 // Emitted when processing reaches a `oneof` group.
 message OneofGroupEntered {
 
+    // The file in which the `oneof` group is defined.
     File file = 1;
 
+    // The type in which the `oneof` group is defined.
     TypeName type = 2;
 
+    // The `oneof` group processing of which is started.
     OneofGroup group = 3;
 }
 
 // Emitted when a `oneof`-level option is found.
 message OneofOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the `oneof` group is defined.
     File file = 1;
 
+    // The type in which the `oneof` group is defined.
     TypeName type = 2;
 
+    // The `oneof` group in which the option is discovered.
     OneofName group = 3;
 
+    // The discovered option.
     Option option = 4;
 }
 
 // Emitted when a `oneof`-group is completely discovered, including all the options and fields.
 message OneofGroupExited {
 
+    // The file in which the `oneof` group is defined.
     File file = 1;
 
+    // The type in which the `oneof` group is defined.
     TypeName type = 2;
 
+    // The `oneof` group processing of which is finished.
     OneofName group = 3;
 }
 
 // Emitted when processing reaches a field.
 message FieldEntered {
 
+    // The file in which the field is defined.
     File file = 1;
 
+    // The type in which the field is defined.
     TypeName type = 2;
 
+    // The field processing of which is started.
     Field field = 3;
 }
 
 // Emitted when a field-level option is found.
 message FieldOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the field is defined.
     File file = 1;
 
+    // The type in which the field is defined.
     TypeName type = 2;
 
+    // The field in which the option is discovered.
     FieldName field = 3;
 
+    // The option discovered.
     Option option = 4;
 }
 
 // Emitted when a field is completely discovered including the options.
 message FieldExited {
 
+    // The file in which the field is defined.
     File file = 1;
 
+    // The type in which the field is defined.
     TypeName type = 2;
 
+    // The field processing of which is finished.
     FieldName field = 3;
 }
 
 // Emitted when processing reaches an enum type.
 message EnumEntered {
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type of the enum.
     EnumType type = 2;
 }
 
 // Emitted when an enum-level option is found.
 message EnumOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type name of the enum.
     TypeName type = 2;
 
+    // The option discovered.
     Option option = 3;
 }
 
 // Emitted when processing reaches an enum constant a.k.a. enum value.
 message EnumConstantEntered {
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type name of the enum.
     TypeName type = 2;
 
+    // The enum constant processing of which is started.
     EnumConstant constant = 3;
 }
 
 // Emitted when an enum constant-level option is found.
 message EnumConstantOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type name of the enum.
     TypeName type = 2;
 
+    // The enum constant in which the option is discovered.
     ConstantName constant = 3;
 
+    // The option discovered.
     Option option = 4;
 }
 
 // Emitted when an enum constant is completely discovered.
 message EnumConstantExited {
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type name of the enum.
     TypeName type = 2;
 
+    // The enum constant processing of which is finished.
     ConstantName constant = 3;
 }
 
 // Emitted when an enum type is completely discovered, including all the constants, etc.
 message EnumExited {
 
+    // The file in which the enum is defined.
     File file = 1;
 
+    // The type of the enum.
     TypeName type = 2;
 }
 
 // Emitted when the processing reaches a service.
 message ServiceEntered {
 
+    // The file in which the service is defined.
     File file = 1;
 
+    // The service processing of which is started.
     Service service = 2;
 }
 
 // Emitted when an service-level option is found.
 message ServiceOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the service is defined.
     File file = 1;
 
+    // The name of the service in which the option is discovered.
     ServiceName service = 2;
 
+    // The discovered option.
     Option option = 3;
 }
 
 // Emitted when a service is completely discovered, including all the option and RPCs.
 message ServiceExited {
 
+    // The file in which the service is defined.
     File file = 1;
 
+    // The name of the service processing of which is finished.
     ServiceName service = 2;
 }
 
 // Emitted when the processing reaches a remote procedure call.
 message RpcEntered {
 
+    // The file in which the RPC is defined.
     File file = 1;
 
+    // The name of the service in which the RPC is defined.
     ServiceName service = 2;
 
+    // The RPC processing of which is started.
     Rpc rpc = 3;
 }
 
 // Emitted when an RPC-level option is found.
 message RpcOptionDiscovered {
+    option (is).java_type = "io.spine.protodata.OptionAware";
 
+    // The file in which the RPC is defined.
     File file = 1;
 
+    // The name of the service in which the RPC is defined.
     ServiceName service = 2;
 
+    // The RPC in which the option is discovered.
     RpcName rpc = 3;
 
+    // The discovered option.
     Option option = 4;
 }
 
 // Emitted when an RPC is completely discovered.
 message RpcExited {
 
+    // The file in which the RPC is defined.
     File file = 1;
 
+    // The name of the service in which the RPC is defined.
     ServiceName service = 2;
 
+    // The RPC processing of which is finished.
     RpcName rpc = 3;
 }
 
 // Emitted when the Protobuf compiler discovers a dependency file.
 //
-// The order of files reported by events of this type is unspecified. Users should not rely on any
-// particular order.
+// The order of files reported by events of this type is unspecified.
+// Users should not rely on any particular order.
 //
-// Each file is only reported by one event, even if the file is imported into
+// Each dependency file is only reported by one event.
 //
 // `DependencyDiscovered` events always precede all other Protobuf compiler events, i.e.
 // the first `FileEntered` will always be emitted after the last `DependencyDiscovered`.
 //
-// Normally, no code should be generated for dependencies. However, they can be used for additional
-// info when generating code for the module's own types.
+// Normally, no code should be generated for dependencies.
+// However, they can be used for additional info when generating code for the module's own types.
 //
 message DependencyDiscovered {
 
-    File path = 1;
+    // The file of the dependency.
+    File file = 1;
 
+    // The source file of the dependency.
     ProtobufSourceFile source = 2;
 }
 

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -43,7 +43,7 @@ message FileEntered {
 
     FilePath path = 1;
 
-    File file = 2;
+    ProtoFileHeader file = 2;
 }
 
 // Emitted when a file-level option is found.

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -41,7 +41,7 @@ import "spine/protodata/source.proto";
 // Emitted when processing of a file begins.
 message FileEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     ProtoFileHeader header = 2;
 }
@@ -49,7 +49,7 @@ message FileEntered {
 // Emitted when a file-level option is found.
 message FileOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     Option option = 2;
 }
@@ -57,13 +57,13 @@ message FileOptionDiscovered {
 // Emitted when a file is completely discovered, including all the types, etc.
 message FileExited {
 
-    FilePath file = 1;
+    File file = 1;
 }
 
 // Emitted when processing reaches a message type.
 message TypeEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     MessageType type = 2;
 }
@@ -71,7 +71,7 @@ message TypeEntered {
 // Emitted when a message-level option is found.
 message TypeOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -81,7 +81,7 @@ message TypeOptionDiscovered {
 // Emitted when a message type is completely discovered, including all the fields, etc.
 message TypeExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 }
@@ -89,7 +89,7 @@ message TypeExited {
 // Emitted when processing reaches a `oneof` group.
 message OneofGroupEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -99,7 +99,7 @@ message OneofGroupEntered {
 // Emitted when a `oneof`-level option is found.
 message OneofOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -111,7 +111,7 @@ message OneofOptionDiscovered {
 // Emitted when a `oneof`-group is completely discovered, including all the options and fields.
 message OneofGroupExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -121,7 +121,7 @@ message OneofGroupExited {
 // Emitted when processing reaches a field.
 message FieldEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -131,7 +131,7 @@ message FieldEntered {
 // Emitted when a field-level option is found.
 message FieldOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -143,7 +143,7 @@ message FieldOptionDiscovered {
 // Emitted when a field is completely discovered including the options.
 message FieldExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -153,7 +153,7 @@ message FieldExited {
 // Emitted when processing reaches an enum type.
 message EnumEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     EnumType type = 2;
 }
@@ -161,7 +161,7 @@ message EnumEntered {
 // Emitted when an enum-level option is found.
 message EnumOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -171,7 +171,7 @@ message EnumOptionDiscovered {
 // Emitted when processing reaches an enum constant a.k.a. enum value.
 message EnumConstantEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -181,7 +181,7 @@ message EnumConstantEntered {
 // Emitted when an enum constant-level option is found.
 message EnumConstantOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -193,7 +193,7 @@ message EnumConstantOptionDiscovered {
 // Emitted when an enum constant is completely discovered.
 message EnumConstantExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 
@@ -203,7 +203,7 @@ message EnumConstantExited {
 // Emitted when an enum type is completely discovered, including all the constants, etc.
 message EnumExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     TypeName type = 2;
 }
@@ -211,7 +211,7 @@ message EnumExited {
 // Emitted when the processing reaches a service.
 message ServiceEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     Service service = 2;
 }
@@ -219,7 +219,7 @@ message ServiceEntered {
 // Emitted when an service-level option is found.
 message ServiceOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     ServiceName service = 2;
 
@@ -229,7 +229,7 @@ message ServiceOptionDiscovered {
 // Emitted when a service is completely discovered, including all the option and RPCs.
 message ServiceExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     ServiceName service = 2;
 }
@@ -237,7 +237,7 @@ message ServiceExited {
 // Emitted when the processing reaches a remote procedure call.
 message RpcEntered {
 
-    FilePath file = 1;
+    File file = 1;
 
     ServiceName service = 2;
 
@@ -247,7 +247,7 @@ message RpcEntered {
 // Emitted when an RPC-level option is found.
 message RpcOptionDiscovered {
 
-    FilePath file = 1;
+    File file = 1;
 
     ServiceName service = 2;
 
@@ -259,7 +259,7 @@ message RpcOptionDiscovered {
 // Emitted when an RPC is completely discovered.
 message RpcExited {
 
-    FilePath file = 1;
+    File file = 1;
 
     ServiceName service = 2;
 
@@ -281,7 +281,7 @@ message RpcExited {
 //
 message DependencyDiscovered {
 
-    FilePath path = 1;
+    File path = 1;
 
     ProtobufSourceFile source = 2;
 }
@@ -293,7 +293,7 @@ message InsertionPointPrinted {
     //
     // This path is relative to the source file set which contains the file.
     //
-    FilePath file = 1;
+    File file = 1;
 
     // The insertion point label.
     //

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -43,7 +43,7 @@ message FileEntered {
 
     FilePath path = 1;
 
-    ProtoFileHeader file = 2;
+    ProtoFileHeader header = 2;
 }
 
 // Emitted when a file-level option is found.

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -41,7 +41,7 @@ import "spine/protodata/source.proto";
 // Emitted when processing of a file begins.
 message FileEntered {
 
-    FilePath path = 1;
+    FilePath file = 1;
 
     ProtoFileHeader header = 2;
 }
@@ -283,7 +283,7 @@ message DependencyDiscovered {
 
     FilePath path = 1;
 
-    ProtobufSourceFile file = 2;
+    ProtobufSourceFile source = 2;
 }
 
 // Emitted when an insertion point printer adds an insertion point to a code file.

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -54,7 +54,7 @@ message FileEntered {
 message FileOptionDiscovered {
     option (is).java_type = "io.spine.protodata.OptionAware";
 
-    // The file option of which was found.
+    // The file, option of which was found.
     File file = 1;
 
     // The discovered option.
@@ -184,7 +184,7 @@ message FieldExited {
     // The type in which the field is defined.
     TypeName type = 2;
 
-    // The field processing of which is finished.
+    // The processed field.
     FieldName field = 3;
 }
 
@@ -208,7 +208,7 @@ message EnumOptionDiscovered {
     // The type name of the enum.
     TypeName type = 2;
 
-    // The option discovered.
+    // The discovered option.
     Option option = 3;
 }
 
@@ -238,7 +238,7 @@ message EnumConstantOptionDiscovered {
     // The enum constant in which the option is discovered.
     ConstantName constant = 3;
 
-    // The option discovered.
+    // The discovered option.
     Option option = 4;
 }
 

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -47,6 +47,9 @@ message FileEntered {
     File file = 1;
 
     // The header of the file.
+    //
+    // The `file` field of the header must be equal to the `file` field of this event.
+    //
     ProtoFileHeader header = 2;
 }
 

--- a/api/src/main/proto/spine/protodata/insertion.proto
+++ b/api/src/main/proto/spine/protodata/insertion.proto
@@ -44,7 +44,7 @@ import "spine/protodata/ast.proto";
 message InsertedPoint {
 
     // The relative path to the code file.
-    FilePath file = 1;
+    File file = 1;
 
     // The label of the insertion point.
     string label = 2 [(required) = true, (column) = true];
@@ -61,7 +61,7 @@ message InsertedPoints {
     option (entity).kind = VIEW;
 
     // The relative path to the code file.
-    FilePath file = 1;
+    File file = 1;
 
     // Insertion points added to the given file.
     //

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -44,13 +44,13 @@ import "spine/protodata/ast.proto";
 message ProtobufSourceFile {
     option (entity).kind = VIEW;
 
-    // The relative path to the file.
-    //
-    // Must be the same as `header.file`.
-    //
+    // The path to the file.
     File file = 1;
 
-    // A header of the Protobuf file.
+    // The header of the Protobuf file.
+    //
+    // The `file` field of the header must be equal to the `file` field of this message type.
+    //
     ProtoFileHeader header = 2;
 
     // All the message types in this source files.

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ message ProtobufSourceFile {
     //
     // Must be the same as `header.file`.
     //
-    FilePath file_path = 1;
+    FilePath file = 1;
 
     ProtoFileHeader header = 2;
 

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -91,5 +91,5 @@ message ProtobufDependency {
     //
     FilePath file_path = 1;
 
-    ProtobufSourceFile file = 2;
+    ProtobufSourceFile source = 2;
 }

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -50,6 +50,7 @@ message ProtobufSourceFile {
     //
     File file = 1;
 
+    // A header of the Protobuf file.
     ProtoFileHeader header = 2;
 
     // All the message types in this source files.

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -50,7 +50,7 @@ message ProtobufSourceFile {
     //
     FilePath file_path = 1;
 
-    File file = 2;
+    ProtoFileHeader file = 2;
 
     // All the message types in this source files.
     //

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -46,11 +46,11 @@ message ProtobufSourceFile {
 
     // The relative path to the file.
     //
-    // Must be the same as `file.path`.
+    // Must be the same as `header.file`.
     //
     FilePath file_path = 1;
 
-    ProtoFileHeader file = 2;
+    ProtoFileHeader header = 2;
 
     // All the message types in this source files.
     //

--- a/api/src/main/proto/spine/protodata/source.proto
+++ b/api/src/main/proto/spine/protodata/source.proto
@@ -48,7 +48,7 @@ message ProtobufSourceFile {
     //
     // Must be the same as `header.file`.
     //
-    FilePath file = 1;
+    File file = 1;
 
     ProtoFileHeader header = 2;
 
@@ -89,7 +89,7 @@ message ProtobufDependency {
     //
     // Must be the same as `file.file_path`.
     //
-    FilePath file_path = 1;
+    File file = 1;
 
     ProtobufSourceFile source = 2;
 }

--- a/api/src/test/kotlin/io/spine/protodata/AstExtensionsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/AstExtensionsSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class AstExtensionsSpec {
                 .setList(Empty.getDefaultInstance())
                 .buildPartial()
 
-            field.isRepeated() shouldBe true
+            field.isRepeated shouldBe true
         }
 
         @Test
@@ -71,7 +71,7 @@ class AstExtensionsSpec {
                     .build())
                 .buildPartial()
 
-            field.isRepeated() shouldBe true
+            field.isRepeated shouldBe true
         }
 
         @Test
@@ -80,7 +80,7 @@ class AstExtensionsSpec {
                 .setSingle(Empty.getDefaultInstance())
                 .buildPartial()
 
-            field.isRepeated() shouldBe false
+            field.isRepeated shouldBe false
         }
     }
 
@@ -91,28 +91,28 @@ class AstExtensionsSpec {
         fun unary() {
             val method = method("who")
 
-            method.cardinality() shouldBe UNARY
+            method.cardinality shouldBe UNARY
         }
 
         @Test
         fun `server streaming`() {
             val method = method("where_are_you")
 
-            method.cardinality() shouldBe SERVER_STREAMING
+            method.cardinality shouldBe SERVER_STREAMING
         }
 
         @Test
         fun `client streaming`() {
             val method = method("rescue_call")
 
-            method.cardinality() shouldBe CLIENT_STREAMING
+            method.cardinality shouldBe CLIENT_STREAMING
         }
 
         @Test
         fun `bidirectional streaming`() {
             val method = method("which_actor")
 
-            method.cardinality() shouldBe BIDIRECTIONAL_STREAMING
+            method.cardinality shouldBe BIDIRECTIONAL_STREAMING
         }
 
         private fun method(name: String): Descriptors.MethodDescriptor {
@@ -128,21 +128,21 @@ class AstExtensionsSpec {
         fun `for a top-level message`() {
             val name = TopLevelMessage.getDescriptor().name()
 
-            name.qualifiedName() shouldBe "spine.protodata.test.TopLevelMessage"
+            name.qualifiedName shouldBe "spine.protodata.test.TopLevelMessage"
         }
 
         @Test
         fun `for a top-level enum`() {
             val name = TopLevelEnum.getDescriptor().name()
 
-            name.qualifiedName() shouldBe "spine.protodata.test.TopLevelEnum"
+            name.qualifiedName shouldBe "spine.protodata.test.TopLevelEnum"
         }
 
         @Test
         fun `for a nested message`() {
             val name = NestedMessage.VeryNestedMessage.getDescriptor().name()
 
-            name.qualifiedName() shouldBe
+            name.qualifiedName shouldBe
                     "spine.protodata.test.TopLevelMessage.NestedMessage.VeryNestedMessage"
         }
 
@@ -150,7 +150,7 @@ class AstExtensionsSpec {
         fun `for a nested enum`() {
             val name = NestedEnum.getDescriptor().name()
 
-            name.qualifiedName() shouldBe "spine.protodata.test.TopLevelMessage.NestedEnum"
+            name.qualifiedName shouldBe "spine.protodata.test.TopLevelMessage.NestedEnum"
         }
 
         @Test
@@ -164,7 +164,7 @@ class AstExtensionsSpec {
         fun `for a nested message without a package`() {
             val name = LocalMessage.getDescriptor().name()
 
-            name.qualifiedName() shouldBe "GlobalMessage.LocalMessage"
+            name.qualifiedName shouldBe "GlobalMessage.LocalMessage"
         }
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ValuesSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ValuesSpec.kt
@@ -52,7 +52,7 @@ class ValuesSpec {
     @Test
     fun `convert a repeated field`() {
         val v = fieldMask { paths.addAll(listOf("foo", "bar", "baz")) }.toValue()
-        v.messageValue.type.qualifiedName() shouldBe FieldMask.getDescriptor().fullName
+        v.messageValue.type.qualifiedName shouldBe FieldMask.getDescriptor().fullName
         v.messageValue.fieldsMap shouldHaveKey "paths"
         val list = v.messageValue.fieldsMap["paths"]!!.listValue
         list.valuesList[0].stringValue shouldBe "foo"

--- a/api/src/test/kotlin/io/spine/protodata/type/TypeSystemSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/type/TypeSystemSpec.kt
@@ -35,7 +35,7 @@ import io.spine.protodata.Service
 import io.spine.protodata.serviceName
 import io.spine.protodata.test.TypesTestEnv.enumTypeName
 import io.spine.protodata.test.TypesTestEnv.messageTypeName
-import io.spine.protodata.test.TypesTestEnv.protoFile
+import io.spine.protodata.test.TypesTestEnv.header
 import io.spine.protodata.test.TypesTestEnv.serviceName
 import io.spine.protodata.test.TypesTestEnv.typeSystem
 import io.spine.protodata.typeName
@@ -55,7 +55,7 @@ class TypeSystemSpec {
             file shouldNotBe null
 
             messageType.name shouldBe messageTypeName
-            file shouldBe protoFile
+            file shouldBe header
         }
 
         @Test
@@ -65,7 +65,7 @@ class TypeSystemSpec {
             file shouldNotBe null
 
             enumType.name shouldBe enumTypeName
-            file shouldBe protoFile
+            file shouldBe header
         }
 
         @Test

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.172"
+        const val mcJava = "2.0.0-SNAPSHOT.173"
 
         /**
          * The version of [Spine.baseTypes].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.111"
+    const val version = "2.0.0-SNAPSHOT.112"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.110"
+    const val version = "2.0.0-SNAPSHOT.111"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -54,16 +54,6 @@ dependencies {
     testImplementation(project(":test-env"))
 }
 
-// For some reason, `validation-runtime` dependency appears on both compile and runtime classpaths.
-// This expression explicitly excludes this dependency from the list.
-modelCompiler {
-    java {
-        codegen {
-            validation { skipValidation() }
-        }
-    }
-}
-
 /** The publishing settings from the root project. */
 val spinePublishing = rootProject.the<SpinePublishing>()
 

--- a/codegen/java/build.gradle.kts
+++ b/codegen/java/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,16 +52,6 @@ protobuf {
                 from(task.outputs)
                 duplicatesStrategy = INCLUDE
             }
-        }
-    }
-}
-
-// For some reason, `validation-runtime` dependency appears on both compile and runtime classpaths.
-// This expression explicitly excludes this dependency from the list.
-modelCompiler {
-    java {
-        codegen {
-            validation { skipValidation() }
         }
     }
 }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
@@ -105,7 +105,7 @@ internal fun composeJavaClassName(
 }
 
 /**
- * Obtains a fully-qualified Java class, generated for the Protobuf type with this name.
+ * Obtains a fully qualified Java class, generated for the Protobuf type with this name.
  */
 internal fun TypeName.javaClassName(declaredIn: File): ClassName =
     composeJavaClassName(declaredIn) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
@@ -45,14 +45,14 @@ import kotlin.io.path.Path
  *
  * The class which represents this message might not be the top level class of the Java file.
  */
-public fun MessageType.javaFile(declaredIn: ProtoFileHeader): Path =
-    name.javaFile(declaredIn)
+public fun MessageType.javaFile(accordingTo: ProtoFileHeader): Path =
+    name.javaFile(accordingTo)
 
-internal fun TypeName.javaFile(declaredIn: ProtoFileHeader): Path {
-    val packageName = declaredIn.javaPackage()
-    val javaMultipleFiles = declaredIn.javaMultipleFiles()
+internal fun TypeName.javaFile(accordingTo: ProtoFileHeader): Path {
+    val packageName = accordingTo.javaPackage()
+    val javaMultipleFiles = accordingTo.javaMultipleFiles()
     val topLevelClassName = when {
-        !javaMultipleFiles -> declaredIn.javaOuterClassName()
+        !javaMultipleFiles -> accordingTo.javaOuterClassName()
         nestingTypeNameList.isNotEmpty() -> nestingTypeNameList.first()
         else -> simpleName
     }
@@ -65,16 +65,16 @@ internal fun TypeName.javaFile(declaredIn: ProtoFileHeader): Path {
  *
  * @return name of the class generated from this message.
  */
-public fun MessageType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
-    name.javaClassName(declaredIn)
+public fun MessageType.javaClassName(accordingTo: ProtoFileHeader): ClassName =
+    name.javaClassName(accordingTo)
 
 /**
  * Obtains the full name of the Java enum, generated from this Protobuf enum.
  *
  * @return name of the enum class generated from this enum.
  */
-public fun EnumType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
-    name.javaClassName(declaredIn)
+public fun EnumType.javaClassName(accordingTo: ProtoFileHeader): ClassName =
+    name.javaClassName(accordingTo)
 
 /**
  * Obtains a Java class name for a Protobuf declaration.
@@ -82,8 +82,8 @@ public fun EnumType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
  * The function calculates the package name taking into account values of
  * `java_package_name` and `java_multiple_files` options that may present in the file.
  *
- * @param declaredIn
- *        the Protobuf file where the declaration resides in.
+ * @param accordingTo
+ *        the header of the Protobuf file where the declaration resides in.
  * @param block
  *        the block of code which adds the name elements to the class name.
  *
@@ -91,14 +91,14 @@ public fun EnumType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
  * @see ProtoFileHeader.javaMultipleFiles
  */
 internal fun composeJavaClassName(
-    declaredIn: ProtoFileHeader,
+    accordingTo: ProtoFileHeader,
     block: MutableList<String>.() -> Unit
 ): ClassName {
-    val packageName = declaredIn.javaPackage()
-    val javaMultipleFiles = declaredIn.javaMultipleFiles()
+    val packageName = accordingTo.javaPackage()
+    val javaMultipleFiles = accordingTo.javaMultipleFiles()
     val nameElements = mutableListOf<String>()
     if (!javaMultipleFiles) {
-        nameElements.add(declaredIn.javaOuterClassName())
+        nameElements.add(accordingTo.javaOuterClassName())
     }
     block(nameElements)
     return ClassName(packageName, nameElements)
@@ -107,8 +107,8 @@ internal fun composeJavaClassName(
 /**
  * Obtains a fully qualified Java class, generated for the Protobuf type with this name.
  */
-internal fun TypeName.javaClassName(declaredIn: ProtoFileHeader): ClassName =
-    composeJavaClassName(declaredIn) {
+internal fun TypeName.javaClassName(accordingTo: ProtoFileHeader): ClassName =
+    composeJavaClassName(accordingTo) {
         addAll(nestingTypeNameList)
         add(simpleName)
     }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/CodeLayout.kt
@@ -31,8 +31,8 @@ package io.spine.protodata.codegen.java
 import com.google.protobuf.BoolValue
 import com.google.protobuf.StringValue
 import io.spine.protodata.EnumType
-import io.spine.protodata.File
 import io.spine.protodata.MessageType
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.TypeName
 import io.spine.protodata.find
 import io.spine.protodata.nameWithoutExtension
@@ -45,10 +45,10 @@ import kotlin.io.path.Path
  *
  * The class which represents this message might not be the top level class of the Java file.
  */
-public fun MessageType.javaFile(declaredIn: File): Path =
+public fun MessageType.javaFile(declaredIn: ProtoFileHeader): Path =
     name.javaFile(declaredIn)
 
-internal fun TypeName.javaFile(declaredIn: File): Path {
+internal fun TypeName.javaFile(declaredIn: ProtoFileHeader): Path {
     val packageName = declaredIn.javaPackage()
     val javaMultipleFiles = declaredIn.javaMultipleFiles()
     val topLevelClassName = when {
@@ -65,7 +65,7 @@ internal fun TypeName.javaFile(declaredIn: File): Path {
  *
  * @return name of the class generated from this message.
  */
-public fun MessageType.javaClassName(declaredIn: File): ClassName =
+public fun MessageType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
     name.javaClassName(declaredIn)
 
 /**
@@ -73,7 +73,7 @@ public fun MessageType.javaClassName(declaredIn: File): ClassName =
  *
  * @return name of the enum class generated from this enum.
  */
-public fun EnumType.javaClassName(declaredIn: File): ClassName =
+public fun EnumType.javaClassName(declaredIn: ProtoFileHeader): ClassName =
     name.javaClassName(declaredIn)
 
 /**
@@ -87,11 +87,11 @@ public fun EnumType.javaClassName(declaredIn: File): ClassName =
  * @param block
  *        the block of code which adds the name elements to the class name.
  *
- * @see File.javaPackage
- * @see File.javaMultipleFiles
+ * @see ProtoFileHeader.javaPackage
+ * @see ProtoFileHeader.javaMultipleFiles
  */
 internal fun composeJavaClassName(
-    declaredIn: File,
+    declaredIn: ProtoFileHeader,
     block: MutableList<String>.() -> Unit
 ): ClassName {
     val packageName = declaredIn.javaPackage()
@@ -107,7 +107,7 @@ internal fun composeJavaClassName(
 /**
  * Obtains a fully qualified Java class, generated for the Protobuf type with this name.
  */
-internal fun TypeName.javaClassName(declaredIn: File): ClassName =
+internal fun TypeName.javaClassName(declaredIn: ProtoFileHeader): ClassName =
     composeJavaClassName(declaredIn) {
         addAll(nestingTypeNameList)
         add(simpleName)
@@ -119,7 +119,7 @@ internal fun TypeName.javaClassName(declaredIn: File): ClassName =
  * @return A value of the `java_package` option, if it is set.
  *         Otherwise, returns the package name of the file.
  */
-public fun File.javaPackage(): String =
+public fun ProtoFileHeader.javaPackage(): String =
     optionList.find("java_package", StringValue::class.java)
         ?.value
         ?: packageName
@@ -127,7 +127,7 @@ public fun File.javaPackage(): String =
 /**
  * Obtains a value of `java_multiple_files` option set for this file.
  */
-public fun File.javaMultipleFiles(): Boolean =
+public fun ProtoFileHeader.javaMultipleFiles(): Boolean =
     optionList.find("java_multiple_files", BoolValue::class.java)
         ?.value
         ?: false
@@ -137,7 +137,7 @@ public fun File.javaMultipleFiles(): Boolean =
  *
  * @return A value of `java_outer_classname` option, if it set for this file.
  */
-public fun File.javaOuterClassName(): String =
+public fun ProtoFileHeader.javaOuterClassName(): String =
     optionList.find("java_outer_classname", StringValue::class.java)
         ?.value
         ?: nameWithoutExtension().camelCase()

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
@@ -26,8 +26,8 @@
 
 package io.spine.protodata.codegen.java
 
-import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ProtoDeclarationName
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ServiceName
 import io.spine.protodata.TypeName
 import io.spine.protodata.type.Convention
@@ -55,9 +55,9 @@ public abstract class BaseJavaConvention<N: ProtoDeclarationName>(
 public class MessageOrEnumConvention(ts: TypeSystem) : BaseJavaConvention<TypeName>(ts) {
 
     override fun declarationFor(name: TypeName): Declaration<Java, ClassName> {
-        val file = typeSystem.findMessageOrEnum(name)?.second
-        check(file != null) { "Unknown type `${name.typeUrl}`." }
-        val cls = name.javaClassName(declaredIn = file)
+        val header = typeSystem.findMessageOrEnum(name)?.second
+        check(header != null) { "Unknown type `${name.typeUrl}`." }
+        val cls = name.javaClassName(accordingTo = header)
         return Declaration(cls, cls.javaFile)
     }
 }
@@ -88,17 +88,17 @@ public abstract class AbstractServiceConvention(ts: TypeSystem) :
 
     override fun declarationFor(name: ServiceName): Declaration<Java, ClassName> {
         val pair = typeSystem.findService(name)
-        val file = pair?.second
-        check(file != null) { "Unknown service `${name.typeUrl}`." }
+        val header = pair?.second
+        check(header != null) { "Unknown service `${name.typeUrl}`." }
         val service = pair.first
-        val cls = javaClassName(service.name, declaredIn = file)
+        val cls = javaClassName(service.name, accordingTo = header)
         return Declaration(cls, cls.javaFile)
     }
 
     /**
      * Calculates a class name for the given service declared in the given file.
      */
-    protected abstract fun javaClassName(name: ServiceName, declaredIn: ProtoFileHeader): ClassName
+    protected abstract fun javaClassName(name: ServiceName, accordingTo: ProtoFileHeader): ClassName
 }
 
 /**
@@ -111,9 +111,9 @@ public class GrpcServiceConvention(ts: TypeSystem) : AbstractServiceConvention(t
 
     protected override fun javaClassName(
         name: ServiceName,
-        declaredIn: ProtoFileHeader
+        accordingTo: ProtoFileHeader
     ): ClassName =
-        composeJavaClassName(declaredIn) {
+        composeJavaClassName(accordingTo) {
             add(name.simpleName + "Grpc")
         }
 }
@@ -127,8 +127,8 @@ public class GrpcServiceConvention(ts: TypeSystem) : AbstractServiceConvention(t
  */
 public class GenericServiceConvention(ts: TypeSystem): AbstractServiceConvention(ts) {
 
-    override fun javaClassName(name: ServiceName, declaredIn: ProtoFileHeader): ClassName =
-        composeJavaClassName(declaredIn) {
+    override fun javaClassName(name: ServiceName, accordingTo: ProtoFileHeader): ClassName =
+        composeJavaClassName(accordingTo) {
             add(name.simpleName)
         }
 }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
@@ -26,7 +26,7 @@
 
 package io.spine.protodata.codegen.java
 
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ProtoDeclarationName
 import io.spine.protodata.ServiceName
 import io.spine.protodata.TypeName
@@ -98,7 +98,7 @@ public abstract class AbstractServiceConvention(ts: TypeSystem) :
     /**
      * Calculates a class name for the given service declared in the given file.
      */
-    protected abstract fun javaClassName(name: ServiceName, declaredIn: File): ClassName
+    protected abstract fun javaClassName(name: ServiceName, declaredIn: ProtoFileHeader): ClassName
 }
 
 /**
@@ -109,7 +109,10 @@ public abstract class AbstractServiceConvention(ts: TypeSystem) :
  */
 public class GrpcServiceConvention(ts: TypeSystem) : AbstractServiceConvention(ts) {
 
-    protected override fun javaClassName(name: ServiceName, declaredIn: File): ClassName =
+    protected override fun javaClassName(
+        name: ServiceName,
+        declaredIn: ProtoFileHeader
+    ): ClassName =
         composeJavaClassName(declaredIn) {
             add(name.simpleName + "Grpc")
         }
@@ -124,7 +127,7 @@ public class GrpcServiceConvention(ts: TypeSystem) : AbstractServiceConvention(t
  */
 public class GenericServiceConvention(ts: TypeSystem): AbstractServiceConvention(ts) {
 
-    override fun javaClassName(name: ServiceName, declaredIn: File): ClassName =
+    override fun javaClassName(name: ServiceName, declaredIn: ProtoFileHeader): ClassName =
         composeJavaClassName(declaredIn) {
             add(name.simpleName)
         }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Conventions.kt
@@ -104,7 +104,7 @@ public abstract class AbstractServiceConvention(ts: TypeSystem) :
 /**
  * This convention governs declarations of generated gRPC stubs.
  *
- * In the context of API-level annotations, putting an annotation on a root gRPC-generated
+ * In the context of API-level annotations, putting an annotation on a gRPC-generated
  * class effectively puts it on all the nested classes.
  */
 public class GrpcServiceConvention(ts: TypeSystem) : AbstractServiceConvention(ts) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
@@ -61,5 +61,5 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
     private fun findFile(path: FilePath): ProtoFileHeader =
         select(ProtobufSourceFile::class.java)
             .findById(path)!!
-            .file
+            .header
 }

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 package io.spine.protodata.codegen.java
 
-import io.spine.protodata.FilePath
+import io.spine.protodata.File
 import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.TypeName
@@ -42,7 +42,7 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
     /**
      * Obtains the [ClassName] of the given Protobuf type.
      */
-    protected fun classNameOf(type: TypeName, declaredIn: FilePath): ClassName {
+    protected fun classNameOf(type: TypeName, declaredIn: File): ClassName {
         val file = findFile(declaredIn)
         return type.javaClassName(file)
     }
@@ -53,12 +53,12 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
      * The path is relative to the generated source root. This path is useful for finding source
      * files in a [SourceSet][io.spine.protodata.renderer.SourceFileSet].
      */
-    protected fun javaFileOf(type: TypeName, declaredIn: FilePath): Path {
+    protected fun javaFileOf(type: TypeName, declaredIn: File): Path {
         val file = findFile(declaredIn)
         return type.javaFile(file)
     }
 
-    private fun findFile(path: FilePath): ProtoFileHeader =
+    private fun findFile(path: File): ProtoFileHeader =
         select(ProtobufSourceFile::class.java)
             .findById(path)!!
             .header

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
@@ -43,8 +43,8 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
      * Obtains the [ClassName] of the given Protobuf type.
      */
     protected fun classNameOf(type: TypeName, declaredIn: File): ClassName {
-        val file = findFile(declaredIn)
-        return type.javaClassName(file)
+        val header = findHeader(declaredIn)
+        return type.javaClassName(header)
     }
 
     /**
@@ -54,11 +54,11 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
      * files in a [SourceSet][io.spine.protodata.renderer.SourceFileSet].
      */
     protected fun javaFileOf(type: TypeName, declaredIn: File): Path {
-        val file = findFile(declaredIn)
-        return type.javaFile(file)
+        val header = findHeader(declaredIn)
+        return type.javaFile(header)
     }
 
-    private fun findFile(path: File): ProtoFileHeader =
+    private fun findHeader(path: File): ProtoFileHeader =
         select(ProtobufSourceFile::class.java)
             .findById(path)!!
             .header

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaRenderer.kt
@@ -26,8 +26,8 @@
 
 package io.spine.protodata.codegen.java
 
-import io.spine.protodata.File
 import io.spine.protodata.FilePath
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.TypeName
 import io.spine.protodata.renderer.Renderer
@@ -58,7 +58,7 @@ public abstract class JavaRenderer : Renderer<Java>(Java) {
         return type.javaFile(file)
     }
 
-    private fun findFile(path: FilePath): File =
+    private fun findFile(path: FilePath): ProtoFileHeader =
         select(ProtobufSourceFile::class.java)
             .findById(path)!!
             .file

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
@@ -46,7 +46,7 @@ public class RejectionThrowableConvention(
     override fun declarationFor(name: TypeName): Declaration<Java, ClassName>? {
         val declaration = typeSystem.findMessage(name) ?: return null
         val (msg, header) = declaration
-        val fileName = header.file.value
+        val fileName = header.file.path
         if (!fileName.endsWith("rejections.proto") // Not a rejection message.
             || msg.declaredIn.isNotDefault()       // Not a top-level message.
         ) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
@@ -45,14 +45,14 @@ public class RejectionThrowableConvention(
     @Suppress("ReturnCount")
     override fun declarationFor(name: TypeName): Declaration<Java, ClassName>? {
         val declaration = typeSystem.findMessage(name) ?: return null
-        val (msg, file) = declaration
-        val fileName = file.path.value
+        val (msg, header) = declaration
+        val fileName = header.file.value
         if (!fileName.endsWith("rejections.proto") // Not a rejection message.
             || msg.declaredIn.isNotDefault()       // Not a top-level message.
         ) {
             return null
         }
-        val packageName = file.javaPackage()
+        val packageName = header.javaPackage()
         val simpleName = name.simpleName
         val cls = ClassName(packageName, simpleName)
         return Declaration(cls, cls.javaFile)

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ import io.spine.protodata.codegen.java.file.javaMultipleFiles
 import io.spine.protodata.codegen.java.file.javaOuterClassName
 import io.spine.protodata.codegen.java.file.javaPackage
 import io.spine.protodata.enumType
-import io.spine.protodata.protoFileHeader
 import io.spine.protodata.messageType
+import io.spine.protodata.protoFileHeader
 import io.spine.protodata.typeName
 import java.io.File.separatorChar
 import org.junit.jupiter.api.DisplayName
@@ -54,7 +54,7 @@ internal class JavaCodegenSpec {
             val type = messageType(typeName)
             val file = protoMultipleFiles()
 
-            val className = type.javaClassName(declaredIn = file)
+            val className = type.javaClassName(accordingTo = file)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$typeName"
         }
@@ -66,7 +66,7 @@ internal class JavaCodegenSpec {
             val type = nestedMessageType(typeName, nestingType)
             val file = protoMultipleFiles()
 
-            val className = type.javaClassName(declaredIn = file)
+            val className = type.javaClassName(accordingTo = file)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$nestingType$$typeName"
         }
@@ -77,7 +77,7 @@ internal class JavaCodegenSpec {
             val type = messageType(typeName)
             val file = protoSingleFile(outerClassName = javaOuterClassName)
 
-            val className = type.javaClassName(declaredIn = file)
+            val className = type.javaClassName(accordingTo = file)
 
             className.binary shouldBe "${JAVA_PACKAGE_NAME}.${OUTER_CLASS_NAME}$${typeName}"
         }
@@ -88,7 +88,7 @@ internal class JavaCodegenSpec {
             val type = enumTypeNamed(typeName)
             val file = protoMultipleFiles()
 
-            val className = type.javaClassName(declaredIn = file)
+            val className = type.javaClassName(accordingTo = file)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$typeName"
         }
@@ -103,7 +103,7 @@ internal class JavaCodegenSpec {
             val type = messageType(typeName)
             val file = protoMultipleFiles()
 
-            val className = type.javaFile(declaredIn = file)
+            val className = type.javaFile(accordingTo = file)
 
             className.toString() shouldBe "$packageNameAsPath$typeName.java"
         }
@@ -115,7 +115,7 @@ internal class JavaCodegenSpec {
             val type = withDeeperNesting(typeName, firstNesting)
             val file = protoMultipleFiles()
 
-            val className = type.javaFile(declaredIn = file)
+            val className = type.javaFile(accordingTo = file)
 
             className.toString() shouldBe "$packageNameAsPath$firstNesting.java"
         }
@@ -125,7 +125,7 @@ internal class JavaCodegenSpec {
             val type = messageType("Fuse")
             val file = protoSingleFile(outerClassName = javaOuterClassName)
 
-            val className = type.javaFile(declaredIn = file)
+            val className = type.javaFile(accordingTo = file)
 
             className.toString() shouldBe "$packageNameAsPath$OUTER_CLASS_NAME.java"
         }

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
@@ -34,7 +34,7 @@ import io.spine.protodata.codegen.java.file.javaMultipleFiles
 import io.spine.protodata.codegen.java.file.javaOuterClassName
 import io.spine.protodata.codegen.java.file.javaPackage
 import io.spine.protodata.enumType
-import io.spine.protodata.file
+import io.spine.protodata.protoFileHeader
 import io.spine.protodata.messageType
 import io.spine.protodata.typeName
 import java.io.File.separatorChar
@@ -45,8 +45,8 @@ import org.junit.jupiter.api.Test
 @DisplayName("Java-related AST extensions should")
 internal class JavaCodegenSpec {
 
-    @Nested
-    inner class `Obtain Java class name from` {
+    @Nested inner class
+    `Obtain Java class name from` {
 
         @Test
         fun `top-level message`() {
@@ -94,8 +94,8 @@ internal class JavaCodegenSpec {
         }
     }
 
-    @Nested
-    inner class `Obtain Java file declaring generated class from` {
+    @Nested inner class
+    `Obtain Java file declaring generated class from` {
 
         @Test
         fun `top-level message`() {
@@ -132,14 +132,14 @@ internal class JavaCodegenSpec {
     }
 }
 
-private fun protoSingleFile(outerClassName: Option? = null) = file {
+private fun protoSingleFile(outerClassName: Option? = null) = protoFileHeader {
     option.apply {
         add(javaPackage)
         outerClassName?.let { add(it) }
     }
 }
 
-private fun protoMultipleFiles(outerClassName: Option? = null) = file {
+private fun protoMultipleFiles(outerClassName: Option? = null) = protoFileHeader {
     option.apply {
         add(javaPackage)
         add(javaMultipleFiles)

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
@@ -52,9 +52,9 @@ internal class JavaCodegenSpec {
         fun `top-level message`() {
             val typeName = "Anvil"
             val type = messageType(typeName)
-            val file = protoMultipleFiles()
+            val header = protoMultipleFiles()
 
-            val className = type.javaClassName(accordingTo = file)
+            val className = type.javaClassName(accordingTo = header)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$typeName"
         }
@@ -64,9 +64,9 @@ internal class JavaCodegenSpec {
             val nestingType = "RedDynamite"
             val typeName = "Fuse"
             val type = nestedMessageType(typeName, nestingType)
-            val file = protoMultipleFiles()
+            val header = protoMultipleFiles()
 
-            val className = type.javaClassName(accordingTo = file)
+            val className = type.javaClassName(accordingTo = header)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$nestingType$$typeName"
         }
@@ -75,9 +75,9 @@ internal class JavaCodegenSpec {
         fun `message with Java outer class name`() {
             val typeName = "Fuse"
             val type = messageType(typeName)
-            val file = protoSingleFile(outerClassName = javaOuterClassName)
+            val header = protoSingleFile(outerClassName = javaOuterClassName)
 
-            val className = type.javaClassName(accordingTo = file)
+            val className = type.javaClassName(accordingTo = header)
 
             className.binary shouldBe "${JAVA_PACKAGE_NAME}.${OUTER_CLASS_NAME}$${typeName}"
         }
@@ -86,9 +86,9 @@ internal class JavaCodegenSpec {
         fun enum() {
             val typeName = "ExplosiveType"
             val type = enumTypeNamed(typeName)
-            val file = protoMultipleFiles()
+            val header = protoMultipleFiles()
 
-            val className = type.javaClassName(accordingTo = file)
+            val className = type.javaClassName(accordingTo = header)
 
             className.binary shouldBe "$JAVA_PACKAGE_NAME.$typeName"
         }
@@ -101,9 +101,9 @@ internal class JavaCodegenSpec {
         fun `top-level message`() {
             val typeName = "Anvil"
             val type = messageType(typeName)
-            val file = protoMultipleFiles()
+            val header = protoMultipleFiles()
 
-            val className = type.javaFile(accordingTo = file)
+            val className = type.javaFile(accordingTo = header)
 
             className.toString() shouldBe "$packageNameAsPath$typeName.java"
         }
@@ -113,9 +113,9 @@ internal class JavaCodegenSpec {
             val firstNesting = "RedDynamite"
             val typeName = "Fuse"
             val type = withDeeperNesting(typeName, firstNesting)
-            val file = protoMultipleFiles()
+            val header = protoMultipleFiles()
 
-            val className = type.javaFile(accordingTo = file)
+            val className = type.javaFile(accordingTo = header)
 
             className.toString() shouldBe "$packageNameAsPath$firstNesting.java"
         }
@@ -123,9 +123,9 @@ internal class JavaCodegenSpec {
         @Test
         fun `message with Java outer class name`() {
             val type = messageType("Fuse")
-            val file = protoSingleFile(outerClassName = javaOuterClassName)
+            val header = protoSingleFile(outerClassName = javaOuterClassName)
 
-            val className = type.javaFile(accordingTo = file)
+            val className = type.javaFile(accordingTo = header)
 
             className.toString() shouldBe "$packageNameAsPath$OUTER_CLASS_NAME.java"
         }

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaCodegenSpec.kt
@@ -52,7 +52,7 @@ internal class JavaCodegenSpec {
         fun `top-level message`() {
             val typeName = "Anvil"
             val type = messageType(typeName)
-            val header = protoMultipleFiles()
+            val header = headerMultipleFiles()
 
             val className = type.javaClassName(accordingTo = header)
 
@@ -64,7 +64,7 @@ internal class JavaCodegenSpec {
             val nestingType = "RedDynamite"
             val typeName = "Fuse"
             val type = nestedMessageType(typeName, nestingType)
-            val header = protoMultipleFiles()
+            val header = headerMultipleFiles()
 
             val className = type.javaClassName(accordingTo = header)
 
@@ -75,7 +75,7 @@ internal class JavaCodegenSpec {
         fun `message with Java outer class name`() {
             val typeName = "Fuse"
             val type = messageType(typeName)
-            val header = protoSingleFile(outerClassName = javaOuterClassName)
+            val header = headerSingleFile(outerClassName = javaOuterClassName)
 
             val className = type.javaClassName(accordingTo = header)
 
@@ -86,7 +86,7 @@ internal class JavaCodegenSpec {
         fun enum() {
             val typeName = "ExplosiveType"
             val type = enumTypeNamed(typeName)
-            val header = protoMultipleFiles()
+            val header = headerMultipleFiles()
 
             val className = type.javaClassName(accordingTo = header)
 
@@ -101,7 +101,7 @@ internal class JavaCodegenSpec {
         fun `top-level message`() {
             val typeName = "Anvil"
             val type = messageType(typeName)
-            val header = protoMultipleFiles()
+            val header = headerMultipleFiles()
 
             val className = type.javaFile(accordingTo = header)
 
@@ -113,7 +113,7 @@ internal class JavaCodegenSpec {
             val firstNesting = "RedDynamite"
             val typeName = "Fuse"
             val type = withDeeperNesting(typeName, firstNesting)
-            val header = protoMultipleFiles()
+            val header = headerMultipleFiles()
 
             val className = type.javaFile(accordingTo = header)
 
@@ -123,7 +123,7 @@ internal class JavaCodegenSpec {
         @Test
         fun `message with Java outer class name`() {
             val type = messageType("Fuse")
-            val header = protoSingleFile(outerClassName = javaOuterClassName)
+            val header = headerSingleFile(outerClassName = javaOuterClassName)
 
             val className = type.javaFile(accordingTo = header)
 
@@ -132,14 +132,14 @@ internal class JavaCodegenSpec {
     }
 }
 
-private fun protoSingleFile(outerClassName: Option? = null) = protoFileHeader {
+private fun headerSingleFile(outerClassName: Option? = null) = protoFileHeader {
     option.apply {
         add(javaPackage)
         outerClassName?.let { add(it) }
     }
 }
 
-private fun protoMultipleFiles(outerClassName: Option? = null) = protoFileHeader {
+private fun headerMultipleFiles(outerClassName: Option? = null) = protoFileHeader {
     option.apply {
         add(javaPackage)
         add(javaMultipleFiles)

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaSourceFileTest.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/JavaSourceFileTest.kt
@@ -46,7 +46,7 @@ private const val PACKAGE = "example"
 private val PERSON_NAME = typeName(PACKAGE, "PersonName")
 private val ACCOUNT_TYPE = typeName(PACKAGE, "AccountType")
 
-internal class `'SourceFile' with Java should` : WithSourceFileSet() {
+internal class `'SourceFile' with Java should` : WithSourceProtoFileSetHeaderHeader() {
 
     private lateinit var file: SourceFile
 

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/SourceFileJavaSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/SourceFileJavaSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import io.spine.protodata.renderer.SourceFile
 import io.spine.protodata.renderer.codeLine
 import kotlin.io.path.Path
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -46,7 +47,8 @@ private const val PACKAGE = "example"
 private val PERSON_NAME = typeName(PACKAGE, "PersonName")
 private val ACCOUNT_TYPE = typeName(PACKAGE, "AccountType")
 
-internal class `'SourceFile' with Java should` : WithSourceProtoFileSetHeaderHeader() {
+@DisplayName("`SourceFile` with Java should")
+internal class SourceFileJavaSpec : WithSourceFileSet() {
 
     private lateinit var file: SourceFile
 

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/TestExts.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/TestExts.kt
@@ -28,6 +28,6 @@ import java.nio.file.Path
 import kotlin.io.path.Path
 
 /**
- * Obtains a Java file path, assuming this string is a fully-qualified class name.
+ * Obtains a Java file path, assuming this string is a fully qualified class name.
  */
 internal fun String.toSourcePath(): Path = Path(replace(".", "//") + ".java")

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/WithSourceFileSet.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/WithSourceFileSet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ internal const val JAVA_FILE = "java/org/example/Test.java"
 /**
  * A base for test cases that require a source file set with a Java file to run.
  */
-internal open class WithSourceProtoFileSetHeaderHeader protected constructor() {
+internal open class WithSourceFileSet protected constructor() {
 
     protected lateinit var sources: List<SourceFileSet>
         private set

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/WithSourceProtoFileSetHeaderHeader.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/WithSourceProtoFileSetHeaderHeader.kt
@@ -38,7 +38,7 @@ internal const val JAVA_FILE = "java/org/example/Test.java"
 /**
  * A base for test cases that require a source file set with a Java file to run.
  */
-internal open class WithSourceFileSet protected constructor() {
+internal open class WithSourceProtoFileSetHeaderHeader protected constructor() {
 
     protected lateinit var sources: List<SourceFileSet>
         private set

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/GeneratedTypeAnnotationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/GeneratedTypeAnnotationSpec.kt
@@ -33,7 +33,7 @@ import io.spine.base.Time
 import io.spine.protodata.Constants.CLI_APP_CLASS
 import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.codegen.java.JAVA_FILE
-import io.spine.protodata.codegen.java.WithSourceFileSet
+import io.spine.protodata.codegen.java.WithSourceProtoFileSetHeaderHeader
 import io.spine.protodata.codegen.java.annotation.GeneratedTypeAnnotation.Companion.currentDateTime
 import io.spine.protodata.renderer.SourceFile
 import io.spine.time.testing.FrozenMadHatterParty
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`GeneratedTypeAnnotation` renderer should")
-internal class GeneratedTypeAnnotationSpec : WithSourceFileSet() {
+internal class GeneratedTypeAnnotationSpec : WithSourceProtoFileSetHeaderHeader() {
 
     @Test
     fun `add the annotation, assuming 'PROTODATA_CLI' as the default generator`() {

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/GeneratedTypeAnnotationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/GeneratedTypeAnnotationSpec.kt
@@ -33,7 +33,7 @@ import io.spine.base.Time
 import io.spine.protodata.Constants.CLI_APP_CLASS
 import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.codegen.java.JAVA_FILE
-import io.spine.protodata.codegen.java.WithSourceProtoFileSetHeaderHeader
+import io.spine.protodata.codegen.java.WithSourceFileSet
 import io.spine.protodata.codegen.java.annotation.GeneratedTypeAnnotation.Companion.currentDateTime
 import io.spine.protodata.renderer.SourceFile
 import io.spine.time.testing.FrozenMadHatterParty
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`GeneratedTypeAnnotation` renderer should")
-internal class GeneratedTypeAnnotationSpec : WithSourceProtoFileSetHeaderHeader() {
+internal class GeneratedTypeAnnotationSpec : WithSourceFileSet() {
 
     @Test
     fun `add the annotation, assuming 'PROTODATA_CLI' as the default generator`() {

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotationSpec.kt
@@ -30,7 +30,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.codegen.java.JAVA_FILE
-import io.spine.protodata.codegen.java.WithSourceProtoFileSetHeaderHeader
+import io.spine.protodata.codegen.java.WithSourceFileSet
 import io.spine.protodata.config.Configuration
 import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
 import kotlin.io.path.Path
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`SuppressRenderer` should")
-internal class SuppressWarningsAnnotationSpec : WithSourceProtoFileSetHeaderHeader() {
+internal class SuppressWarningsAnnotationSpec : WithSourceFileSet() {
 
     companion object {
         val emptyRequest: CodeGeneratorRequest = CodeGeneratorRequest.getDefaultInstance()

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotationSpec.kt
@@ -30,7 +30,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.codegen.java.JAVA_FILE
-import io.spine.protodata.codegen.java.WithSourceFileSet
+import io.spine.protodata.codegen.java.WithSourceProtoFileSetHeaderHeader
 import io.spine.protodata.config.Configuration
 import io.spine.protodata.config.ConfigurationFormat.PROTO_JSON
 import kotlin.io.path.Path
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`SuppressRenderer` should")
-internal class SuppressWarningsAnnotationSpec : WithSourceFileSet() {
+internal class SuppressWarningsAnnotationSpec : WithSourceProtoFileSetHeaderHeader() {
 
     companion object {
         val emptyRequest: CodeGeneratorRequest = CodeGeneratorRequest.getDefaultInstance()

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,14 +47,6 @@ dependencies {
 
     testImplementation(project(":test-env"))
     testImplementation(JUnit.params)
-}
-
-modelCompiler {
-    java {
-        codegen {
-            validation { skipValidation() }
-        }
-    }
 }
 
 apply<IncrementGuard>()

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/DependencyView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/DependencyView.kt
@@ -28,7 +28,7 @@ package io.spine.protodata.backend
 
 import io.spine.core.External
 import io.spine.core.Subscribe
-import io.spine.protodata.FilePath
+import io.spine.protodata.File
 import io.spine.protodata.ProtobufDependency
 import io.spine.protodata.event.DependencyDiscovered
 import io.spine.protodata.plugin.View
@@ -38,11 +38,11 @@ import io.spine.server.entity.alter
  * A view of a dependency Proto file.
  */
 internal class DependencyView :
-    View<FilePath, ProtobufDependency, ProtobufDependency.Builder>() {
+    View<File, ProtobufDependency, ProtobufDependency.Builder>() {
 
     @Subscribe
     internal fun on(@External e: DependencyDiscovered) = alter {
-        filePath = e.path
+        file = e.path
         source = e.source
     }
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/DependencyView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/DependencyView.kt
@@ -43,6 +43,6 @@ internal class DependencyView :
     @Subscribe
     internal fun on(@External e: DependencyDiscovered) = alter {
         filePath = e.path
-        file = e.file
+        source = e.source
     }
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ internal class ProtoSourceFileView
 
     @Subscribe
     fun on(@External e: FieldEntered) = modifyType(e.type) {
-        if (e.field.isPartOfOneof()) {
+        if (e.field.isPartOfOneof) {
             val oneof = findOneof(e.field.oneofName)
             oneof.addField(e.field)
         } else {

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
@@ -31,7 +31,7 @@ import io.spine.core.Subscribe
 import io.spine.protodata.EnumType
 import io.spine.protodata.Field
 import io.spine.protodata.FieldName
-import io.spine.protodata.FilePath
+import io.spine.protodata.File
 import io.spine.protodata.MessageType
 import io.spine.protodata.OneofGroup
 import io.spine.protodata.OneofName
@@ -63,7 +63,7 @@ import io.spine.server.entity.alter
  * A view which collects information about a Protobuf source file.
  */
 internal class ProtoSourceFileView
-    : View<FilePath, ProtobufSourceFile, ProtobufSourceFile.Builder>() {
+    : View<File, ProtobufSourceFile, ProtobufSourceFile.Builder>() {
 
     @Subscribe
     fun on(@External e: FileEntered) = alter {

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
@@ -67,13 +67,13 @@ internal class ProtoSourceFileView
 
     @Subscribe
     fun on(@External e: FileEntered) = alter {
-        filePath = e.file.path
-        file = e.file
+        filePath = e.path
+        header = e.header
     }
 
     @Subscribe
     fun on(@External e: FileOptionDiscovered) = alter {
-        fileBuilder.addOption(e.option)
+        headerBuilder.addOption(e.option)
     }
 
     @Subscribe

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/ProtoSourceFileView.kt
@@ -67,7 +67,7 @@ internal class ProtoSourceFileView
 
     @Subscribe
     fun on(@External e: FileEntered) = alter {
-        filePath = e.path
+        file = e.file
         header = e.header
     }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/SecureRandomString.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/SecureRandomString.kt
@@ -39,7 +39,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * @see <a href="https://github.com/nikbucher/j-nanoid">j-nanoid</a>
  */
 @OptIn(ExperimentalEncodingApi::class)
-internal object SecureRandomString {
+public object SecureRandomString {
 
     private const val DEFAULT_SIZE = 20
 
@@ -51,7 +51,7 @@ internal object SecureRandomString {
         Base64.UrlSafe
     }
 
-    fun generate(size: Int = DEFAULT_SIZE): String {
+    public fun generate(size: Int = DEFAULT_SIZE): String {
         val buffer = ByteArray(size)
         random.nextBytes(buffer)
         return encoder.encode(buffer)

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/TypeExtensions.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/TypeExtensions.kt
@@ -30,11 +30,14 @@ import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.BOOL
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.BYTES
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.DOUBLE
+import com.google.protobuf.Descriptors.FieldDescriptor.Type.ENUM
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.FIXED32
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.FIXED64
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.FLOAT
+import com.google.protobuf.Descriptors.FieldDescriptor.Type.GROUP
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.INT32
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.INT64
+import com.google.protobuf.Descriptors.FieldDescriptor.Type.MESSAGE
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.SFIXED32
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.SFIXED64
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.SINT32
@@ -43,7 +46,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor.Type.STRING
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.UINT32
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.UINT64
 import com.google.protobuf.Descriptors.FileDescriptor
-import io.spine.protodata.File.SyntaxVersion
+import io.spine.protodata.ProtoFileHeader.SyntaxVersion
 import io.spine.protodata.PrimitiveType
 import io.spine.protodata.PrimitiveType.TYPE_BOOL
 import io.spine.protodata.PrimitiveType.TYPE_BYTES
@@ -70,9 +73,9 @@ import io.spine.protodata.name
  */
 internal fun FieldDescriptor.type(): Type {
     return when (type) {
-        FieldDescriptor.Type.ENUM -> enum(this)
-        FieldDescriptor.Type.MESSAGE -> message(this)
-        FieldDescriptor.Type.GROUP -> error("Cannot process field `$fullName` of type `$type`.")
+        ENUM -> enum(this)
+        MESSAGE -> message(this)
+        GROUP -> error("Cannot process the field `$fullName` of type `$type`.")
         else -> primitiveType().asType()
     }
 }
@@ -105,14 +108,14 @@ internal fun FieldDescriptor.primitiveType(): PrimitiveType =
 /**
  * Obtains the type of the given [field] as an enum type.
  */
-internal fun enum(field: FieldDescriptor): Type = type {
+private fun enum(field: FieldDescriptor): Type = type {
     enumeration = field.enumType.name()
 }
 
 /**
- * Obtains the type of the given [field] as message type.
+ * Obtains the type of the given [field] as a message type.
  */
-internal fun message(field: FieldDescriptor): Type = type {
+private fun message(field: FieldDescriptor): Type = type {
     message = field.messageType.name()
 }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -51,7 +51,7 @@ import io.spine.protodata.enumConstant
 import io.spine.protodata.field
 import io.spine.protodata.filePath
 import io.spine.protodata.name
-import io.spine.protodata.path
+import io.spine.protodata.file
 import io.spine.protodata.protoFileHeader
 import io.spine.protodata.rpc
 
@@ -200,7 +200,7 @@ internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
  * @see toFileWithOptions
  */
 internal fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
-    path = path()
+    file = file()
     packageName = `package`
     syntax = this@toHeader.syntaxVersion()
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -185,10 +185,10 @@ internal fun buildRpc(
 /**
  * Extracts metadata from this file descriptor, including file options.
  *
- * @see toFile
+ * @see toHeader
  */
 internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
-    val file = toFile()
+    val file = toHeader()
     return file.copy {
         option.addAll(options.toList())
     }
@@ -199,10 +199,10 @@ internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
  *
  * @see toFileWithOptions
  */
-internal fun FileDescriptor.toFile(): ProtoFileHeader = protoFileHeader {
+internal fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
     path = path()
     packageName = `package`
-    syntax = this@toFile.syntaxVersion()
+    syntax = this@toHeader.syntaxVersion()
 }
 
 /**

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -49,9 +49,8 @@ import io.spine.protodata.constantName
 import io.spine.protodata.copy
 import io.spine.protodata.enumConstant
 import io.spine.protodata.field
-import io.spine.protodata.filePath
-import io.spine.protodata.name
 import io.spine.protodata.file
+import io.spine.protodata.name
 import io.spine.protodata.protoFileHeader
 import io.spine.protodata.rpc
 
@@ -208,6 +207,6 @@ internal fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
 /**
  * Obtains the file path from this file descriptor.
  */
-internal fun FileDescriptorProto.toFilePath() = filePath {
-    value = name
+internal fun FileDescriptorProto.toFile() = file {
+    path = name
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -67,8 +67,8 @@ internal fun FieldDescriptor.buildFieldWithOptions(
     val field = buildField(this, declaringType, documentation)
     return field.copy {
         // There are several similar expressions in this file. Sadly, they have no common
-        // compile-time type which would allow us to extract the duplicates into a function.
-        option.addAll(listOptions(options))
+        // compile-time type that would allow us to extract the duplicates into a function.
+        option.addAll(options.toList())
     }
 }
 
@@ -124,7 +124,7 @@ internal fun EnumValueDescriptor.buildConstantWithOptions(
 ): EnumConstant {
     val constant = buildConstant(this, declaringType, documentation)
     return constant.copy {
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
     }
 }
 
@@ -158,7 +158,7 @@ internal fun MethodDescriptor.buildRpcWithOptions(
 ): Rpc {
     val rpc = buildRpc(this, declaringService, documentation)
     return rpc.copy {
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
     }
 }
 
@@ -175,7 +175,7 @@ internal fun buildRpc(
     documentation: Documentation
 ) = rpc {
     name = desc.name()
-    cardinality = desc.cardinality()
+    cardinality = desc.cardinality
     requestType = desc.inputType.name()
     responseType = desc.outputType.name()
     doc = documentation.forRpc(desc)
@@ -190,7 +190,7 @@ internal fun buildRpc(
 internal fun FileDescriptor.toFileWithOptions(): File {
     val file = toFile()
     return file.copy {
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
     }
 }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -36,7 +36,7 @@ import io.spine.protodata.EnumConstant
 import io.spine.protodata.Field
 import io.spine.protodata.FieldKt
 import io.spine.protodata.FieldKt.ofMap
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.Rpc
 import io.spine.protodata.ServiceName
 import io.spine.protodata.TypeName
@@ -49,10 +49,10 @@ import io.spine.protodata.constantName
 import io.spine.protodata.copy
 import io.spine.protodata.enumConstant
 import io.spine.protodata.field
-import io.spine.protodata.file
 import io.spine.protodata.filePath
 import io.spine.protodata.name
 import io.spine.protodata.path
+import io.spine.protodata.protoFileHeader
 import io.spine.protodata.rpc
 
 /**
@@ -187,7 +187,7 @@ internal fun buildRpc(
  *
  * @see toFile
  */
-internal fun FileDescriptor.toFileWithOptions(): File {
+internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
     val file = toFile()
     return file.copy {
         option.addAll(options.toList())
@@ -199,7 +199,7 @@ internal fun FileDescriptor.toFileWithOptions(): File {
  *
  * @see toFileWithOptions
  */
-internal fun FileDescriptor.toFile(): File = file {
+internal fun FileDescriptor.toFile(): ProtoFileHeader = protoFileHeader {
     path = path()
     packageName = `package`
     syntax = this@toFile.syntaxVersion()

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/AstComponents.kt
@@ -184,10 +184,10 @@ internal fun buildRpc(
 /**
  * Extracts metadata from this file descriptor, including file options.
  *
- * @see toHeader
+ * @see toHeaderWithoutOptions
  */
-internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
-    val file = toHeader()
+internal fun FileDescriptor.toHeader(): ProtoFileHeader {
+    val file = toHeaderWithoutOptions()
     return file.copy {
         option.addAll(options.toList())
     }
@@ -196,12 +196,12 @@ internal fun FileDescriptor.toFileWithOptions(): ProtoFileHeader {
 /**
  * Extracts metadata from this file descriptor, excluding file options.
  *
- * @see toFileWithOptions
+ * @see toHeader
  */
-internal fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
+internal fun FileDescriptor.toHeaderWithoutOptions(): ProtoFileHeader = protoFileHeader {
     file = file()
     packageName = `package`
-    syntax = this@toHeader.syntaxVersion()
+    syntax = this@toHeaderWithoutOptions.syntaxVersion()
 }
 
 /**

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -82,13 +82,13 @@ private class ProtoFileEvents(
     suspend fun SequenceScope<EventMessage>.produceFileEvents() {
         yield(
             FileEntered.newBuilder()
-                .setPath(header.path)
+                .setPath(header.file)
                 .setHeader(header)
                 .build()
         )
         produceOptionEvents(fileDescriptor.options) {
             FileOptionDiscovered.newBuilder()
-                .setFile(header.path)
+                .setFile(header.file)
                 .setOption(it)
                 .build()
         }
@@ -106,7 +106,7 @@ private class ProtoFileEvents(
         }
         yield(
             FileExited.newBuilder()
-                .setFile(header.path)
+                .setFile(header.file)
                 .build()
         )
     }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -69,7 +69,7 @@ private class ProtoFileEvents(
     private val fileDescriptor: FileDescriptor
 ) {
 
-    private val header = fileDescriptor.toHeader()
+    private val header = fileDescriptor.toHeaderWithoutOptions()
 
     private val documentation = Documentation.fromFile(fileDescriptor)
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -82,7 +82,7 @@ private class ProtoFileEvents(
     suspend fun SequenceScope<EventMessage>.produceFileEvents() {
         yield(
             FileEntered.newBuilder()
-                .setPath(header.file)
+                .setFile(header.file)
                 .setHeader(header)
                 .build()
         )

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -69,7 +69,7 @@ private class ProtoFileEvents(
     private val fileDescriptor: FileDescriptor
 ) {
 
-    private val file = fileDescriptor.toFile()
+    private val header = fileDescriptor.toHeader()
 
     private val documentation = Documentation.fromFile(fileDescriptor)
 
@@ -82,31 +82,31 @@ private class ProtoFileEvents(
     suspend fun SequenceScope<EventMessage>.produceFileEvents() {
         yield(
             FileEntered.newBuilder()
-                .setPath(file.path)
-                .setFile(file)
+                .setPath(header.path)
+                .setHeader(header)
                 .build()
         )
         produceOptionEvents(fileDescriptor.options) {
             FileOptionDiscovered.newBuilder()
-                .setFile(file.path)
+                .setFile(header.path)
                 .setOption(it)
                 .build()
         }
-        val messageEvents = MessageCompilerEvents(file, documentation)
+        val messageEvents = MessageCompilerEvents(header, documentation)
         fileDescriptor.messageTypes.forEach {
             messageEvents.apply { produceMessageEvents(it) }
         }
-        val enumEvents = EnumCompilerEvents(file, documentation)
+        val enumEvents = EnumCompilerEvents(header, documentation)
         fileDescriptor.enumTypes.forEach {
             enumEvents.apply { produceEnumEvents(it) }
         }
-        val serviceEvents = ServiceCompilerEvents(file, documentation)
+        val serviceEvents = ServiceCompilerEvents(header, documentation)
         fileDescriptor.services.forEach {
             serviceEvents.apply { produceServiceEvents(it) }
         }
         yield(
             FileExited.newBuilder()
-                .setFile(file.path)
+                .setFile(header.path)
                 .build()
         )
     }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -133,7 +133,7 @@ private class DefinitionFactory(
         name = typeName
         file = path
         doc = documentation.forMessage(this@asMessage)
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
         if (containingType != null) {
             declaredIn = containingType.name()
         }
@@ -147,14 +147,14 @@ private class DefinitionFactory(
         val groupName = name()
         name = groupName
         field.addAll(listFields(fields, typeName))
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
         doc = documentation.forOneof(this@asOneof)
     }
 
     private fun EnumDescriptor.asEnum() = enumType {
         val typeName = name()
         name = typeName
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
         file = path
         constant.addAll(values.map { it.buildConstantWithOptions(typeName, documentation) })
         if (containingType != null) {
@@ -168,7 +168,7 @@ private class DefinitionFactory(
         name = serviceName
         file = path
         rpc.addAll(methods.map { it.buildRpcWithOptions(serviceName, documentation) })
-        option.addAll(listOptions(options))
+        option.addAll(options.toList())
         doc = documentation.forService(this@asService)
     }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -67,7 +67,7 @@ private fun FileDescriptor.toPbSourceFile(): ProtobufSourceFile {
     val definitions = DefinitionFactory(this, path, doc)
     return protobufSourceFile {
         filePath = path
-        file = toFileWithOptions()
+        header = toFileWithOptions()
         with(definitions) {
             type.putAll(messageTypes().associateByUrl())
             enumType.putAll(enumTypes().associateByUrl())

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -45,7 +45,7 @@ import io.spine.protodata.event.dependencyDiscovered
 import io.spine.protodata.messageType
 import io.spine.protodata.name
 import io.spine.protodata.oneofGroup
-import io.spine.protodata.path
+import io.spine.protodata.file
 import io.spine.protodata.protobufSourceFile
 import io.spine.protodata.service
 
@@ -56,13 +56,13 @@ import io.spine.protodata.service
  */
 internal fun discoverDependencies(fileDescriptor: FileDescriptor) =
     dependencyDiscovered {
-        val id = fileDescriptor.path()
+        val id = fileDescriptor.file()
         path = id
         file = fileDescriptor.toPbSourceFile()
     }
 
 private fun FileDescriptor.toPbSourceFile(): ProtobufSourceFile {
-    val path = path()
+    val path = file()
     val doc = Documentation.fromFile(this)
     val definitions = DefinitionFactory(this, path, doc)
     return protobufSourceFile {

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -33,7 +33,7 @@ import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.protodata.EnumType
-import io.spine.protodata.FilePath
+import io.spine.protodata.File
 import io.spine.protodata.MessageType
 import io.spine.protodata.ProtoDeclaration
 import io.spine.protodata.ProtobufSourceFile
@@ -42,10 +42,10 @@ import io.spine.protodata.TypeName
 import io.spine.protodata.backend.Documentation
 import io.spine.protodata.enumType
 import io.spine.protodata.event.dependencyDiscovered
+import io.spine.protodata.file
 import io.spine.protodata.messageType
 import io.spine.protodata.name
 import io.spine.protodata.oneofGroup
-import io.spine.protodata.file
 import io.spine.protodata.protobufSourceFile
 import io.spine.protodata.service
 
@@ -87,7 +87,7 @@ private fun <T : ProtoDeclaration> Sequence<T>.associateByUrl() =
  */
 private class DefinitionFactory(
     private val file: FileDescriptor,
-    private val path: FilePath,
+    private val path: File,
     private val documentation: Documentation,
 ) {
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -67,7 +67,7 @@ private fun FileDescriptor.toPbSourceFile(): ProtobufSourceFile {
     val definitions = DefinitionFactory(this, path, doc)
     return protobufSourceFile {
         file = path
-        header = toFileWithOptions()
+        header = toHeader()
         with(definitions) {
             type.putAll(messageTypes().associateByUrl())
             enumType.putAll(enumTypes().associateByUrl())

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -57,7 +57,7 @@ import io.spine.protodata.service
 internal fun discoverDependencies(fileDescriptor: FileDescriptor) =
     dependencyDiscovered {
         val id = fileDescriptor.file()
-        path = id
+        file = id
         source = fileDescriptor.toPbSourceFile()
     }
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/DependencyEvents.kt
@@ -58,7 +58,7 @@ internal fun discoverDependencies(fileDescriptor: FileDescriptor) =
     dependencyDiscovered {
         val id = fileDescriptor.file()
         path = id
-        file = fileDescriptor.toPbSourceFile()
+        source = fileDescriptor.toPbSourceFile()
     }
 
 private fun FileDescriptor.toPbSourceFile(): ProtobufSourceFile {
@@ -66,7 +66,7 @@ private fun FileDescriptor.toPbSourceFile(): ProtobufSourceFile {
     val doc = Documentation.fromFile(this)
     val definitions = DefinitionFactory(this, path, doc)
     return protobufSourceFile {
-        filePath = path
+        file = path
         header = toFileWithOptions()
         with(definitions) {
             type.putAll(messageTypes().associateByUrl())

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
@@ -29,7 +29,7 @@ package io.spine.protodata.backend.event
 import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
 import io.spine.base.EventMessage
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.TypeName
 import io.spine.protodata.backend.Documentation
 import io.spine.protodata.constantName
@@ -50,15 +50,17 @@ import io.spine.protodata.name
  * Produces events for an enum.
  */
 internal class EnumCompilerEvents(
-    private val file: File,
+    private val file: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 
     /**
      * Yields compiler events for the given enum type.
      *
-     * Opens with an [EnumEntered] event. Then go the events regarding the type metadata. Then go
-     * the events regarding the enum constants. At last, closes with an [EnumExited] event.
+     * Opens with an [EnumEntered] event.
+     * Then the events regarding the type metadata go.
+     * Then go the events regarding the enum constants.
+     * At last, closes with an [EnumExited] event.
      */
     internal suspend fun SequenceScope<EventMessage>.produceEnumEvents(
         desc: EnumDescriptor,

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
@@ -50,7 +50,7 @@ import io.spine.protodata.name
  * Produces events for an enum.
  */
 internal class EnumCompilerEvents(
-    private val file: ProtoFileHeader,
+    private val header: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 
@@ -67,7 +67,7 @@ internal class EnumCompilerEvents(
         nestedIn: TypeName? = null
     ) {
         val typeName = desc.name()
-        val path = file.path
+        val path = header.file
         val type = enumType {
             name = typeName
             file = path
@@ -114,7 +114,7 @@ internal class EnumCompilerEvents(
             value = desc.name
         }
         val theConstant = buildConstant(desc, typeName, documentation)
-        val path = file.path
+        val path = header.file
         yield(
             enumConstantEntered {
                 file = path

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -56,7 +56,7 @@ import io.spine.protodata.oneofGroup
  * Produces events for a message.
  */
 internal class MessageCompilerEvents(
-    private val file: ProtoFileHeader,
+    private val header: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 
@@ -71,7 +71,7 @@ internal class MessageCompilerEvents(
         nestedIn: TypeName? = null
     ) {
         val typeName = desc.name()
-        val path = file.path
+        val path = header.file
         val messageType = messageType {
             name = typeName
             file = path
@@ -108,7 +108,7 @@ internal class MessageCompilerEvents(
             produceMessageEvents(nestedIn = typeName, desc = it)
         }
 
-        val enums = EnumCompilerEvents(file, documentation)
+        val enums = EnumCompilerEvents(header, documentation)
         desc.enumTypes.forEach {
             enums.apply {
                 produceEnumEvents(nestedIn = typeName, desc = it)
@@ -138,7 +138,7 @@ internal class MessageCompilerEvents(
             name = oneofName
             doc = documentation.forOneof(desc)
         }
-        val path = file.path
+        val path = header.file
         yield(
             oneofGroupEntered {
                 file = path
@@ -178,7 +178,7 @@ internal class MessageCompilerEvents(
     ) {
         val fieldName = desc.name()
         val theField = buildField(desc, typeName, documentation)
-        val path = file.path
+        val path = header.file
         yield(
             fieldEntered {
                 file = path

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -30,7 +30,7 @@ import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import io.spine.base.EventMessage
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.TypeName
 import io.spine.protodata.backend.Documentation
 import io.spine.protodata.event.FieldEntered
@@ -56,7 +56,7 @@ import io.spine.protodata.oneofGroup
  * Produces events for a message.
  */
 internal class MessageCompilerEvents(
-    private val file: File,
+    private val file: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/OptionsCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/OptionsCompilerEvents.kt
@@ -55,7 +55,7 @@ internal suspend fun SequenceScope<EventMessage>.produceOptionEvents(
 }
 
 /**
- * Parses the this `options` message into a list of [Option]s.
+ * Parses this `options` message into a list of [Option]s.
  */
 internal fun ExtendableMessage<*>.toList(): List<Option> =
     parseOptions(this).toList()

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/OptionsCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/OptionsCompilerEvents.kt
@@ -55,10 +55,10 @@ internal suspend fun SequenceScope<EventMessage>.produceOptionEvents(
 }
 
 /**
- * Parses the given `options` message into a list of [Option]s.
+ * Parses the this `options` message into a list of [Option]s.
  */
-internal fun listOptions(options: ExtendableMessage<*>): List<Option> =
-    parseOptions(options).toList()
+internal fun ExtendableMessage<*>.toList(): List<Option> =
+    parseOptions(this).toList()
 
 private fun parseOptions(options: ExtendableMessage<*>): Sequence<Option> =
     sequence {

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
@@ -47,7 +47,7 @@ import io.spine.protodata.service
  * Produces events for a service.
  */
 internal class ServiceCompilerEvents(
-    private val file: ProtoFileHeader,
+    private val header: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 
@@ -60,7 +60,7 @@ internal class ServiceCompilerEvents(
     internal suspend fun SequenceScope<EventMessage>.produceServiceEvents(
         descriptor: ServiceDescriptor
     ) {
-        val path = file.path
+        val path = header.file
         val serviceName = descriptor.name()
         yield(
             serviceEntered {
@@ -94,7 +94,7 @@ internal class ServiceCompilerEvents(
         serviceName: ServiceName,
         desc: MethodDescriptor
     ) {
-        val path = file.path
+        val path = header.file
         val theRpc = buildRpc(desc, serviceName, documentation)
         yield(
             rpcEntered {

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
@@ -29,7 +29,7 @@ package io.spine.protodata.backend.event
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.base.EventMessage
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.ServiceName
 import io.spine.protodata.backend.Documentation
 import io.spine.protodata.event.ServiceEntered
@@ -47,7 +47,7 @@ import io.spine.protodata.service
  * Produces events for a service.
  */
 internal class ServiceCompilerEvents(
-    private val file: File,
+    private val file: ProtoFileHeader,
     private val documentation: Documentation
 ) {
 

--- a/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,9 @@ import io.spine.protodata.ProtobufDependency
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.asType
 import io.spine.protodata.backend.event.CompilerEvents
-import io.spine.protodata.backend.event.toFilePath
-import io.spine.protodata.option
+import io.spine.protodata.backend.event.toFile
 import io.spine.protodata.file
+import io.spine.protodata.option
 import io.spine.protodata.test.DoctorProto
 import io.spine.protodata.test.PhDProto
 import io.spine.protodata.test.XtraOptsProto
@@ -227,7 +227,7 @@ class CodeGenerationContextSpec {
                     emitCompilerEvents(pipelineId)
                     dependencyFiles = thirdPartyFiles.map {
                         blackbox.assertEntity<DependencyView, _>(
-                            it.toFilePath()
+                            it.toFile()
                         ).run {
                             exists()
                             actual()!!.state()
@@ -244,7 +244,7 @@ class CodeGenerationContextSpec {
 
                     protoSourceFiles = thirdPartyFiles.map {
                         blackbox.assertEntity<ProtoSourceFileView, _>(
-                            it.toFilePath()
+                            it.toFile()
                         ).run {
                             exists()
                             actual()!!.state() as ProtobufSourceFile

--- a/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -53,7 +53,7 @@ import io.spine.protodata.asType
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.backend.event.toFilePath
 import io.spine.protodata.option
-import io.spine.protodata.path
+import io.spine.protodata.file
 import io.spine.protodata.test.DoctorProto
 import io.spine.protodata.test.PhDProto
 import io.spine.protodata.test.XtraOptsProto
@@ -162,7 +162,7 @@ class CodeGenerationContextSpec {
         @Test
         fun `with files marked for generation`() {
             val assertSourceFile = ctx.assertEntity<ProtoSourceFileView, _>(
-                DoctorProto.getDescriptor().path()
+                DoctorProto.getDescriptor().file()
             )
             assertSourceFile.exists()
 
@@ -187,7 +187,7 @@ class CodeGenerationContextSpec {
         @Test
         fun `with dependencies`() {
             val assertSourceFile = ctx.assertEntity(
-                AnyProto.getDescriptor().path(),
+                AnyProto.getDescriptor().file(),
                 DependencyView::class.java
             )
             assertSourceFile.exists()
@@ -196,7 +196,7 @@ class CodeGenerationContextSpec {
         @Test
         fun `with respect for custom options among the source files`() {
             val phdFile = ctx.assertEntity<ProtoSourceFileView, _>(
-                PhDProto.getDescriptor().path()
+                PhDProto.getDescriptor().file()
             ).actual()!!.state() as ProtobufSourceFile
             val paperType = phdFile.typeMap.values.find { it.name.simpleName == "Paper" }!!
             val keywordsField = paperType.fieldList.find { it.name.value == "keywords" }!!

--- a/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/compiler/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -232,7 +232,7 @@ class CodeGenerationContextSpec {
                             exists()
                             actual()!!.state()
                         }
-                    }.map { state -> (state as ProtobufDependency).file }
+                    }.map { state -> (state as ProtobufDependency).source }
                 }
             }
 

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
@@ -34,7 +34,7 @@ public object Names {
     /**
      * The ID of the Protobuf Gradle Plugin.
      */
-    public const val PROTOBUF_PLUGIN: String = "com.google.protobuf"
+    public const val PROTOBUF_GRADLE_PLUGIN_ID: String = "com.google.protobuf"
 
     /**
      * The name of the `protoc` plugin exposed by ProtoData.

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
@@ -58,7 +58,7 @@ public object Names {
     public const val USER_CLASSPATH_CONFIGURATION: String = "protoData"
 
     /**
-     * The name of the configuration containing to ProtoData `fat-cli` artifact.
+     * The name of the configuration containing ProtoData `fat-cli` artifact.
      */
     public const val PROTO_DATA_RAW_ARTIFACT: String = "protoDataRawArtifact"
 }

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Names.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,11 @@ package io.spine.protodata.gradle
 public object Names {
 
     /**
+     * The ID of the Protobuf Gradle Plugin.
+     */
+    public const val PROTOBUF_PLUGIN: String = "com.google.protobuf"
+
+    /**
      * The name of the `protoc` plugin exposed by ProtoData.
      */
     public const val PROTODATA_PROTOC_PLUGIN: String = "protodata"
@@ -45,4 +50,15 @@ public object Names {
      * The name of the Gradle extension added by ProtoData Gradle plugin.
      */
     public const val EXTENSION_NAME: String = "protoData"
+
+    /**
+     * The name of the Gradle Configuration created by ProtoData Gradle plugin for holding
+     * user-defined classpath.
+     */
+    public const val USER_CLASSPATH_CONFIGURATION: String = "protoData"
+
+    /**
+     * The name of the configuration containing to ProtoData `fat-cli` artifact.
+     */
+    public const val PROTO_DATA_RAW_ARTIFACT: String = "protoDataRawArtifact"
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -56,12 +56,12 @@ import org.gradle.api.tasks.SourceSet
 /**
  * A task which executes a single ProtoData command.
  *
- * This class is public to allow users find ProtoData tasks by their type. This is useful
- * to configure task dependencies, enable and disable individual tasks, add conditions
- * via `onlyIf { }`, etc.
+ * This class is public to allow users to find ProtoData tasks by their type.
+ * This is useful to configure task dependencies, enable and disable individual tasks,
+ * add conditions via `onlyIf { }`, etc.
  *
  * Users should NOT change the CLI command, user directory, etc. directly.
- * Please refer to the `protoData { }` extension to configure ProtoData.
+ * Please refer to the `protoData { }` extension configuring ProtoData.
  */
 public abstract class LaunchProtoData : JavaExec() {
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -37,7 +37,7 @@ import io.spine.protodata.gradle.CleanTask
 import io.spine.protodata.gradle.CodegenSettings
 import io.spine.protodata.gradle.LaunchTask
 import io.spine.protodata.gradle.Names.EXTENSION_NAME
-import io.spine.protodata.gradle.Names.PROTOBUF_PLUGIN
+import io.spine.protodata.gradle.Names.PROTOBUF_GRADLE_PLUGIN_ID
 import io.spine.protodata.gradle.Names.PROTODATA_PROTOC_PLUGIN
 import io.spine.protodata.gradle.Names.PROTO_DATA_RAW_ARTIFACT
 import io.spine.protodata.gradle.Names.USER_CLASSPATH_CONFIGURATION
@@ -216,7 +216,7 @@ private fun Project.createCleanTask(sourceSet: SourceSet, ext: Extension) {
 
 private fun Project.configureWithProtobufPlugin(protoDataVersion: String, ext: Extension) {
     val protocPlugin = ProtocPluginArtifact(protoDataVersion)
-    pluginManager.withPlugin(PROTOBUF_PLUGIN) {
+    pluginManager.withPlugin(PROTOBUF_GRADLE_PLUGIN_ID) {
         configureProtobufPlugin(protocPlugin, ext)
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,10 @@ import io.spine.protodata.gradle.CleanTask
 import io.spine.protodata.gradle.CodegenSettings
 import io.spine.protodata.gradle.LaunchTask
 import io.spine.protodata.gradle.Names.EXTENSION_NAME
+import io.spine.protodata.gradle.Names.PROTOBUF_PLUGIN
 import io.spine.protodata.gradle.Names.PROTODATA_PROTOC_PLUGIN
+import io.spine.protodata.gradle.Names.PROTO_DATA_RAW_ARTIFACT
+import io.spine.protodata.gradle.Names.USER_CLASSPATH_CONFIGURATION
 import io.spine.protodata.gradle.ProtocPluginArtifact
 import io.spine.tools.code.manifest.Version
 import io.spine.tools.gradle.project.sourceSets
@@ -105,13 +108,15 @@ public class Plugin : GradlePlugin<Project> {
     }
 }
 
-private const val PROTO_DATA_RAW_ARTIFACT = "protoDataRawArtifact"
-
 /**
  * The name of the Gradle Configuration created by ProtoData Gradle plugin for holding
  * user-defined classpath.
  */
-public const val USER_CLASSPATH_CONFIGURATION_NAME: String = "protoData"
+@Deprecated(
+    "Use `Names.USER_CLASSPATH_CONFIGURATION` instead.",
+    ReplaceWith("Names.USER_CLASSPATH_CONFIGURATION")
+)
+public const val USER_CLASSPATH_CONFIGURATION_NAME: String = USER_CLASSPATH_CONFIGURATION
 
 private fun Project.createExtension(): Extension {
     val extension = Extension(this)
@@ -130,7 +135,7 @@ private fun Project.createConfigurations(protoDataVersion: String) {
     val cliDependency = Artifacts.fatCli(protoDataVersion)
     dependencies.add(artifactConfig.name, cliDependency)
 
-    configurations.create(USER_CLASSPATH_CONFIGURATION_NAME) {
+    configurations.create(USER_CLASSPATH_CONFIGURATION) {
         it.exclude(group = Artifacts.group, module = Artifacts.compiler)
     }
 }
@@ -139,7 +144,7 @@ private val Project.protoDataRawArtifact: Configuration
     get() = configurations.getByName(PROTO_DATA_RAW_ARTIFACT)
 
 private val Project.userClasspath: Configuration
-    get() = configurations.getByName(USER_CLASSPATH_CONFIGURATION_NAME)
+    get() = configurations.getByName(USER_CLASSPATH_CONFIGURATION)
 
 /**
  * Creates [LaunchProtoData] and `clean` task for all source sets of this project
@@ -208,11 +213,6 @@ private fun Project.createCleanTask(sourceSet: SourceSet, ext: Extension) {
         launchTask.mustRunAfter(this)
     }
 }
-
-/**
- * The ID of the Protobuf Gradle Plugin.
- */
-private const val PROTOBUF_PLUGIN = "com.google.protobuf"
 
 private fun Project.configureWithProtobufPlugin(protoDataVersion: String, ext: Extension) {
     val protocPlugin = ProtocPluginArtifact(protoDataVersion)
@@ -285,8 +285,8 @@ private fun Project.configureProtoTask(task: GenerateProtoTask, ext: Extension) 
  *
  * The current Protobuf support of Kotlin is based on Java codegen. Therefore,
  * it's likely that Java would be enabled in the project for Kotlin proto
- * code to be generated. Though, it may change someday and Kotlin support of Protobuf would be
- * self-sufficient. This method assumes such case when it checks the presence of
+ * code to be generated. Though, it may change someday, and Kotlin support for Protobuf would be
+ * self-sufficient. This method assumes such a case when it checks the presence of
  * Kotlin compilation tasks.
  */
 private fun Project.hasJavaOrKotlin(): Boolean {
@@ -385,6 +385,7 @@ private fun Project.configureIdea() {
             val protocOutput = file(generatedSourceProtoDir)
             val idea = extensions.getByType<IdeaModel>()
             with(idea.module) {
+                excludeDirs.add(protocOutput)
                 sourceDirs = filterSources(sourceDirs, protocOutput)
                 testSources.filter { !it.residesIn(protocOutput) }
                 generatedSourceDirs = filterSources(generatedSourceDirs, protocOutput)

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:14 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:19 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Tue Nov 21 02:49:14 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 02:49:18 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -122,7 +122,7 @@
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -566,9 +566,10 @@
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -942,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1074,7 +1075,7 @@ This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -1530,9 +1531,9 @@ This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -1725,10 +1726,6 @@ This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1742,10 +1739,6 @@ This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.0.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1906,7 +1899,7 @@ This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2033,7 +2026,7 @@ This report was generated on **Mon Nov 20 14:44:29 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -2469,6 +2462,7 @@ This report was generated on **Mon Nov 20 14:44:29 WET 2023** using [Gradle-Lice
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -2829,7 +2823,7 @@ This report was generated on **Mon Nov 20 14:44:29 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2956,7 +2950,7 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -3400,9 +3394,9 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -3595,10 +3589,6 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3612,10 +3602,6 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.0.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3776,7 +3762,7 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3903,7 +3889,7 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -4347,9 +4333,10 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -4723,7 +4710,7 @@ This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4850,7 +4837,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -5290,6 +5277,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -5650,7 +5638,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5777,7 +5765,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -6266,6 +6254,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -6748,7 +6737,7 @@ This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7518,7 +7507,7 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7645,7 +7634,7 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -8096,9 +8085,9 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
      * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
      * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
@@ -8291,10 +8280,6 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8308,10 +8293,6 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.0.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8472,4 +8453,4 @@ This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 14:44:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:28:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-api:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -942,12 +942,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:36 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-cli:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1906,12 +1906,12 @@ This report was generated on **Sun Nov 05 16:40:36 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:37 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2829,959 +2829,12 @@ This report was generated on **Sun Nov 05 16:40:37 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:37 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.14.3`
-
-## Runtime
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
-     * **Project URL:** [http://source.android.com/](http://source.android.com/)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.22.0.
-     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.21.1.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
-     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
-     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-util. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.26.0.
-     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
-
-1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.37.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
-     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
-     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.1.
-     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-## Compile, tests, and tooling
-1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
-     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
-     * **License:** Public Domain
-
-1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
-     * **Project URL:** [https://jcommander.org](https://jcommander.org)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.12.7.**No license information found**
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.12.7.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.12.7.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.12.7.1.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.12.7.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-jaxb-annotations. **Version** : 2.12.7.
-     * **Project URL:** [https://github.com/FasterXML/jackson-modules-base](https://github.com/FasterXML/jackson-modules-base)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.12.7.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.2.4.
-     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
-     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
-     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
-
-1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
-     * **Project URL:** [http://source.android.com/](http://source.android.com/)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.22.0.
-     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.1.
-     * **Project URL:** [https://github.com/google/auto/tree/master/common](https://github.com/google/auto/tree/master/common)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/auto/tree/master/service](https://github.com/google/auto/tree/master/service)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
-     * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
-     * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.21.1.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.21.1.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
-     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
-     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.1-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava-parent. **Version** : 32.1.1-jre.**No license information found**
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 31.1-jre.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
-     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
-     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 2.7.0.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
-
-1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
-     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
-     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.**No license information found**
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
-     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
-     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-
-1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : grpc-util. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
-     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-api. **Version** : 5.5.5.**No license information found**
-1.  **Group** : io.kotest. **Name** : kotest-assertions-api-jvm. **Version** : 5.5.5.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 5.5.5.**No license information found**
-1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 5.5.5.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 5.5.5.**No license information found**
-1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 5.5.5.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 5.5.5.**No license information found**
-1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 5.5.5.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.26.0.
-     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
-     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
-1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
-     * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
-     * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
-     * **License:** [Eclipse Public License v. 2.0](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
-     * **License:** [GNU General Public License, version 2 with the GNU Classpath Exception](https://www.gnu.org/software/classpath/license.html)
-
-1.  **Group** : jakarta.xml.bind. **Name** : jakarta.xml.bind-api. **Version** : 2.3.2.
-     * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
-     * **License:** [Eclipse Distribution License - v 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
-     * **License:** [Eclipse Public License v. 2.0](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
-     * **License:** [GNU General Public License, version 2 with the GNU Classpath Exception](https://www.gnu.org/software/classpath/license.html)
-
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
-
-1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
-     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
-     * **Project URL:** [http://junit.org](http://junit.org)
-     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
-     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
-     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
-
-1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
-     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.33.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.37.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
-     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.31.
-     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
-     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
-1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
-     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.10.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
-     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.0.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.10.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-annotations-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-junit5. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.17.3.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.3.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.3.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.3.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.7.5.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.**No license information found**
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.15.3.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.**No license information found**
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.5.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
-     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
-     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
-     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.1.
-     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-
-The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
-
-This report was generated on **Sun Nov 05 16:40:38 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
-
-
-
-
-# Dependencies of `io.spine.protodata:protodata-compiler:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4723,12 +3776,959 @@ This report was generated on **Sun Nov 05 16:40:38 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:38 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.15.0`
+
+## Runtime
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
+     * **Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.21.1.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-util. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.26.0.
+     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.37.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
+     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
+     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.1.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+## Compile, tests, and tooling
+1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
+     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
+     * **License:** Public Domain
+
+1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
+     * **Project URL:** [https://jcommander.org](https://jcommander.org)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.12.7.**No license information found**
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.12.7.
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.12.7.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.12.7.1.
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.12.7.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-jaxb-annotations. **Version** : 2.12.7.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-base](https://github.com/FasterXML/jackson-modules-base)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.12.7.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.2.4.
+     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
+     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
+     * **Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.1.
+     * **Project URL:** [https://github.com/google/auto/tree/master/common](https://github.com/google/auto/tree/master/common)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/auto/tree/master/service](https://github.com/google/auto/tree/master/service)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
+     * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
+     * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.21.1.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.21.1.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
+     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava-parent. **Version** : 32.1.1-jre.**No license information found**
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 31.1-jre.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
+     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 2.7.0.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
+     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.**No license information found**
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-util. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-api. **Version** : 5.5.5.**No license information found**
+1.  **Group** : io.kotest. **Name** : kotest-assertions-api-jvm. **Version** : 5.5.5.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 5.5.5.**No license information found**
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 5.5.5.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 5.5.5.**No license information found**
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 5.5.5.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 5.5.5.**No license information found**
+1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 5.5.5.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.26.0.
+     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
+1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
+     * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
+     * **License:** [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
+     * **License:** [Eclipse Public License v. 2.0](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
+     * **License:** [GNU General Public License, version 2 with the GNU Classpath Exception](https://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : jakarta.xml.bind. **Name** : jakarta.xml.bind-api. **Version** : 2.3.2.
+     * **Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
+     * **License:** [Eclipse Distribution License - v 1.0](http://www.eclipse.org/org/documents/edl-v10.php)
+     * **License:** [Eclipse Public License v. 2.0](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
+     * **License:** [GNU General Public License, version 2 with the GNU Classpath Exception](https://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
+     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
+     * **Project URL:** [http://junit.org](http://junit.org)
+     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
+     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
+     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
+
+1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
+     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.33.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.37.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
+     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.31.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
+     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
+     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
+1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.0.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.0.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.0.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.10.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-annotations-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-test-junit5. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.17.3.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.3.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.3.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.3.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.7.5.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.15.3.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.**No license information found**
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.5.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.1.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+
+The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5650,12 +5650,12 @@ This report was generated on **Sun Nov 05 16:40:38 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:39 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6748,12 +6748,12 @@ This report was generated on **Sun Nov 05 16:40:39 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.15.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7518,12 +7518,12 @@ This report was generated on **Sun Nov 05 16:40:42 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.14.3`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.15.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8472,4 +8472,4 @@ This report was generated on **Sun Nov 05 16:40:42 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 05 16:40:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:00 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Wed Nov 22 17:09:20 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:00 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:02 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:02 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Wed Nov 22 17:09:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 22 17:09:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 19:14:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Mon Nov 20 18:28:27 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Mon Nov 20 18:28:28 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Mon Nov 20 18:28:29 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Mon Nov 20 18:28:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 18:28:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 19:15:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Tue Nov 21 23:55:48 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Tue Nov 21 23:55:52 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 23:55:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 22 17:09:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Tue Nov 21 04:00:03 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 04:00:07 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 23:55:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:14 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Mon Nov 20 19:15:53 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:15 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Mon Nov 20 19:15:54 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Mon Nov 20 19:15:55 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Mon Nov 20 19:15:56 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Mon Nov 20 19:15:57 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 19:15:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 02:49:18 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -943,7 +943,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:19 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Tue Nov 21 03:19:19 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:20 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Tue Nov 21 03:19:20 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3762,7 +3762,7 @@ This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4710,7 +4710,7 @@ This report was generated on **Tue Nov 21 03:19:21 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5638,7 +5638,7 @@ This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6737,7 +6737,7 @@ This report was generated on **Tue Nov 21 03:19:22 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7507,7 +7507,7 @@ This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8453,4 +8453,4 @@ This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 21 03:19:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 21 04:00:07 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -942,7 +942,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1906,7 +1906,7 @@ This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2829,7 +2829,7 @@ This report was generated on **Mon Nov 13 19:13:46 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3776,7 +3776,7 @@ This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4723,7 +4723,7 @@ This report was generated on **Mon Nov 13 19:13:47 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5650,7 +5650,7 @@ This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6748,7 +6748,7 @@ This report was generated on **Mon Nov 13 19:13:48 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7518,7 +7518,7 @@ This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:32 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8472,4 +8472,4 @@ This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 13 19:13:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 14:44:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2023, TeamDev. All rights reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Redistribution and use in source and/or binary forms, with or without
-  ~ modification, must retain the above copyright notice and the following
-  ~ disclaimer.
-  ~
-  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  -->
-
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <modelVersion>4.0.0</modelVersion>
 <!-- 

--- a/pom.xml
+++ b/pom.xml
@@ -134,15 +134,9 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.186</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.110</version>
+    <version>2.0.0-SNAPSHOT.111</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -242,7 +236,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.24.1</version>
+    <version>3.25.0</version>
   </dependency>
   <dependency>
     <groupId>io.gitlab.arturbosch.detekt</groupId>
@@ -252,43 +246,43 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.57.2</version>
+    <version>1.59.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.3</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.3</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-annotation</artifactId>
-    <version>2.0.0-SNAPSHOT.172</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-base</artifactId>
-    <version>2.0.0-SNAPSHOT.172</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.172</version>
+    <version>2.0.0-SNAPSHOT.173</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.172</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-rejection</artifactId>
-    <version>2.0.0-SNAPSHOT.172</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -301,9 +295,14 @@ all modules and does not describe the project structure per-subproject.
     <version>2.0.0-SNAPSHOT.184</version>
   </dependency>
   <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-tool-base</artifactId>
+    <version>2.0.0-SNAPSHOT.187</version>
+  </dependency>
+  <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.110</version>
+    <version>2.0.0-SNAPSHOT.111</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <modelVersion>4.0.0</modelVersion>
 <!-- 
@@ -10,7 +36,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.14.3</version>
+<version>0.15.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -226,17 +252,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.59.0</version>
+    <version>1.57.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.14.2</version>
+    <version>0.13.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.14.2</version>
+    <version>0.13.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/test-env/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
@@ -30,7 +30,6 @@ import com.google.protobuf.StringValue
 import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.find
 import io.spine.protodata.renderer.SourceFileSet
-import io.spine.server.query.select
 import io.spine.tools.code.Java
 import kotlin.io.path.Path
 import kotlin.io.path.div
@@ -44,7 +43,7 @@ public class DeletingRenderer : SoloRenderer<Java>(Java) {
         val types = select<DeletedType>().all()
         types.forEach {
             val source = select<ProtobufSourceFile>().findById(it.type.file)
-            val javaPackage = source!!.file.optionList
+            val javaPackage = source!!.header.optionList
                 .find("java_package", StringValue::class.java)!!.value
             val simpleName = it.type.name.simpleName
             val javaFileDir = Path(javaPackage.replace('.', '/'))

--- a/test-env/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
@@ -28,9 +28,9 @@ package io.spine.protodata.test
 
 import io.spine.protodata.qualifiedName
 import io.spine.protodata.renderer.SourceFileSet
-import io.spine.server.query.select
 import io.spine.tools.code.Java
 import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.Path
 
 /**
@@ -41,8 +41,9 @@ public class InternalAccessRenderer : SoloRenderer<Java>(Java) {
     override fun render(sources: SourceFileSet) {
         val internalTypes = select<InternalType>().all()
         internalTypes.forEach { internalType ->
-            val path = internalType.name.qualifiedName.replace('.', File.separatorChar)
-            sources.createFile(Path("${path}Internal.java"),
+            val path = internalType.toPath()
+            sources.createFile(
+                path,
                 """
                 class ${internalType.name.simpleName}Internal {
                     // Here goes case specific code.
@@ -52,3 +53,11 @@ public class InternalAccessRenderer : SoloRenderer<Java>(Java) {
         }
     }
 }
+
+private fun InternalType.toPath(): Path {
+    val path = qualifiedName.replace('.', File.separatorChar)
+    return Path("${path}Internal.java")
+}
+
+private val InternalType.qualifiedName: String
+    get() = name.qualifiedName

--- a/test-env/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/InternalAccessRenderer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class InternalAccessRenderer : SoloRenderer<Java>(Java) {
     override fun render(sources: SourceFileSet) {
         val internalTypes = select<InternalType>().all()
         internalTypes.forEach { internalType ->
-            val path = internalType.name.qualifiedName().replace('.', File.separatorChar)
+            val path = internalType.name.qualifiedName.replace('.', File.separatorChar)
             sources.createFile(Path("${path}Internal.java"),
                 """
                 class ${internalType.name.simpleName}Internal {

--- a/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
@@ -36,7 +36,7 @@ import io.spine.protobuf.pack
 import io.spine.protodata.EnumConstant
 import io.spine.protodata.EnumType
 import io.spine.protodata.Field
-import io.spine.protodata.File
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.FilePath
 import io.spine.protodata.MessageType
 import io.spine.protodata.Option
@@ -49,7 +49,7 @@ import io.spine.protodata.type.TypeSystem
 import io.spine.protodata.constantName
 import io.spine.protodata.enumConstant
 import io.spine.protodata.fieldName
-import io.spine.protodata.file
+import io.spine.protodata.protoFileHeader
 import io.spine.protodata.filePath
 import io.spine.protodata.messageType
 import io.spine.protodata.option
@@ -85,13 +85,13 @@ public object TypesTestEnv {
         type = type { primitive = TYPE_STRING }
         value = StringValue.of("CartoonRejections").pack()
     }
-    public val protoFile: File = file {
+    public val protoFile: ProtoFileHeader = protoFileHeader {
         path = filePath
         packageName = "acme.example"
         option.add(multipleFilesOption)
         option.add(javaPackageOption)
     }
-    public val rejectionsProtoFile: File = file {
+    public val rejectionsProtoFile: ProtoFileHeader = protoFileHeader {
         path = rejectionsFilePath
         packageName = "acme.example"
         option.add(javaPackageOption)

--- a/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
@@ -63,8 +63,8 @@ import io.spine.protodata.field as newField
 
 public object TypesTestEnv {
 
-    public val filePath: FilePath = filePath { value = "acme/example/foo.proto" }
-    public val rejectionsFilePath: FilePath = filePath {
+    public val protoSourceFile: FilePath = filePath { value = "acme/example/foo.proto" }
+    public val rejectionsFile: FilePath = filePath {
         value = "acme/example/cartoon_rejections.proto"
     }
     public val multipleFilesOption: Option = option {
@@ -86,13 +86,13 @@ public object TypesTestEnv {
         value = StringValue.of("CartoonRejections").pack()
     }
     public val header: ProtoFileHeader = protoFileHeader {
-        file = filePath
+        file = protoSourceFile
         packageName = "acme.example"
         option.add(multipleFilesOption)
         option.add(javaPackageOption)
     }
     public val rejectionsProtoHeader: ProtoFileHeader = protoFileHeader {
-        file = rejectionsFilePath
+        file = rejectionsFile
         packageName = "acme.example"
         option.add(javaPackageOption)
         option.add(outerClassnameOption)
@@ -118,12 +118,12 @@ public object TypesTestEnv {
         single = Empty.getDefaultInstance()
     }
     public val messageType: MessageType = messageType {
-        file = filePath
+        file = protoSourceFile
         name = messageTypeName
         field.add(stringField)
     }
     public val rejectionType: MessageType = messageType {
-        file = rejectionsFilePath
+        file = rejectionsFile
         name = rejectionTypeName
         field.add(idField)
     }
@@ -141,7 +141,7 @@ public object TypesTestEnv {
         number = 1
     }
     public val enumType: EnumType = newEnumType {
-        file = filePath
+        file = protoSourceFile
         name = enumTypeName
         constant.add(undefinedConstant)
         constant.add(enumConstant)
@@ -152,19 +152,19 @@ public object TypesTestEnv {
         typeUrlPrefix = "service.spine.io"
     }
     public val service: Service = service {
-        file = filePath
+        file = protoSourceFile
         name = serviceName
     }
     public val typeSystem: TypeSystem = run {
         val definitions = protobufSourceFile {
-            filePath = TypesTestEnv.filePath
+            file = TypesTestEnv.protoSourceFile
             header = this@run.header
             type.put(messageTypeName.typeUrl, messageType)
             enumType.put(enumTypeName.typeUrl, TypesTestEnv.enumType)
             service.put(serviceName.typeUrl, TypesTestEnv.service)
         }
         val rejections = protobufSourceFile {
-            filePath = rejectionsFilePath
+            file = rejectionsFile
             header = rejectionsProtoHeader
             type.put(rejectionTypeName.typeUrl, rejectionType)
         }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
@@ -36,36 +36,36 @@ import io.spine.protobuf.pack
 import io.spine.protodata.EnumConstant
 import io.spine.protodata.EnumType
 import io.spine.protodata.Field
-import io.spine.protodata.ProtoFileHeader
-import io.spine.protodata.FilePath
+import io.spine.protodata.File
 import io.spine.protodata.MessageType
 import io.spine.protodata.Option
 import io.spine.protodata.PrimitiveType.TYPE_BOOL
 import io.spine.protodata.PrimitiveType.TYPE_STRING
+import io.spine.protodata.ProtoFileHeader
 import io.spine.protodata.Service
 import io.spine.protodata.ServiceName
 import io.spine.protodata.TypeName
-import io.spine.protodata.type.TypeSystem
 import io.spine.protodata.constantName
 import io.spine.protodata.enumConstant
 import io.spine.protodata.fieldName
-import io.spine.protodata.protoFileHeader
-import io.spine.protodata.filePath
+import io.spine.protodata.file
 import io.spine.protodata.messageType
 import io.spine.protodata.option
+import io.spine.protodata.protoFileHeader
 import io.spine.protodata.protobufSourceFile
 import io.spine.protodata.service
 import io.spine.protodata.serviceName
 import io.spine.protodata.type
+import io.spine.protodata.type.TypeSystem
 import io.spine.protodata.typeName
 import io.spine.protodata.enumType as newEnumType
 import io.spine.protodata.field as newField
 
 public object TypesTestEnv {
 
-    public val protoSourceFile: FilePath = filePath { value = "acme/example/foo.proto" }
-    public val rejectionsFile: FilePath = filePath {
-        value = "acme/example/cartoon_rejections.proto"
+    public val protoSourceFile: File = file { path = "acme/example/foo.proto" }
+    public val rejectionsFile: File = file {
+        path = "acme/example/cartoon_rejections.proto"
     }
     public val multipleFilesOption: Option = option {
         name = "java_multiple_files"
@@ -157,7 +157,7 @@ public object TypesTestEnv {
     }
     public val typeSystem: TypeSystem = run {
         val definitions = protobufSourceFile {
-            file = TypesTestEnv.protoSourceFile
+            file = protoSourceFile
             header = this@run.header
             type.put(messageTypeName.typeUrl, messageType)
             enumType.put(enumTypeName.typeUrl, TypesTestEnv.enumType)

--- a/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
@@ -85,25 +85,25 @@ public object TypesTestEnv {
         type = type { primitive = TYPE_STRING }
         value = StringValue.of("CartoonRejections").pack()
     }
-    public val protoFile: ProtoFileHeader = protoFileHeader {
+    public val header: ProtoFileHeader = protoFileHeader {
         path = filePath
         packageName = "acme.example"
         option.add(multipleFilesOption)
         option.add(javaPackageOption)
     }
-    public val rejectionsProtoFile: ProtoFileHeader = protoFileHeader {
+    public val rejectionsProtoHeader: ProtoFileHeader = protoFileHeader {
         path = rejectionsFilePath
         packageName = "acme.example"
         option.add(javaPackageOption)
         option.add(outerClassnameOption)
     }
     public val messageTypeName: TypeName = typeName {
-        packageName = protoFile.packageName
+        packageName = header.packageName
         simpleName = "Foo"
         typeUrlPrefix = "type.spine.io"
     }
     public val rejectionTypeName: TypeName = typeName {
-        packageName = rejectionsProtoFile.packageName
+        packageName = rejectionsProtoHeader.packageName
         simpleName = "CannotDrawCartoon"
         typeUrlPrefix = "type.spine.io"
     }
@@ -128,7 +128,7 @@ public object TypesTestEnv {
         field.add(idField)
     }
     public val enumTypeName: TypeName = typeName {
-        packageName = protoFile.packageName
+        packageName = header.packageName
         typeUrlPrefix = messageTypeName.typeUrlPrefix
         simpleName = "Kind"
     }
@@ -158,14 +158,14 @@ public object TypesTestEnv {
     public val typeSystem: TypeSystem = run {
         val definitions = protobufSourceFile {
             filePath = TypesTestEnv.filePath
-            file = protoFile
+            header = this@run.header
             type.put(messageTypeName.typeUrl, messageType)
             enumType.put(enumTypeName.typeUrl, TypesTestEnv.enumType)
             service.put(serviceName.typeUrl, TypesTestEnv.service)
         }
         val rejections = protobufSourceFile {
             filePath = rejectionsFilePath
-            file = rejectionsProtoFile
+            header = rejectionsProtoHeader
             type.put(rejectionTypeName.typeUrl, rejectionType)
         }
         TypeSystem(setOf(definitions, rejections))

--- a/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/TypesTestEnv.kt
@@ -86,13 +86,13 @@ public object TypesTestEnv {
         value = StringValue.of("CartoonRejections").pack()
     }
     public val header: ProtoFileHeader = protoFileHeader {
-        path = filePath
+        file = filePath
         packageName = "acme.example"
         option.add(multipleFilesOption)
         option.add(javaPackageOption)
     }
     public val rejectionsProtoHeader: ProtoFileHeader = protoFileHeader {
-        path = rejectionsFilePath
+        file = rejectionsFilePath
         packageName = "acme.example"
         option.add(javaPackageOption)
         option.add(outerClassnameOption)

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotatedView.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotatedView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ final class AnnotatedView extends View<FieldId, Annotated, Annotated.Builder> {
     @Subscribe
     void on(@External @Where(field = "option.name", equals = OPTION_NAME)
                     FieldOptionDiscovered event) {
-        StringValue value = unpack(event.getOption().getValue(), StringValue.class);
+        var value = unpack(event.getOption().getValue(), StringValue.class);
         builder().setJavaAnnotation(value.getValue());
     }
 

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/AnnotationRenderer.java
@@ -51,7 +51,7 @@ public final class AnnotationRenderer extends JavaRenderer {
          if (!sources.inputRoot().endsWith("java")) {
              return;
          }
-        Set<Annotated> annotatedFields = select(Annotated.class).all();
+        var annotatedFields = select(Annotated.class).all();
         annotatedFields.forEach(field -> renderFor(field, sources));
 
         sources.forEach(file -> {
@@ -64,10 +64,9 @@ public final class AnnotationRenderer extends JavaRenderer {
     }
 
     private void renderFor(Annotated field, SourceFileSet sourceSet) {
-        FieldId id = field.getId();
-        FieldGetter getter = new FieldGetter(id);
-        Path path = javaFileOf(id.getType(), id.getFile());
-
+        var id = field.getId();
+        var getter = new FieldGetter(id);
+        var path = javaFileOf(id.getType(), id.getFile());
         sourceSet.file(path)
                  .at(getter)
                  .withExtraIndentation(INDENT_LEVEL)

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/FieldGetter.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/FieldGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,10 @@ final class FieldGetter implements NonRepeatingInsertionPoint {
     @NonNull
     @Override
     public TextCoordinates locateOccurrence(Text text) {
-        String fieldName = camelCase(field.getField().getValue());
-        String getterName = "get" + fieldName;
-        Pattern pattern = Pattern.compile("public .+ " + getterName);
-        List<String> lines = text.lines();
+        var fieldName = camelCase(field.getField().getValue());
+        var getterName = "get" + fieldName;
+        var pattern = Pattern.compile("public .+ " + getterName);
+        var lines = text.lines();
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
             if (pattern.matcher(line).find()) {

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/GeneratedByProtoData.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/GeneratedByProtoData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScope.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScope.java
@@ -35,7 +35,7 @@ import io.spine.text.Text;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.protodata.Ast.qualifiedName;
+import static io.spine.protodata.Ast.getQualifiedName;
 import static io.spine.protodata.renderer.CoordinatesFactory.nowhere;
 import static java.lang.String.format;
 
@@ -70,7 +70,7 @@ final class ClassScope implements NonRepeatingInsertionPoint {
      */
     @Override
     public TextCoordinates locateOccurrence(Text text) {
-        String pattern = format(NATIVE_INSERTION_POINT_FMT, qualifiedName(typeName));
+        String pattern = format(NATIVE_INSERTION_POINT_FMT, getQualifiedName(typeName));
         List<String> lines = text.lines();
         for (int lineNumber = 0; lineNumber < lines.size(); lineNumber++) {
             String line = lines.get(lineNumber);

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScopePrinter.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScopePrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ public final class ClassScopePrinter extends InsertionPointPrinter<Java> {
     @Override
     protected Set<InsertionPoint> supportedInsertionPoints() {
         return select(UuidType.class).all()
-                                     .stream()
-                                     .map(type -> new ClassScope(type.getName()))
-                                     .collect(toSet());
+                .stream()
+                .map(type -> new ClassScope(type.getName()))
+                .collect(toSet());
     }
 }

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/Template.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/Template.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ final class Template {
      * @return formatted code lines
      */
     ImmutableList<String> format(Object... positionalArgs) {
-        String formatted = String.format(code, positionalArgs);
-        ImmutableList<String> lines = NEW_LINE_SPLITTER.splitToStream(formatted)
-                                                       .collect(toImmutableList());
+        var formatted = String.format(code, positionalArgs);
+        var lines = NEW_LINE_SPLITTER.splitToStream(formatted)
+                                     .collect(toImmutableList());
         return lines;
     }
 }

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidJavaRenderer.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidJavaRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.protodata.test.uuid;
 
 import com.google.common.collect.ImmutableList;
-import io.spine.protodata.FilePath;
+import io.spine.protodata.File;
 import io.spine.protodata.TypeName;
 import io.spine.protodata.codegen.java.ClassName;
 import io.spine.protodata.codegen.java.JavaRenderer;
@@ -72,12 +72,12 @@ public final class UuidJavaRenderer extends JavaRenderer {
     protected void render(SourceFileSet sources) {
         Set<UuidType> uuidTypes = select(UuidType.class).all();
         for (UuidType type : uuidTypes) {
-            TypeName typeName = type.getName();
-            FilePath file = type.getDeclaredIn();
-            ClassName className = classNameOf(typeName, file);
-            InsertionPoint classScope = new ClassScope(typeName);
-            ImmutableList<String> lines = METHOD_FORMAT.format(className, UUID.class.getName());
-            Path javaFilePath = javaFileOf(typeName, file);
+            var typeName = type.getName();
+            var file = type.getDeclaredIn();
+            var className = classNameOf(typeName, file);
+            var classScope = new ClassScope(typeName);
+            var lines = METHOD_FORMAT.format(className, UUID.class.getName());
+            var javaFilePath = javaFileOf(typeName, file);
 
             // If there are no Java files, we deal with another language.
             // Have this workaround until we get access to the `sourceRoot` property.

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidPlugin.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidTypeRepository.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidTypeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidTypeView.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/UuidTypeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/protodata-extension/src/main/proto/spine/protodata/test/annotated.proto
+++ b/tests/protodata-extension/src/main/proto/spine/protodata/test/annotated.proto
@@ -23,7 +23,7 @@ message Annotated {
 
 message FieldId {
 
-    spine.protodata.FilePath file = 1;
+    spine.protodata.File file = 1;
 
     spine.protodata.TypeName type = 2;
 

--- a/tests/protodata-extension/src/main/proto/spine/protodata/test/uuid_type.proto
+++ b/tests/protodata-extension/src/main/proto/spine/protodata/test/uuid_type.proto
@@ -20,5 +20,5 @@ message UuidType {
     protodata.TypeName name = 1;
 
     // The file where the type is declared.
-    protodata.FilePath declared_in = 2;
+    protodata.File declared_in = 2;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.14.3")
+val protoDataVersion: String by extra("0.15.0")


### PR DESCRIPTION
This PR improves the names of proto types used in a domain model of code generation. Some types and their properties were renamed to better reflect the nature of data they represent.

## Renamed types and properties
 * `File` -> `ProtoFileHeader` because it carries options, the package and syntax info. It's more than a file.
 * Correspondingly, `File.path` became `ProtoFileHeader.file`.

The previous renamings allowed us to do these renamings:
 * `FilePath.value` -> `File.path`. It's a proto replacement for `kotlin.File`.

In other types properties that used to be `path` or `file_path` became `file`. 
Properties that used to be `file` (referring to `ProtobufSourceFile`) became `source.


## Added extension properties

`Field` got the following extension properties:
 * `isMessage` — it reads better than `Field.type.hasMessage()`, which we get generated from proto type.
 * `isMap`
 * `isList` became property instead of `isList()` function. This is to highlight the fact that a field cannot change its nature once created.
 * `isRepeated` — similarly to `isList` became a property.
 * `isPartOfOneof`  — similarly to `isList` became a property.
 * `qualifiedName` — returns the property name including the qualified name of the type which declares it.

`Type` got these extension properties:
 * `isMessage`
 * `isAny`

## `FileAware` and `OptionAware` interface were introduced
Events that are associated with a `File` became `FileAware`.
Events that are associated with an `Option` became `OptionAware`.

## Other changes
 * `Renderer` got inline function `select()` for idiomatic calls from Kotlin.
 * Removed `skipValidation()` in builds because it's no longer needed.
 * `SecureRandomString` made public for usage in Validation.
 * Constants related to ProtoData configuration were added to `Names` object for usage in McJava.
