### PR TITLE
Improve working with settings

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.renderer
 import com.google.common.collect.ImmutableSet.toImmutableSet
 import io.spine.annotation.Internal
 import io.spine.protodata.ProtoDeclarationName
+import io.spine.protodata.renderer.SourceFileSet.Companion.create
 import io.spine.protodata.type.Convention
 import io.spine.protodata.type.NameElement
 import io.spine.server.query.Querying
@@ -258,9 +259,9 @@ internal constructor(
     }
 
     /**
-     * Applies the given [action] to all the code files which are accessed by a [Renderer].
+     * Applies given [action] to all the code files which are accessed by a [Renderer].
      *
-     * When a file's code is first accessed, runs the given action.
+     * When a file's code is first accessed, the method runs the given action.
      * The action may change the code if necessary, for example,
      * by adding insertion points.
      */
@@ -378,7 +379,7 @@ public class FileCreation<N: ProtoDeclarationName>(
      *
      * If the convention does not define a declaration for the given type, returns `null`.
      *
-     * @param N the type of the Protobuf declaration name such as message, enum, or a service.
+     * @param T the type of the Protobuf declaration name such as message, enum, or a service.
      */
     public fun <L : Language, T : NameElement<L>> namedUsing(
         convention: Convention<L, N, T>

--- a/api/src/main/kotlin/io/spine/protodata/settings/LoadsSettings.kt
+++ b/api/src/main/kotlin/io/spine/protodata/settings/LoadsSettings.kt
@@ -66,6 +66,12 @@ private fun LoadsSettings.missingSettings(): Nothing {
 }
 
 /**
+ * Loads settings with the type specified by the generic parameter [T].
+ */
+public inline fun <reified T: Any> LoadsSettings.loadSettings(): T =
+    loadSettings(T::class.java)
+
+/**
  * Obtains the default ID of the settings consumer which is used
  * for [loading settings][LoadsSettings.loadSettings].
  *

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -926,12 +926,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:20 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.17.2`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2024,12 +2024,12 @@ This report was generated on **Thu Jan 18 02:13:20 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2944,12 +2944,12 @@ This report was generated on **Thu Jan 18 02:13:21 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.2`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4025,12 +4025,12 @@ This report was generated on **Thu Jan 18 02:13:21 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4956,12 +4956,12 @@ This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5880,12 +5880,12 @@ This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6975,12 +6975,12 @@ This report was generated on **Thu Jan 18 02:13:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.17.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7754,12 +7754,12 @@ This report was generated on **Thu Jan 18 02:13:23 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.17.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.17.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8692,4 +8692,4 @@ This report was generated on **Thu Jan 18 02:13:23 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 18 02:13:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 19 23:26:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodegenSettings.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodegenSettings.kt
@@ -52,6 +52,11 @@ public interface CodegenSettings {
     public var requestFilesDir: Any
 
     /**
+     * A directory with settings files for ProtoData.
+     */
+    public var settingsDir: Any
+
+    /**
      * The subdirectories to which the files generated from Protobuf are placed.
      *
      * If the code files that need processing are placed in a few subdirectories within

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,23 +26,18 @@
 
 package io.spine.protodata.gradle
 
-import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
-import org.gradle.api.tasks.SourceSet
-
 /**
- * Utilities for working with `CodeGeneratorRequest` files.
+ * Constants for directory names used by ProtoData.
  */
-public object CodeGeneratorRequestFile {
+public object Directories {
 
     /**
-     * The default name of the subdirectory of the `build` directory where code generation
-     * request files are placed.
+     * The name of the ProtoData working directory under the `build`.
      */
-    @Suppress("ConstPropertyName") // https://bit.ly/kotlin-prop-names
-    public const val defaultDirectory: String = "$PROTODATA_WORKING_DIR/requests"
+    public const val PROTODATA_WORKING_DIR: String = "protodata"
 
     /**
-     * Obtains the name of the file with the code generation request for the given source set.
+     * The name of the directory where the ProtoData settings files are stored.
      */
-    public fun name(sourceSet: SourceSet): String = "${sourceSet.name}.bin"
+    public const val SETTINGS_SUBDIR: String = "settings"
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
@@ -28,8 +28,9 @@ package io.spine.protodata.gradle.plugin
 
 import com.google.common.annotations.VisibleForTesting
 import io.spine.protodata.gradle.CodeGeneratorRequestFile
-import io.spine.protodata.gradle.CodeGeneratorRequestFile.defaultDirectory
 import io.spine.protodata.gradle.CodegenSettings
+import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
+import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.gradle.protobuf.generatedSourceProtoDir
 import org.gradle.api.Project
@@ -40,6 +41,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.listProperty
+import org.jetbrains.kotlin.konan.file.File
 
 /**
  * The `protoData { }` Gradle extension.
@@ -58,6 +60,10 @@ public class Extension(internal val project: Project): CodegenSettings {
         get() = requestFilesDirProperty.get()
         set(value) = requestFilesDirProperty.set(project.file(value))
 
+    override var settingsDir: Any
+        get() = settingsDirProperty.get()
+        set(value) = requestFilesDirProperty.set(project.file(value))
+
     @VisibleForTesting
     public val plugins: ListProperty<String> =
         factory.listProperty<String>().convention(listOf())
@@ -68,7 +74,13 @@ public class Extension(internal val project: Project): CodegenSettings {
 
     internal val requestFilesDirProperty: DirectoryProperty = with(project) {
         objects.directoryProperty().convention(
-            layout.buildDirectory.dir(defaultDirectory)
+            layout.buildDirectory.dir(CodeGeneratorRequestFile.defaultDirectory)
+        )
+    }
+
+    internal val settingsDirProperty: DirectoryProperty = with(project) {
+        objects.directoryProperty().convention(
+            layout.buildDirectory.dir(PROTODATA_WORKING_DIR + File.separatorChar + SETTINGS_SUBDIR)
         )
     }
 
@@ -150,9 +162,6 @@ public class Extension(internal val project: Project): CodegenSettings {
             "grpc",
             "js",
             "dart",
-            //TODO:2024-01-19:alexander.yevsyukov: Remove these two entries.
-            "spine",
-            "protodata"
         )
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
@@ -88,7 +88,7 @@ public class Extension(internal val project: Project): CodegenSettings {
     }
 
     /**
-     * Allows to configure the subdirectories under the generated source set.
+     * Allows configuring the subdirectories under the generated source set.
      *
      * Defaults to [defaultSubdirectories].
      */
@@ -150,6 +150,7 @@ public class Extension(internal val project: Project): CodegenSettings {
             "grpc",
             "js",
             "dart",
+            //TODO:2024-01-19:alexander.yevsyukov: Remove these two entries.
             "spine",
             "protodata"
         )

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -46,6 +46,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -73,11 +74,11 @@ public abstract class LaunchProtoData : JavaExec() {
     public abstract val configurationFile: RegularFileProperty
 
     /**
-     * The directory where settings files for ProtoData components are stored.
+     * The directory which stores ProtoData settings files.
      *
      * If not specified, the project root directory will be used.
      */
-    @get:Internal
+    @get:InputDirectory
     public abstract val settingsDir: DirectoryProperty
 
     @get:Input

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -197,7 +197,7 @@ private fun Provider<List<Directory>>.absolutePaths(): String =
  * Logs error if the given source set contains `proto` directory which contains files,
  * which assumes that the request file should have been created.
  */
-internal fun LaunchProtoData.checkRequestFile(sourceSet: SourceSet): Boolean {
+internal fun LaunchProtoData.hasRequestFile(sourceSet: SourceSet): Boolean {
     val requestFile = requestFile.get().asFile
     if (!requestFile.exists() && sourceSet.containsProtoFiles()) {
         logger.error {

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -181,7 +181,7 @@ private fun Project.createLaunchTask(sourceSet: SourceSet, ext: Extension): Laun
         }
         setPreLaunchCleanup()
         onlyIf {
-            checkRequestFile(sourceSet)
+            hasRequestFile(sourceSet)
         }
         dependsOn(
             protoDataRawArtifact.buildDependencies,

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExts.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,12 @@
 
 package io.spine.protodata.gradle.plugin
 
+import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
+import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
+import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
@@ -54,3 +59,13 @@ internal fun Project.kotlinCompileFor(sourceSet: SourceSet): KotlinCompile<*>? {
     val taskName = sourceSet.getCompileTaskName("Kotlin")
     return tasks.findByName(taskName) as KotlinCompile<*>?
 }
+
+/**
+ * Obtains the provider with the default location of the ProtoData settings directory.
+ *
+ * By convention, ProtoData expects settings under the `build/protodata/settings` directory.
+ */
+public val Project.protoDataSettingsDir: Provider<Directory>
+    get() = layout.buildDirectory.dir(
+        PROTODATA_WORKING_DIR + File.separatorChar + SETTINGS_SUBDIR
+    )

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExts.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/ProjectExts.kt
@@ -26,12 +26,7 @@
 
 package io.spine.protodata.gradle.plugin
 
-import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
-import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
-import java.io.File
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
@@ -59,13 +54,3 @@ internal fun Project.kotlinCompileFor(sourceSet: SourceSet): KotlinCompile<*>? {
     val taskName = sourceSet.getCompileTaskName("Kotlin")
     return tasks.findByName(taskName) as KotlinCompile<*>?
 }
-
-/**
- * Obtains the provider with the default location of the ProtoData settings directory.
- *
- * By convention, ProtoData expects settings under the `build/protodata/settings` directory.
- */
-public val Project.protoDataSettingsDir: Provider<Directory>
-    get() = layout.buildDirectory.dir(
-        PROTODATA_WORKING_DIR + File.separatorChar + SETTINGS_SUBDIR
-    )

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.17.1</version>
+<version>0.17.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.17.1")
+val protoDataVersion: String by extra("0.17.2")


### PR DESCRIPTION
This PR brings the directory for passing settings to ProtoData to the next level of visibility. Namely:
  * The `settingsDir` property for ProtoData Gradle project extension was introduced for allowing customization of the directory.
  * `LaunchProtoData` task now ensures that the directory with settings exists by itself. This is to handle the cases when callers do not need to pass custom settings, and, therefore, there are no tasks that create the directory. Yet, ProtoData CLI app _expects_ that the directory exists, and we want to keep it this way for simplicity. So, `LaunchProtoData` task handles the case of not passing settings to simplify the protocol.

### Other notable changes
  * Added `inline` extension fun which allows to do `loadsSettings<MyType>()` instead of passing the class.
  * Consolidated directory names under the `Directories` object.
  * Improved names of fields of `LanuchProtoData` to avoid the confusion with outdated `Config` types.
  * `spine` and `protodata` directories were removed from defaults of `Extension.defaultSubdirectories` because they are no longer used.
