### PR TITLE
Introduce `CreateSettingsDirectory` task

### DIFF
--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -195,3 +195,20 @@ fun DokkaTask.isInPublishingGraph(): Boolean =
             startsWith("publish") && !startsWith("publishToMavenLocal")
         }
     }
+
+/**
+ * Disables Dokka and Javadoc tasks in this `Project`.
+ *
+ * This function could be useful to improve build speed when building subprojects containing
+ * test environments or integration test projects.
+ */
+fun Project.disableDocumentationTasks() {
+    gradle.taskGraph.whenReady {
+        tasks.forEach { task ->
+            val lowercaseName = task.name.toLowerCase()
+            if (lowercaseName.contains("dokka") || lowercaseName.contains("javadoc")) {
+                task.enabled = false
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.17.0"
+    private const val fallbackVersion = "0.17.2"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.17.0"
+    private const val fallbackDfVersion = "0.17.2"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2024,7 +2024,7 @@ This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2944,7 +2944,7 @@ This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4025,7 +4025,7 @@ This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4956,7 +4956,7 @@ This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5880,7 +5880,7 @@ This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6975,7 +6975,7 @@ This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7754,7 +7754,7 @@ This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8700,4 +8700,4 @@ This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:09:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2024,7 +2024,7 @@ This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2944,7 +2944,7 @@ This report was generated on **Wed Jan 24 17:38:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4025,7 +4025,7 @@ This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4956,7 +4956,7 @@ This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5880,7 +5880,7 @@ This report was generated on **Wed Jan 24 17:38:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6975,7 +6975,7 @@ This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7754,7 +7754,7 @@ This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8700,4 +8700,4 @@ This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 24 17:38:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 18:15:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-api:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -926,12 +926,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-cli:0.17.3`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2024,12 +2024,12 @@ This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:55 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2944,12 +2944,12 @@ This report was generated on **Fri Jan 19 23:26:02 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.3`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4025,12 +4025,12 @@ This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:56 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4956,12 +4956,12 @@ This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5880,12 +5880,12 @@ This report was generated on **Fri Jan 19 23:26:03 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6975,12 +6975,12 @@ This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.17.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7754,12 +7754,12 @@ This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.17.2`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.17.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8430,7 +8430,15 @@ This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.10.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.10.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8692,4 +8700,4 @@ This report was generated on **Fri Jan 19 23:26:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 19 23:26:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 24 17:09:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodeGeneratorRequestFile.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodeGeneratorRequestFile.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata.gradle
 
 import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
+import io.spine.protodata.gradle.Directories.REQUESTS_SUBDIR
 import org.gradle.api.tasks.SourceSet
 
 /**
@@ -39,7 +40,7 @@ public object CodeGeneratorRequestFile {
      * request files are placed.
      */
     @Suppress("ConstPropertyName") // https://bit.ly/kotlin-prop-names
-    public const val defaultDirectory: String = "$PROTODATA_WORKING_DIR/requests"
+    public const val defaultDirectory: String = "$PROTODATA_WORKING_DIR/$REQUESTS_SUBDIR"
 
     /**
      * Obtains the name of the file with the code generation request for the given source set.

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodegenSettings.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/CodegenSettings.kt
@@ -52,11 +52,6 @@ public interface CodegenSettings {
     public var requestFilesDir: Any
 
     /**
-     * A directory with settings files for ProtoData.
-     */
-    public var settingsDir: Any
-
-    /**
      * The subdirectories to which the files generated from Protobuf are placed.
      *
      * If the code files that need processing are placed in a few subdirectories within

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
@@ -40,4 +40,10 @@ public object Directories {
      * The name of the directory where the ProtoData settings files are stored.
      */
     public const val SETTINGS_SUBDIR: String = "settings"
+
+    /**
+     * The name of the directory where [code generation requests files][CodeGeneratorRequestFile]
+     * are stored.
+     */
+    public const val REQUESTS_SUBDIR: String = "requests"
 }

--- a/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
+++ b/gradle-api/src/main/kotlin/io/spine/protodata/gradle/Directories.kt
@@ -32,18 +32,20 @@ package io.spine.protodata.gradle
 public object Directories {
 
     /**
-     * The name of the ProtoData working directory under the `build`.
+     * The name of the ProtoData working directory which is conventionally
+     * placed under the `build` directory.
      */
     public const val PROTODATA_WORKING_DIR: String = "protodata"
 
     /**
-     * The name of the directory where the ProtoData settings files are stored.
+     * The name of the subdirectory under [PROTODATA_WORKING_DIR] where
+     * the ProtoData settings files are stored.
      */
     public const val SETTINGS_SUBDIR: String = "settings"
 
     /**
-     * The name of the directory where [code generation requests files][CodeGeneratorRequestFile]
-     * are stored.
+     * The name of the subdirectory under [PROTODATA_WORKING_DIR] where
+     * [code generation requests files][CodeGeneratorRequestFile] are stored.
      */
     public const val REQUESTS_SUBDIR: String = "requests"
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.gradle.plugin
+
+import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
+import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+public abstract class CreateSettingsDirectory: DefaultTask() {
+
+    @get:OutputDirectory
+    public abstract val settingsDir: DirectoryProperty
+
+    init {
+        @Suppress("LeakingThis") // As advised by Gradle docs.
+        settingsDir.convention(
+            project.layout.buildDirectory.dir("$PROTODATA_WORKING_DIR/$SETTINGS_SUBDIR")
+        )
+    }
+
+    @TaskAction
+    internal fun createDirectory() {
+        project.ensureSettingsDirExists(settingsDir.get().asFile)
+    }
+}
+
+/**
+ * Ensures that the settings directory exists.
+ *
+ * ProtoData CLI expects that the directory exists.
+ * ProtoData may be configured to run without settings, e.g., when running tests.
+ *
+ * Normally, there will be a task that writes settings for ProtoData, and `LaunchProtoData`
+ * task would depend on this task.
+ *
+ * This function handles the case when the directory is missed.
+ * If the directory does not exist, it creates it performing logging operations
+ * using the project logger.
+ */
+private fun Project.ensureSettingsDirExists(settingsDirectory: File) {
+    if (!settingsDirectory.exists()) {
+        if (settingsDirectory.mkdirs()) {
+            logger.warn(
+                "The ProtoData settings directory has been created: `{}`.",
+                settingsDirectory
+            )
+        } else {
+            logger.error(
+                "Unable to create the ProtoData settings directory: `{}`.",
+                settingsDirectory)
+        }
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
@@ -35,8 +35,16 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+/**
+ * Creates a directory for storing settings files passed to ProtoData.
+ */
 public abstract class CreateSettingsDirectory: DefaultTask() {
 
+    /**
+     * The directory to store ProtoData settings files.
+     *
+     * Default value is `$buildDir/protodata/settings`.
+     */
     @get:OutputDirectory
     public abstract val settingsDir: DirectoryProperty
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/CreateSettingsDirectory.kt
@@ -70,7 +70,7 @@ public abstract class CreateSettingsDirectory: DefaultTask() {
  * Normally, there will be a task that writes settings for ProtoData, and `LaunchProtoData`
  * task would depend on this task.
  *
- * This function handles the case when the directory is missed.
+ * This function handles the case when the directory is missing.
  * If the directory does not exist, it creates it performing logging operations
  * using the project logger.
  */

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Extension.kt
@@ -29,8 +29,6 @@ package io.spine.protodata.gradle.plugin
 import com.google.common.annotations.VisibleForTesting
 import io.spine.protodata.gradle.CodeGeneratorRequestFile
 import io.spine.protodata.gradle.CodegenSettings
-import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
-import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.gradle.protobuf.generatedSourceProtoDir
 import org.gradle.api.Project
@@ -41,7 +39,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.listProperty
-import org.jetbrains.kotlin.konan.file.File
 
 /**
  * The `protoData { }` Gradle extension.
@@ -60,10 +57,6 @@ public class Extension(internal val project: Project): CodegenSettings {
         get() = requestFilesDirProperty.get()
         set(value) = requestFilesDirProperty.set(project.file(value))
 
-    override var settingsDir: Any
-        get() = settingsDirProperty.get()
-        set(value) = requestFilesDirProperty.set(project.file(value))
-
     @VisibleForTesting
     public val plugins: ListProperty<String> =
         factory.listProperty<String>().convention(listOf())
@@ -75,12 +68,6 @@ public class Extension(internal val project: Project): CodegenSettings {
     internal val requestFilesDirProperty: DirectoryProperty = with(project) {
         objects.directoryProperty().convention(
             layout.buildDirectory.dir(CodeGeneratorRequestFile.defaultDirectory)
-        )
-    }
-
-    internal val settingsDirProperty: DirectoryProperty = with(project) {
-        objects.directoryProperty().convention(
-            layout.buildDirectory.dir(PROTODATA_WORKING_DIR + File.separatorChar + SETTINGS_SUBDIR)
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -44,7 +44,7 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -67,8 +67,11 @@ import org.gradle.api.tasks.SourceSet
  */
 public abstract class LaunchProtoData : JavaExec() {
 
+    /**
+     * The file containing the binary form of `CodeGeneratorRequest` passed to this task.
+     */
     @get:InputFile
-    internal lateinit var requestFile: Provider<RegularFile>
+    internal abstract val requestFile: RegularFileProperty
 
     /**
      * The directory which stores ProtoData settings files.

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -33,8 +33,6 @@ import io.spine.protodata.cli.SettingsDirParam
 import io.spine.protodata.cli.SourceRootParam
 import io.spine.protodata.cli.TargetRootParam
 import io.spine.protodata.cli.UserClasspathParam
-import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
-import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
 import io.spine.protodata.gradle.error
 import io.spine.protodata.gradle.info
 import io.spine.tools.gradle.protobuf.containsProtoFiles
@@ -106,13 +104,6 @@ public abstract class LaunchProtoData : JavaExec() {
      */
     @get:OutputDirectories
     internal lateinit var targets: Provider<List<Directory>>
-
-    init {
-        @Suppress("LeakingThis") // As advised by Gradle docs.
-        settingsDir.convention(
-            project.layout.buildDirectory.dir("$PROTODATA_WORKING_DIR/$SETTINGS_SUBDIR")
-        )
-    }
 
     /**
      * Configures the CLI command for this task.

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -72,11 +72,9 @@ public abstract class LaunchProtoData : JavaExec() {
 
     /**
      * The directory which stores ProtoData settings files.
-     *
-     * If not specified, the project root directory will be used.
      */
     @get:InputDirectory
-    public abstract val settingsDir: DirectoryProperty
+    internal abstract val settingsDir: DirectoryProperty
 
     @get:Input
     internal lateinit var plugins: Provider<List<String>>
@@ -145,12 +143,7 @@ public abstract class LaunchProtoData : JavaExec() {
             }
 
             yield(SettingsDirParam.name)
-            val dir = if (settingsDir.isPresent) {
-                project.file(settingsDir).absolutePath
-            } else {
-                project.projectDir.absolutePath
-            }
-            yield(dir)
+            yield(project.file(settingsDir).absolutePath)
         }.asIterable()
         logger.info { "ProtoData command for `${path}`: ${command.joinToString(separator = " ")}" }
         classpath(protoDataConfiguration)

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -82,9 +82,6 @@ public abstract class LaunchProtoData : JavaExec() {
     @get:Input
     internal lateinit var plugins: Provider<List<String>>
 
-    @get:Input
-    internal lateinit var optionProviders: Provider<List<String>>
-
     /**
      * The paths to the directories with the generated source code.
      *

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -33,22 +33,23 @@ import io.spine.protodata.cli.SettingsDirParam
 import io.spine.protodata.cli.SourceRootParam
 import io.spine.protodata.cli.TargetRootParam
 import io.spine.protodata.cli.UserClasspathParam
+import io.spine.protodata.gradle.Directories.PROTODATA_WORKING_DIR
+import io.spine.protodata.gradle.Directories.SETTINGS_SUBDIR
 import io.spine.protodata.gradle.error
 import io.spine.protodata.gradle.info
 import io.spine.tools.gradle.protobuf.containsProtoFiles
-import java.io.File
 import java.io.File.pathSeparator
 import org.gradle.api.Action
-import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectories
@@ -74,8 +75,8 @@ public abstract class LaunchProtoData : JavaExec() {
      *
      * If not specified, the project root directory will be used.
      */
-    @get:Internal
-    internal lateinit var settingsDir: Provider<Directory>
+    @get:InputDirectory
+    public abstract val settingsDir: DirectoryProperty
 
     @get:Input
     internal lateinit var plugins: Provider<List<String>>
@@ -107,6 +108,13 @@ public abstract class LaunchProtoData : JavaExec() {
      */
     @get:OutputDirectories
     internal lateinit var targets: Provider<List<Directory>>
+
+    init {
+        @Suppress("LeakingThis") // As advised by Gradle docs.
+        settingsDir.convention(
+            project.layout.buildDirectory.dir("$PROTODATA_WORKING_DIR/$SETTINGS_SUBDIR")
+        )
+    }
 
     /**
      * Configures the CLI command for this task.
@@ -153,10 +161,6 @@ public abstract class LaunchProtoData : JavaExec() {
 
     internal fun setPreLaunchCleanup() {
         doFirst(CleanAction())
-    }
-
-    internal fun ensureSettingsDirectory(settingsDirectory: File) {
-        doFirst { project.ensureSettingsDirExists(settingsDirectory) }
     }
 
     /**
@@ -210,30 +214,3 @@ internal fun LaunchProtoData.hasRequestFile(sourceSet: SourceSet): Boolean {
     return requestFile.exists()
 }
 
-/**
- * Ensures that the settings directory exists.
- *
- * ProtoData CLI expects that the directory exists.
- * ProtoData may be configured to run without settings, e.g., when running tests.
- *
- * Normally, there will be a task that writes settings for ProtoData, and `LaunchProtoData`
- * task would depend on this task.
- *
- * This function handles the case when the directory is missed.
- * If the directory does not exist, it creates it performing logging operations
- * using the project logger.
- */
-private fun Project.ensureSettingsDirExists(settingsDirectory: File) {
-    if (!settingsDirectory.exists()) {
-        if (settingsDirectory.mkdirs()) {
-            logger.warn(
-                "The ProtoData settings directory has been created: `{}`.",
-                settingsDirectory
-            )
-        } else {
-            logger.error(
-                "Unable to create the ProtoData settings directory: `{}`.",
-                settingsDirectory)
-        }
-    }
-}

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -465,7 +465,9 @@ private fun Project.configureIdea() {
  * Excludes the given directory and its immediate subdirectories from
  * being seen as ones with the source code.
  *
- * The primary use of this extension is to exclude `build/generated/source`.
+ * The primary use of this extension is to exclude `build/generated/source/proto` and its
+ * subdirectories to avoid duplication of types in the generated code with those in
+ * produced by ProtoData under the `$projectDir/generated/` directory.
  */
 private fun IdeaModule.excludeWithNested(directory: File) {
     if (directory.exists()) {

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -181,7 +181,6 @@ private fun Project.createLaunchTask(
     val result = tasks.create<LaunchProtoData>(taskName) {
         settingsDir.set(settingsDirTask.settingsDir.get())
         plugins = ext.plugins
-        optionProviders = ext.optionProviders
         requestFile.set(ext.requestFile(sourceSet))
         protoDataConfiguration = protoDataRawArtifact
         userClasspathConfiguration = userClasspath

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/Plugin.kt
@@ -182,7 +182,7 @@ private fun Project.createLaunchTask(
         settingsDir.set(settingsDirTask.settingsDir.get())
         plugins = ext.plugins
         optionProviders = ext.optionProviders
-        requestFile = ext.requestFile(sourceSet)
+        requestFile.set(ext.requestFile(sourceSet))
         protoDataConfiguration = protoDataRawArtifact
         userClasspathConfiguration = userClasspath
         project.afterEvaluate {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.17.2</version>
+<version>0.17.3</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -312,7 +312,17 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>gfm-plugin</artifactId>
+    <version>1.9.10</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
     <artifactId>javadoc-plugin</artifactId>
+    <version>1.9.10</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>jekyll-plugin</artifactId>
     <version>1.9.10</version>
   </dependency>
   <dependency>

--- a/test-env/build.gradle.kts
+++ b/test-env/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,3 +57,8 @@ protobuf {
 tasks.withType<PublishToMavenRepository>().configureEach {
     onlyIf { false }
 }
+
+/**
+ * No need to generate the documentation for test environment code.
+ */
+disableDocumentationTasks()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.17.2")
+val protoDataVersion: String by extra("0.17.3")


### PR DESCRIPTION
This PR introduces `CreateSettingsDirectory` task type which simply ensures that a directory for ProtoData settings files exists.

The task is needed for these reasons:
 * We need some code for ensuring the directory _when_ there are no other tasks that create setting files.
 * Having a task for this is the way recommended by Gradle and implied by the rules of validating `@InputDirectory` properties.
 * Should the user need to configure the settings directory, the task property is the place.

### Other notable changes
 * The property `settingsDir` was removed from `CodegenSettings` interface and `Extension` class accordingly.
 * Constants for directory names were consolidated under the `Directories` object.
 * Documentation tasks are disabled for `test-env` module.
 * `LaunchProtoData.requestFile` property became `val` and got type `RegularFileProperty` (instead of `Provider<RegularFile>`) for simplicity.
 * `LaunchProtoData.settingsDir` also became `val` an got type `DirectoryProperty` for the same reason.
 * `LaunchProtoData` task now depends on `CreateSettingsDirectory`.
 * The property `LaunchProtoData.optionProviders`  was removed as it's not used for quite some time.
