### PR TITLE
Improve type annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,10 @@ allprojects {
     version = extra["protoDataVersion"]!!
 
     repositories.standardToSpineSdk()
+    repositories {
+        intellijReleases
+        jetBrainsCacheRedirector
+    }
 
     configurations.all {
         resolutionStrategy {

--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.kotlin.dsl.maven
+
+val RepositoryHandler.intellijReleases: MavenArtifactRepository
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+
+val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("ConstPropertyName")
+
+package io.spine.internal.dependency
+
+/**
+ * The components of the IntelliJ Platform.
+ *
+ * Make sure to add the `intellijReleases` and `jetBrainsCacheRedirector`
+ * repositories to your project. See `kotlin/Repositories.kt` for details.
+ */
+object IntelliJ {
+
+    /**
+     * The version of the IntelliJ platform.
+     *
+     * This is the version used by Kotlin compiler `1.9.21`.
+     * Advance this version with caution because it may break the setup of
+     * IntelliJ platform standalone execution.
+     */
+    const val version = "213.7172.53"
+
+    object Platform {
+        private const val group = "com.jetbrains.intellij.platform"
+        const val core = "$group:core:$version"
+        const val util = "$group:util:$version"
+    }
+
+    object JavaPsi {
+        private const val group = "com.jetbrains.intellij.java"
+        const val api = "$group:java-psi:$version"
+        const val impl = "$group:java-psi-impl:$version"
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.14.2"
+    private const val fallbackVersion = "0.15.2"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.14.2"
+    private const val fallbackDfVersion = "0.15.2"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.190"
+        const val toolBase = "2.0.0-SNAPSHOT.191"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.186"
+        const val toolBase = "2.0.0-SNAPSHOT.190"
 
         /**
          * The version of [Spine.javadocTools].
@@ -151,6 +151,7 @@ object Spine {
 
     const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
     const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
+    const val psiJava = "$toolsGroup:spine-psi-java:${ArtifactVersion.toolBase}"
     const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
     const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
     const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"

--- a/codegen/java/build.gradle.kts
+++ b/codegen/java/build.gradle.kts
@@ -38,6 +38,7 @@ plugins {
 dependencies {
     api(project(":compiler"))
     api(JavaPoet.lib)
+    api(Spine.psiJava)
 
     testImplementation(JavaX.annotations)
     testImplementation(Spine.testUtilTime)

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/EnumName.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/EnumName.kt
@@ -24,14 +24,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.protodata.type
+package io.spine.protodata.codegen.java
 
-import io.spine.tools.code.Language
+import kotlin.reflect.KClass
 
 /**
- * A [CodeElement] that represents a name of a language-specific type.
- *
- * In Java, it would be a fully qualified class name.
- * In Kotlin — it could be a class name, an object name, or a function name.
+ * A fully qualified name of a Java enum type.
  */
-public interface NameElement<L : Language> : CodeElement<L>
+public class EnumName internal constructor(
+    packageName: String,
+    simpleNames: List<String>
+) : ClassOrEnumName(packageName, simpleNames) {
+
+    /**
+     * Creates a new enum name from the given package name and a simple name.
+     *
+     * If an enum is nested inside another class, the [simpleName] parameter must
+     * contain all the names from the outermost class to the innermost one, and
+     * finished with the enum type name.
+     */
+    public constructor(packageName: String, vararg simpleName: String) :
+            this(packageName, simpleName.toList())
+
+    /**
+     * Obtains the name of the given Java enum via its class.
+     */
+    public constructor(enum: Class<out Enum<*>>) :
+            this(enum.`package`?.name ?: "", enum.nestedNames())
+
+    /**
+     * Obtains the name of the given Kotlin enum via its class.
+     */
+    public constructor(enum: KClass<out Enum<*>>) : this(enum.java)
+}

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Expression.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/Expression.kt
@@ -121,7 +121,7 @@ public class Literal(value: Any) : Expression(value.toString())
  *         the method type parameters.
  */
 @JvmOverloads
-public fun ClassName.call(
+public fun ClassOrEnumName.call(
     name: String,
     arguments: List<Expression> = listOf(),
     generics: List<ClassName> = listOf()
@@ -152,7 +152,7 @@ public fun ClassName.getDefaultInstance(): MethodCall =
  * Example: `ClassName("com.acme.Bird").enumValue(1)` yields
  * "`com.acme.Bird.forNumber(1)`".
  */
-public fun ClassName.enumValue(number: Int): MethodCall =
+public fun EnumName.enumValue(number: Int): MethodCall =
     call("forNumber", listOf(Literal(number)))
 
 /**

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaValueConverter.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/JavaValueConverter.kt
@@ -57,7 +57,7 @@ public class JavaValueConverter(
     override fun toMessage(value: Value): Expression {
         val messageValue = value.messageValue
         val type = messageValue.type
-        val className = convention.declarationFor(type).name
+        val className = convention.declarationFor(type).name as ClassName
         return if (messageValue.fieldsMap.isEmpty()) {
             className.getDefaultInstance()
         } else {
@@ -72,7 +72,7 @@ public class JavaValueConverter(
     override fun toEnum(value: Value): MethodCall {
         val enumValue = value.enumValue
         val type = enumValue.type
-        val enumClassName = convention.declarationFor(type).name
+        val enumClassName = convention.declarationFor(type).name as EnumName
         return enumClassName.enumValue(enumValue.constNumber)
     }
 
@@ -86,16 +86,16 @@ public class JavaValueConverter(
     override fun toMap(value: Value): MethodCall {
         val firstEntry = value.mapValue.valueList.firstOrNull()
         val firstKey = firstEntry?.key
-        val keyClass = firstKey?.type?.toClass()
+        val keyClass = firstKey?.type?.toClass() as ClassName?
         val firstValue = firstEntry?.value
-        val valueClass = firstValue?.type?.toClass()
+        val valueClass = firstValue?.type?.toClass() as ClassName?
         val valuesMap = value.mapValue.valueList.associate {
             valueToCode(it.key) to valueToCode(it.value)
         }
         return mapExpression(valuesMap, keyClass, valueClass)
     }
 
-    private fun Type.toClass(): ClassName = when (kindCase) {
+    private fun Type.toClass(): ClassOrEnumName = when (kindCase) {
         MESSAGE -> convention.declarationFor(message).name
         ENUMERATION -> convention.declarationFor(enumeration).name
         PRIMITIVE -> primitive.toJavaClass()

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/ProtocInsertionPoints.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/ProtocInsertionPoints.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public enum class TypedInsertionPoint {
     BUILDER_SCOPE,
 
     /**
-     * The place where class-level definition go in an enum class.
+     * The place where class-level definition goes in an enum class.
      *
      * Only available for enum types.
      */

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConvention.kt
@@ -40,7 +40,7 @@ import io.spine.tools.code.Java
  */
 public class RejectionThrowableConvention(
     typeSystem: TypeSystem
-) : BaseJavaConvention<TypeName>(typeSystem) {
+) : BaseJavaConvention<TypeName, ClassName>(typeSystem) {
 
     @Suppress("ReturnCount")
     override fun declarationFor(name: TypeName): Declaration<Java, ClassName>? {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
@@ -35,8 +35,8 @@ import kotlin.io.path.Path
  * A fully qualified name of a Java type.
  */
 public abstract class TypeName internal constructor(
-    protected val packageName: String,
-    protected val simpleNames: List<String>
+    public val packageName: String,
+    public val simpleNames: List<String>
 ) : NameElement<Java>, JavaElement {
 
     init {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.codegen.java
+
+import io.spine.protodata.type.NameElement
+import io.spine.tools.code.Java
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+/**
+ * A fully qualified name of a Java type.
+ */
+public abstract class TypeName internal constructor(
+    protected val packageName: String,
+    protected val simpleNames: List<String>
+) : NameElement<Java>, JavaElement {
+
+    init {
+        require(simpleNames.isNotEmpty()) {
+            "A type name must have a least one simple name."
+        }
+    }
+
+    /**
+     * A prefix to be used to refer this type as a fully qualified name.
+     *
+     * If [packageName] is empty, the prefix is also empty.
+     * Otherwise, the prefix contains the package name followed by a dot (`.`).
+     */
+    protected val packagePrefix: String
+        get() = if (packageName.isEmpty()) "" else "$packageName."
+}
+
+/**
+ * A fully qualified Java class or enum name.
+ */
+public abstract class ClassOrEnumName internal constructor(
+    packageName: String,
+    simpleNames: List<String>
+) : TypeName(packageName, simpleNames) {
+
+    /**
+     * The canonical name of the type.
+     *
+     * This is the name by which the class is referred to in Java code.
+     *
+     * For regular Java classes, this is similar to [ClassName.binary],
+     * except that in a binary name nested classes are separated by
+     * the dollar (`$`) sign, and in canonical — by the dot (`.`) sign.
+     */
+    @get:JvmName("canonical")
+    public val canonical: String = "$packagePrefix${simpleNames.joinToString(".")}"
+
+    /**
+     * The path to the Java source file of this type.
+     */
+    @get:JvmName("javaFile")
+    public val javaFile: Path by lazy {
+        val dir = packageName.replace('.', '/')
+        val topLevelClass = simpleNames.first()
+        Path("$dir/$topLevelClass.java")
+    }
+
+    /**
+     * The simple name of this type.
+     *
+     * If the type is nested inside a class, the outer class name is NOT included.
+     */
+    @get:JvmName("simpleName")
+    public val simpleName: String
+        get() = simpleNames.last()
+
+    /**
+     * Obtains the [canonical] name of the type.
+     */
+    override fun toCode(): String = canonical
+
+    /**
+     * Obtains the [canonical] name of the type.
+     */
+    override fun toString(): String = canonical
+
+    override fun hashCode(): Int = canonical.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ClassOrEnumName) return false
+        return canonical == other.canonical
+    }
+}
+
+/**
+ * Obtains a name of a class taking into account nesting hierarchy.
+ *
+ * The receiver class may be nested inside another class, which may be
+ * nested inside another class, and so on.
+ *
+ * The returned list contains simple names of the classes, starting
+ * from the outermost to the innermost, which is the receiver of
+ * this extension function.
+ *
+ * If the class is not nested, the returned list contains only
+ * a simple name of the class.
+ */
+internal fun Class<*>.nestedNames(): List<String> {
+    if (declaringClass == null) {
+        return listOf(this.simpleName)
+    }
+    val names = mutableListOf<String>()
+    var cls: Class<*>? = this
+    do {
+        names.add(cls!!.simpleName)
+        cls = cls.declaringClass
+    } while (cls != null)
+    return names.reversed()
+}

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/TypeName.kt
@@ -46,6 +46,15 @@ public abstract class TypeName internal constructor(
     }
 
     /**
+     * The simple name of this type.
+     *
+     * If the type is nested inside a class, the outer class name is NOT included.
+     */
+    @get:JvmName("simpleName")
+    public val simpleName: String
+        get() = simpleNames.last()
+    
+    /**
      * A prefix to be used to refer this type as a fully qualified name.
      *
      * If [packageName] is empty, the prefix is also empty.
@@ -53,6 +62,14 @@ public abstract class TypeName internal constructor(
      */
     protected val packagePrefix: String
         get() = if (packageName.isEmpty()) "" else "$packageName."
+
+    public companion object {
+
+        /**
+         * A regular expression for a simple Java type name.
+         */
+        public val simpleNameRegex: Regex = Regex("^[a-zA-Z_$][a-zA-Z\\d_$]*$")
+    }
 }
 
 /**
@@ -86,13 +103,9 @@ public abstract class ClassOrEnumName internal constructor(
     }
 
     /**
-     * The simple name of this type.
-     *
-     * If the type is nested inside a class, the outer class name is NOT included.
+     * Tells if this type is nested inside another type.
      */
-    @get:JvmName("simpleName")
-    public val simpleName: String
-        get() = simpleNames.last()
+    public val isNested: Boolean = simpleNames.size > 1
 
     /**
      * Obtains the [canonical] name of the type.

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/SuppressWarningsAnnotation.kt
@@ -33,10 +33,12 @@ import io.spine.protodata.renderer.SourceFile
  * Suppresses warnings in the generated code.
  *
  * If no configuration is provided to ProtoData, suppresses all the warnings with `"ALL"`.
- * Otherwise, parses the config as a [SuppressionSettings] and suppresses only the specified warnings.
+ * Otherwise, parses the config as a [SuppressionSettings] and suppresses only
+ * the specified warnings.
  *
- * Warnings in the generated code do no good for the user, as they cannot be fixed without changing
- * the code generation logic. We recommend suppressing them.
+ * Warnings in the generated code do no good for the user, as they cannot be
+ * fixed without changing the code generation logic.
+ * That's why we recommend suppressing them.
  *
  * @see io.spine.protodata.codegen.java.annotation.TypeAnnotation
  */
@@ -50,18 +52,19 @@ public class SuppressWarningsAnnotation :
     override fun renderAnnotationArguments(file: SourceFile): String = "{${warningList()}}"
 
     /**
-     * Obtains the code for suppressing configured warnings.
+     * Obtains the code for suppressing warnings.
      *
      * If [SuppressionSettings] are not available, or the list of warnings is empty,
      * the method assumes [ALL_WARNINGS] are to be suppressed.
      *
-     * If settings are given, takes the list of warnings from the instance, removing single-
-     * or double quotes that could be in the values
+     * If settings are given, the method takes the list of warnings from the instance,
+     * removing single- or double quotes that could be in the values
      *
-     * **NOTE:** [ALL_WARNINGS] are assumed to avoid the case of working with a default instance
-     * of [SuppressionSettings] (e.g. when it was loaded from a file). Obviously, the user did
-     * not intend to suppress an empty list of warnings, if [SuppressionSettings] instance was added
-     * to ProtoData settings but no specific warnings were specified.
+     * **NOTE**: [ALL_WARNINGS] are assumed to avoid the case of working with
+     * a default instance of [SuppressionSettings] (e.g., when it was loaded from a file).
+     * We assume that the user did not intend to suppress an empty list of warnings,
+     * if [SuppressionSettings] instance was added to ProtoData settings
+     * but no specific warnings were specified.
      */
     private fun warningList(): String {
         val warnings = if (!configIsPresent()) {
@@ -77,15 +80,17 @@ public class SuppressWarningsAnnotation :
                 withQuotesStripped
             }
         }
-        val warningsList = warnings.joinToString { '"' + it + '"' }
-        return warningsList
+        val warningList = warnings.joinToString { '"' + it + '"' }
+        return warningList
     }
 
     /**
      * Overrides the check method and removes all the checks.
      *
-     * `SuppressWarnings` is a valid type annotation, so we don't have to check it. However,
-     * in JDK 19, this annotation type does not have a `@Target`. Because of this, the check fails.
+     * `SuppressWarnings` is a valid type annotation, so we don't have to check it.
+     * However, in JDK 19, this annotation type does not have a `@Target`.
+     * Because of this, the check in the parent class fails.
+     * We override the method with no-op to avoid the problem when running under JDK 19.
      *
      * See the [JDK bug](https://bugs.openjdk.org/browse/JDK-8280745) for more info.
      */

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -37,12 +37,21 @@ import java.lang.annotation.Target
 /**
  * A [JavaRenderer] which annotates a Java type using the given [annotation][annotationClass].
  *
- * The implementation assumes that [PrintBeforePrimaryDeclaration][io.spine.protodata.codegen.java.file.PrintBeforePrimaryDeclaration]
- * renderer is inserted before a reference to a renderer derived from this class.
+ * @param T the type of the annotation.
  */
-@Suppress("TooManyFunctions") // Overriding some methods to make them final.
 public abstract class TypeAnnotation<T : Annotation>(
+
+    /**
+     * The class of the annotation to apply.
+     */
     protected val annotationClass: Class<T>,
+
+    /**
+     * The subject of the annotation.
+     *
+     * If `null`, the annotation is applied to all the classes passed to this annotation.
+     * If not `null`, the annotation is applied only to the types specified by this field.
+     */
     protected val subject: ClassOrEnumName? = null
 ) : JavaRenderer() {
 
@@ -84,7 +93,6 @@ public abstract class TypeAnnotation<T : Annotation>(
 //                BeforePrimaryDeclaration
 //            }
 //        }
-
 
         val annotationCode = annotationCode(file)
         //TODO:2023-12-13:alexander.yevsyukov: Check if this is top-level type.

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -41,8 +41,11 @@ import java.lang.annotation.Target
  */
 @Suppress("TooManyFunctions") // Overriding some methods to make them final.
 public abstract class TypeAnnotation<T : Annotation>(
-    protected val annotationClass: Class<T>
+    protected val annotationClass: Class<T>,
+    //protected val subject: ClassOrEnumName? = null
 ) : JavaRenderer() {
+
+    //private val specific: Boolean = subject != null
 
     init {
         @Suppress("LeakingThis")
@@ -55,6 +58,9 @@ public abstract class TypeAnnotation<T : Annotation>(
         sources.filter { shouldAnnotate(it) }
             .forEach { file ->
                 val annotationCode = annotationCode(file)
+                //TODO:2023-12-13:alexander.yevsyukov: Check if this is top-level type.
+                // If yes, use `BeforePrimaryTypeDeclaration` insertion point.
+                // Otherwise, use an insertion point for a nested type.
                 val line = file.at(BeforePrimaryDeclaration)
                 line.add(annotationCode)
             }
@@ -66,7 +72,7 @@ public abstract class TypeAnnotation<T : Annotation>(
     /**
      * Specifies whether to annotate a given file using the caller's implementation.
      *
-     * By default, checks whether the target file already includes the annotation.
+     * By default, the method checks whether the target file already includes the annotation.
      *
      * If a [Repeatable] annotation is attached to the annotation class,
      * it always applies the annotation and returns `true`.
@@ -79,6 +85,10 @@ public abstract class TypeAnnotation<T : Annotation>(
      */
     @Suppress("ReturnCount") // Cannot go lower here.
     protected open fun shouldAnnotate(file: SourceFile): Boolean {
+        //TODO:2023-12-13:alexander.yevsyukov: Check if this is top-level type.
+        // If yes, use `BeforePrimaryTypeDeclaration` insertion point.
+        // Otherwise, use an insertion point for a nested type.
+
         val coordinates = BeforePrimaryDeclaration.locateOccurrence(file.text())
         if (coordinates == nowhere) {
             return false

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -60,8 +60,13 @@ public abstract class TypeAnnotation<T : Annotation>(
 
     init {
         @Suppress("LeakingThis")
-            // In a controlled environment, we're disabling this check for one child class.
-            // Should be fine while the method is `internal` and not `protected` or `public`.
+        /* We call an overridable method from the constructor here.
+           We need this method to be overridable because we're disabling this check
+           for one child class (`SuppressWarningsAnnotation`).
+           Please see the documentation of [SuppressWarningsAnnotation.checkAnnotationClass]
+           for more details. Since the method is `internal`, and not `protected` or `public`,
+           we should be fine.
+        */
         checkAnnotationClass()
     }
 
@@ -70,9 +75,10 @@ public abstract class TypeAnnotation<T : Annotation>(
             annotateMany(sources)
         } else {
             val file = sources.find(subject!!.javaFile)
-            file?.let {
-                annotate(it)
+            check(file != null) {
+                "Cannot find a file for the type `${subject.canonical}`."
             }
+            annotate(file)
         }
     }
 

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
@@ -32,6 +32,8 @@ import io.spine.protodata.renderer.NonRepeatingInsertionPoint
 import io.spine.string.ti
 import io.spine.text.Text
 import io.spine.text.TextCoordinates
+import io.spine.tools.psi.java.lineNumber
+import io.spine.tools.psi.java.locate
 
 /**
  * An insertion point before a nested type declaration.
@@ -48,11 +50,12 @@ public class BeforeNestedTypeDeclaration(
 
     override val label: String = ""
 
-    private val pattern = Regex("""class\s+([A-Za-z_$][A-Za-z\d_$]*\s+)?$name\s*\{""")
-
     override fun locateOccurrence(text: Text): TextCoordinates {
-        text.locateOutsideComments(pattern)?.let {
-            return it
+        val psiFile = PsiJavaParser.instance.parse(text.value)
+        val psiClass = psiFile.locate(name.simpleNames)
+        psiClass?.let {
+            val lineNumber = it.lineNumber
+            return atLine(lineNumber)
         }
         logger.atWarning().log { """
             Cannot find a declaration of the nested type `$name` in the code:

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
@@ -37,6 +37,8 @@ import io.spine.tools.psi.java.locate
 
 /**
  * An insertion point before a nested type declaration.
+ *
+ * @see BeforePrimaryDeclaration
  */
 public class BeforeNestedTypeDeclaration(
     private val name: ClassOrEnumName

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclaration.kt
@@ -51,7 +51,7 @@ public class BeforeNestedTypeDeclaration(
     override val label: String = ""
 
     override fun locateOccurrence(text: Text): TextCoordinates {
-        val psiFile = PsiJavaParser.instance.parse(text.value)
+        val psiFile = text.psiFile()
         val psiClass = psiFile.locate(name.simpleNames)
         psiClass?.let {
             val lineNumber = it.lineNumber

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclaration.kt
@@ -45,6 +45,8 @@ import io.spine.tools.psi.java.lineNumber
  *
  * This insertion point is not bound to the contents of the file in `label`,
  * thus allowing this type to be an object.
+ *
+ * @see BeforeNestedTypeDeclaration
  */
 internal object BeforePrimaryDeclaration : NonRepeatingInsertionPoint {
 

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/PsiJavaParser.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/PsiJavaParser.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.codegen.java.file
+
+import com.intellij.core.JavaCoreProjectEnvironment
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import io.spine.server.Closeable
+import io.spine.tools.psi.IdeaStandaloneExecution
+import io.spine.tools.psi.java.Parser
+import io.spine.tools.psi.java.PsiJavaAppEnvironment
+
+/**
+ * Parsing environment for Java files based on IntelliJ PSI.
+ */
+public object PsiJavaParser: Closeable {
+
+    private var project: Project? = null
+    private var rootDisposable: Disposable? = null
+
+    /**
+     * Obtains the instance of the [Parser].
+     */
+    public val instance: Parser by lazy {
+        createEnvironment()
+        Parser(project!!)
+    }
+
+    private fun createEnvironment() {
+        IdeaStandaloneExecution.setup()
+        rootDisposable = Disposer.newDisposable()
+        val appEnvironment = PsiJavaAppEnvironment.create(rootDisposable!!)
+        val environment = JavaCoreProjectEnvironment(rootDisposable!!, appEnvironment)
+        project = environment.project
+    }
+
+    override fun close() {
+        if (isOpen) {
+            rootDisposable!!.dispose()
+            rootDisposable = null
+            project = null
+        }
+    }
+
+    override fun isOpen(): Boolean {
+        return rootDisposable != null
+    }
+}

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
@@ -26,42 +26,19 @@
 
 package io.spine.protodata.codegen.java.file
 
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaFile
 import io.spine.string.Separator
-import io.spine.string.trimWhitespace
 import io.spine.text.Text
-import io.spine.text.TextCoordinates
-import io.spine.text.textCoordinates
-
-/**
- * Locates the pattern point in the given text checking that it is
- * not inside a Java comment line or block.
- *
- * @return the coordinates of the pattern or `null` if the pattern was not found.
- */
-internal fun Text.locateOutsideComments(pattern: Regex): TextCoordinates? {
-    var isBlockComment = false
-    lines().forEachIndexed { index, line ->
-        val trimmed = line.trimWhitespace()
-        if (trimmed.startsWith("//")) {
-            return@forEachIndexed
-        }
-        if (trimmed.startsWith("/*")) {
-            isBlockComment = true
-        }
-        if (line.contains("*/")) {
-            isBlockComment = false
-        }
-        if (!isBlockComment && pattern.find(line) != null) {
-            return textCoordinates {
-                wholeLine = index
-            }
-        }
-    }
-    return null
-}
 
 /**
  * Prints the lines of the text into a single string using the system line separator.
  */
 internal fun Text.printLines(): String =
         lines().joinToString(separator = Separator.system.value)
+
+/**
+ * Obtains the instance of [PsiFile] for this text.
+ */
+public fun Text.psiFile(): PsiJavaFile =
+    PsiJavaParser.instance.parse(value)

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.codegen.java.file
+
+import io.spine.string.Separator
+import io.spine.string.trimWhitespace
+import io.spine.text.Text
+import io.spine.text.TextCoordinates
+import io.spine.text.textCoordinates
+
+/**
+ * Locates the pattern point in the given text checking that it is
+ * not inside a Java comment line or block.
+ *
+ * @return the coordinates of the pattern or `null` if the pattern was not found.
+ */
+internal fun Text.locateOutsideComments(pattern: Regex): TextCoordinates? {
+    var isBlockComment = false
+    lines().forEachIndexed { index, line ->
+        val trimmed = line.trimWhitespace()
+        if (trimmed.startsWith("//")) {
+            return@forEachIndexed
+        }
+        if (trimmed.startsWith("/*")) {
+            isBlockComment = true
+        }
+        if (line.contains("*/")) {
+            isBlockComment = false
+        }
+        if (!isBlockComment && pattern.find(line) != null) {
+            return textCoordinates {
+                wholeLine = index
+            }
+        }
+    }
+    return null
+}
+
+/**
+ * Prints the lines of the text into a single string using the system line separator.
+ */
+internal fun Text.printLines(): String =
+        lines().joinToString(separator = Separator.system.value)

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.codegen.java.file
 
+import com.intellij.openapi.util.text.StringUtilRt
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import io.spine.string.Separator
@@ -40,5 +41,7 @@ internal fun Text.printLines(): String =
 /**
  * Obtains the instance of [PsiFile] for this text.
  */
-public fun Text.psiFile(): PsiJavaFile =
-    PsiJavaParser.instance.parse(value)
+public fun Text.psiFile(): PsiJavaFile {
+    val convertedSeparators = StringUtilRt.convertLineSeparators(value)
+    return PsiJavaParser.instance.parse(convertedSeparators)
+}

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/file/TextExts.kt
@@ -26,11 +26,11 @@
 
 package io.spine.protodata.codegen.java.file
 
-import com.intellij.openapi.util.text.StringUtilRt
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import io.spine.string.Separator
 import io.spine.text.Text
+import io.spine.tools.psi.convertLineSeparators
 
 /**
  * Prints the lines of the text into a single string using the system line separator.
@@ -41,7 +41,5 @@ internal fun Text.printLines(): String =
 /**
  * Obtains the instance of [PsiFile] for this text.
  */
-public fun Text.psiFile(): PsiJavaFile {
-    val convertedSeparators = StringUtilRt.convertLineSeparators(value)
-    return PsiJavaParser.instance.parse(convertedSeparators)
-}
+public fun Text.psiFile(): PsiJavaFile =
+    PsiJavaParser.instance.parse(value.convertLineSeparators())

--- a/codegen/java/src/test/java/given/NestingExperiments.java
+++ b/codegen/java/src/test/java/given/NestingExperiments.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package given;
+
+/**
+ * This file shows various nesting levels of classes, interfaces, and enums.
+ */
+@SuppressWarnings({
+        "unused", "EmptyClass", "InterfaceNeverImplemented", "InnerClassTooDeeplyNested"
+})
+public class NestingExperiments {
+
+    public interface NestedInterface {
+
+        public static class NestedClass {
+
+        }
+    }
+
+    public enum NestedEnum {
+
+        ENUM_VALUE {
+
+            // Non-static.
+            class WeCanDoIt {
+
+            }
+        },
+    }
+}

--- a/codegen/java/src/test/java/given/package-info.java
+++ b/codegen/java/src/test/java/given/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package given;

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/ExpressionTest.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/ExpressionTest.kt
@@ -191,8 +191,8 @@ class `'ClassName' should` {
     @Test
     fun `obtain enum constants by number`() {
         val cls = Incarnation::class
-        val className = ClassName(cls)
-        assertCode(className.enumValue(2), "${cls.qualifiedName}.forNumber(2)")
+        val enumName = EnumName(cls)
+        assertCode(enumName.enumValue(2), "${cls.qualifiedName}.forNumber(2)")
     }
 
     @Test

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/MessageOrEnumConventionSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/MessageOrEnumConventionSpec.kt
@@ -45,7 +45,7 @@ internal class MessageOrEnumConventionSpec {
         declaration shouldNotBe null
         val (cls, path) = declaration
         val expectedClassName = "dev.acme.example.Foo"
-        cls.binary shouldBe expectedClassName
+        (cls as ClassName).binary shouldBe expectedClassName
         path shouldBe expectedClassName.toSourcePath()
     }
 
@@ -56,7 +56,7 @@ internal class MessageOrEnumConventionSpec {
         declaration shouldNotBe null
         val (cls, path) = declaration
         val expectedClassName = "dev.acme.example.Kind"
-        cls.binary shouldBe expectedClassName
+        cls.canonical shouldBe expectedClassName
         path shouldBe expectedClassName.toSourcePath()
     }
 }

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConventionSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/RejectionThrowableConventionSpec.kt
@@ -49,7 +49,8 @@ internal class RejectionThrowableConventionSpec {
         throwable shouldNotBe null
 
         val (messageClass, messagePath) = message
-        messageClass.binary shouldBe "dev.acme.example.CartoonRejections\$CannotDrawCartoon"
+        (messageClass as ClassName).binary shouldBe
+                "dev.acme.example.CartoonRejections\$CannotDrawCartoon"
         messagePath shouldBe Path("dev/acme/example/CartoonRejections.java")
 
         val (throwableClass, throwablePath) = throwable!!

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclarationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclarationSpec.kt
@@ -93,5 +93,5 @@ private val text = text {
             TRÊS
         }                
     }
-    """.ti()
+    """.ti() // We deliberately use OS-specific line endings here to simulate loading from disk.
 }

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclarationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforeNestedTypeDeclarationSpec.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.codegen.java.file
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldNotBe
+import io.spine.protodata.codegen.java.ClassName
+import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
+import io.spine.string.ti
+import io.spine.text.text
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`BeforeNestedTypeDeclaration` should")
+class BeforeNestedTypeDeclarationSpec {
+
+    @Test
+    fun `reject non-nested types`() {
+        assertThrows<IllegalArgumentException> {
+            BeforeNestedTypeDeclaration(ClassName(packageName, "TopLevel"))
+        }
+    }
+
+    @Test
+    fun `find nested types`() {
+        val nested = ClassName(packageName, "TopLevel", "Nested")
+        val deeplyNested = ClassName(packageName, "TopLevel", "Nested", "DeeplyNested")
+
+        val nestedLocation = BeforeNestedTypeDeclaration(nested).locateOccurrence(text)
+        val deeperLocation = BeforeNestedTypeDeclaration(deeplyNested).locateOccurrence(text)
+
+        nestedLocation shouldNotBe nowhere
+        deeperLocation shouldNotBe nowhere
+        deeperLocation.wholeLine shouldBeGreaterThan nestedLocation.wholeLine
+    }
+
+    @Test
+    fun `find nested enum`() {
+        val nestedEnum = ClassName(packageName, "TopLevel", "NestedEnum")
+        val location = BeforeNestedTypeDeclaration(nestedEnum).locateOccurrence(text)
+        location shouldNotBe nowhere
+    }
+}
+
+private const val packageName = "given.java.source.file"
+
+private val text = text {
+    value = """
+    /* File header comment. */    
+    package $packageName;
+
+    /** 
+     * Top level class Javadoc. 
+     */
+    public class TopLevel {
+
+        /** Nested class Javadoc. */
+        private static class Nested {
+    
+            private static class DeeplyNested {
+            }
+        }
+                
+        /** Nested enum Javadoc. */
+        public enum NestedEnum {
+            UM,
+            DOIS,
+            TRÊS
+        }                
+    }
+    """.ti()
+}

--- a/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclarationSpec.kt
+++ b/codegen/java/src/test/kotlin/io/spine/protodata/codegen/java/file/BeforePrimaryDeclarationSpec.kt
@@ -26,50 +26,37 @@
 
 package io.spine.protodata.codegen.java.file
 
-import io.kotest.matchers.ints.shouldBeGreaterThan
-import io.kotest.matchers.shouldNotBe
-import io.spine.protodata.codegen.java.ClassName
-import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
+import io.kotest.matchers.shouldBe
 import io.spine.string.ti
 import io.spine.text.text
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
-@DisplayName("`BeforeNestedTypeDeclaration` should")
-class BeforeNestedTypeDeclarationSpec {
+@DisplayName("`BeforePrimaryDeclaration` should locate a top level Java type:")
+class BeforePrimaryDeclarationSpec {
 
     @Test
-    fun `reject non-nested types`() {
-        assertThrows<IllegalArgumentException> {
-            BeforeNestedTypeDeclaration(ClassName(PACKAGE_NAME, "TopLevel"))
-        }
+    fun `a class`() {
+        val location = BeforePrimaryDeclaration.locateOccurrence(classSource)
+        location.wholeLine shouldBe 6
     }
 
     @Test
-    fun `find nested types`() {
-        val nested = ClassName(PACKAGE_NAME, "TopLevel", "Nested")
-        val deeplyNested = ClassName(PACKAGE_NAME, "TopLevel", "Nested", "DeeplyNested")
-
-        val nestedLocation = BeforeNestedTypeDeclaration(nested).locateOccurrence(text)
-        val deeperLocation = BeforeNestedTypeDeclaration(deeplyNested).locateOccurrence(text)
-
-        nestedLocation shouldNotBe nowhere
-        deeperLocation shouldNotBe nowhere
-        deeperLocation.wholeLine shouldBeGreaterThan nestedLocation.wholeLine
+    fun `an interface`() {
+        val location = BeforePrimaryDeclaration.locateOccurrence(interfaceSource)
+        location.wholeLine shouldBe 1
     }
 
     @Test
-    fun `find nested enum`() {
-        val nestedEnum = ClassName(PACKAGE_NAME, "TopLevel", "NestedEnum")
-        val location = BeforeNestedTypeDeclaration(nestedEnum).locateOccurrence(text)
-        location shouldNotBe nowhere
+    fun `an enum`() {
+        val location = BeforePrimaryDeclaration.locateOccurrence(enumSource)
+        location.wholeLine shouldBe 2
     }
 }
 
-private const val PACKAGE_NAME = "given.java.source.file"
+private const val PACKAGE_NAME = "given.java.file"
 
-private val text = text {
+private val classSource = text {
     value = """
     /* File header comment. */    
     package $PACKAGE_NAME;
@@ -81,17 +68,23 @@ private val text = text {
 
         /** Nested class Javadoc. */
         private static class Nested {
-    
-            private static class DeeplyNested {
-            }
         }
-                
-        /** Nested enum Javadoc. */
-        public enum NestedEnum {
-            UM,
-            DOIS,
-            TRÊS
-        }                
     }
+    """.ti()
+}
+
+private val interfaceSource = text {
+    value = """
+    /** Top level interface Javadoc. */
+    public interface TopLevel {
+    }
+    """.ti()
+}
+
+private val enumSource = text {
+    value = """
+    // File header comment.    
+    package $PACKAGE_NAME;
+    public enum TopLevel { ONE, TWO }
     """.ti()
 }

--- a/compiler/src/main/kotlin/io/spine/protodata/backend/ImplicitPluginWithRenderers.kt
+++ b/compiler/src/main/kotlin/io/spine/protodata/backend/ImplicitPluginWithRenderers.kt
@@ -31,7 +31,7 @@ import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.renderer.Renderer
 
 /**
- * An adapter plugin for gathering renderers that do not belong to a semantically-defined plugin.
+ * An adapter plugin for gathering renderers that do not belong to a semantically defined plugin.
  *
  * This plugin is used for testing ProtoData and for compatibility reasons.
  */

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-api:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -931,12 +931,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:35:58 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-cli:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1883,12 +1883,12 @@ This report was generated on **Wed Dec 13 16:35:58 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2807,12 +2807,12 @@ This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -3742,12 +3742,12 @@ This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4678,12 +4678,12 @@ This report was generated on **Wed Dec 13 16:35:59 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:36:00 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5606,12 +5606,12 @@ This report was generated on **Wed Dec 13 16:36:00 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:36:00 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6705,12 +6705,12 @@ This report was generated on **Wed Dec 13 16:36:00 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:36:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.15.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7475,12 +7475,12 @@ This report was generated on **Wed Dec 13 16:36:01 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:36:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.15.2`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.15.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8417,4 +8417,4 @@ This report was generated on **Wed Dec 13 16:36:01 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 13 16:36:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 14 01:34:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -930,7 +930,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2032,7 +2032,7 @@ This report was generated on **Fri Dec 22 20:06:11 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2956,7 +2956,7 @@ This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:49 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4041,7 +4041,7 @@ This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4976,7 +4976,7 @@ This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5904,7 +5904,7 @@ This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:13 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7003,7 +7003,7 @@ This report was generated on **Fri Dec 22 20:06:13 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7773,7 +7773,7 @@ This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8715,4 +8715,4 @@ This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 25 16:22:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -563,7 +563,6 @@
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
@@ -931,7 +930,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -939,6 +938,14 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 # Dependencies of `io.spine.protodata:protodata-cli:0.15.3`
 
 ## Runtime
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
 1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
@@ -1023,9 +1030,24 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
@@ -1068,6 +1090,14 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
@@ -1081,6 +1111,11 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
 1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
      * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
      * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
@@ -1089,9 +1124,34 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
      * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
 
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
-     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -1110,6 +1170,19 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.5.2.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -1119,14 +1192,23 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
 ## Compile, tests, and tooling
 1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
      * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
      * **License:** Public Domain
 
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
 1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
      * **Project URL:** [https://jcommander.org](https://jcommander.org)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.12.7.**No license information found**
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1339,6 +1421,17 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
 1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 2.7.0.
      * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
      * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
@@ -1346,6 +1439,10 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -1548,6 +1645,14 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1572,6 +1677,11 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
      * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
@@ -1609,6 +1719,14 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
 1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
      * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
@@ -1638,9 +1756,26 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -1777,13 +1912,22 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
 
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.3.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.5.2.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.3.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.3.
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.5.2.
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1834,6 +1978,10 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
      * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1880,10 +2028,11 @@ This report was generated on **Thu Dec 14 01:34:51 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2807,7 +2956,7 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2815,6 +2964,14 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 # Dependencies of `io.spine.protodata:protodata-codegen-java:0.15.3`
 
 ## Runtime
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
 1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
@@ -2894,9 +3051,24 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
@@ -2939,6 +3111,14 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
@@ -2952,6 +3132,11 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
 1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
      * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
      * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
@@ -2960,9 +3145,34 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
      * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
 
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
-     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -2981,6 +3191,19 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.5.2.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.4.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -2990,14 +3213,23 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
 ## Compile, tests, and tooling
 1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
      * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
      * **License:** Public Domain
 
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
 1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
      * **Project URL:** [https://jcommander.org](https://jcommander.org)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.12.7.**No license information found**
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -3198,6 +3430,17 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
 1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 2.7.0.
      * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
      * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
@@ -3205,6 +3448,10 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -3407,6 +3654,14 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3431,6 +3686,11 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.23.
      * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
@@ -3468,6 +3728,14 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
 1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
      * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
@@ -3497,9 +3765,26 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -3636,13 +3921,22 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.3.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.5.2.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.3.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.**No license information found**
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.5.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.3.
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.5.2.
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3693,6 +3987,10 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
      * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3739,10 +4037,11 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4310,7 +4609,6 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.104.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.110.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.111.**No license information found**
 1.  **Group** : jakarta.activation. **Name** : jakarta.activation-api. **Version** : 1.2.1.
@@ -4678,7 +4976,7 @@ This report was generated on **Thu Dec 14 01:34:52 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5606,7 +5904,7 @@ This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:13 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6705,7 +7003,7 @@ This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7475,7 +7773,7 @@ This report was generated on **Thu Dec 14 01:34:53 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8417,4 +8715,4 @@ This report was generated on **Thu Dec 14 01:34:54 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 14 01:34:54 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 22 20:06:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,18 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-psi-java</artifactId>
+    <version>2.0.0-SNAPSHOT.190</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-tool-base</artifactId>
+    <version>2.0.0-SNAPSHOT.190</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
     <version>2.0.0-SNAPSHOT.111</version>
@@ -158,7 +170,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.186</version>
+    <version>2.0.0-SNAPSHOT.190</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -261,17 +273,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.186</version>
+    <version>2.0.0-SNAPSHOT.190</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.184</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.187</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.15.2</version>
+<version>0.15.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -28,9 +28,9 @@ import com.google.protobuf.gradle.protobuf
 import io.spine.internal.dependency.Grpc
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.Kotlin
+import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
-import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.Truth
 import io.spine.internal.dependency.Validation
 import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
@@ -63,6 +63,10 @@ subprojects {
     }
 
     repositories.standardToSpineSdk()
+    repositories {
+        intellijReleases
+        jetBrainsCacheRedirector
+    }
 
     val protoDataVersion: String by extra
     configurations {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.15.2")
+val protoDataVersion: String by extra("0.15.3")


### PR DESCRIPTION
This PR extends `psi-java` artifact recently introduced in `tool-base` for parsing Java files:
 * `PsiJavaParser` facade was introduced to simplify the creation of a PSI `Project`, and an instance of `Parser` associated with it.
 * `BeforePrimaryDeclaration` insertion point was migrated to use `PsiJavaFile`.

Also this PR improves `TypeAnnotation` allowing it to work with nested types:
 * A hierarchy of Java type names was introduced, `EnumName` and `ClassName` being the leaves of the hierarchy.
 * `BeforeNestedTypeDeclaration` insertion point was introduced.
 * `TypeAnnotation` also got the `subject` property to simplify the usage when the type to be annotated is already known.
