### PR TITLE
Simplify annotation check flow

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceAtLine.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceAtLine.kt
@@ -31,7 +31,6 @@ import io.spine.string.Indent
 import io.spine.string.Indent.Companion.DEFAULT_JAVA_INDENT_SIZE
 import io.spine.string.Separator
 import io.spine.string.atLevel
-import io.spine.text.TextFactory.lineSplitter
 
 /**
  * A fluent builder for inserting code into pre-prepared insertion points.
@@ -78,7 +77,7 @@ internal constructor(
         val sourceLines = text.lines()
         val locations = point.locate(text).map { it.wholeLine }
         val newCode = lines.indent(indent, indentLevel)
-        val newLines = lineSplitter().splitToList(newCode)
+        val newLines = newCode.lines()
         var alreadyInsertedCount = 0
         val updatedLines = ArrayList(sourceLines)
         sourceLines.forEachIndexed { index, _ ->

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
@@ -269,6 +269,9 @@ private constructor(
         return text(code)
     }
 
+    /**
+     * Adds an action to be executed before obtaining the [text] of this source file.
+     */
     internal fun whenRead(action: (SourceFile) -> Unit) {
         preReadActions.add(action)
         if (alreadyRead) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -35,6 +35,7 @@ import io.spine.protodata.renderer.SourceFile
 import io.spine.protodata.renderer.SourceFileSet
 import java.lang.annotation.ElementType.TYPE
 import java.lang.annotation.Target
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * A [JavaRenderer] which annotates a Java type using the given [annotation][annotationClass].
@@ -95,7 +96,9 @@ public abstract class TypeAnnotation<T : Annotation>(
             annotateMany(sources)
         } else {
             val file = this.file ?: subjectFileIn(sources)
-            annotate(file)
+            if (shouldAnnotate(file)) {
+                annotate(file)
+            }
         }
     }
 
@@ -107,18 +110,17 @@ public abstract class TypeAnnotation<T : Annotation>(
         return file
     }
 
-    private fun annotateMany(sources: SourceFileSet) {
-        sources.filter {
-            shouldAnnotate(it)
-        }.forEach {
-            annotate(it)
-        }
+    private fun annotateMany(sources: SourceFileSet) = sources.forEach {
+        annotate(it)
     }
 
-    private fun annotate(file: SourceFile) {
-        val line = file.at(insertionPoint())
-        val annotationCode = annotationCode(file)
-        line.add(annotationCode)
+    @VisibleForTesting
+    internal fun annotate(file: SourceFile) {
+        if (shouldAnnotate(file)) {
+            val line = file.at(insertionPoint())
+            val annotationCode = annotationCode(file)
+            line.add(annotationCode)
+        }
     }
 
     private fun insertionPoint() =
@@ -207,5 +209,5 @@ public abstract class TypeAnnotation<T : Annotation>(
 private val <T: Annotation> Class<T>.isRepeatable: Boolean
     get() = isAnnotationPresent(Repeatable::class.java)
 
-private val <T: Annotation> Class<T>.codeReference: String
+internal val <T: Annotation> Class<T>.codeReference: String
     get() = if (isJavaLang) simpleName else name

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -96,9 +96,7 @@ public abstract class TypeAnnotation<T : Annotation>(
             annotateMany(sources)
         } else {
             val file = this.file ?: subjectFileIn(sources)
-            if (shouldAnnotate(file)) {
-                annotate(file)
-            }
+            annotate(file)
         }
     }
 

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -110,9 +110,10 @@ public abstract class TypeAnnotation<T : Annotation>(
         return file
     }
 
-    private fun annotateMany(sources: SourceFileSet) = sources.forEach {
-        annotate(it)
-    }
+    private fun annotateMany(sources: SourceFileSet) =
+        sources.forEach {
+            annotate(it)
+        }
 
     @VisibleForTesting
     internal fun annotate(file: SourceFile) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -93,7 +93,9 @@ public abstract class TypeAnnotation<T : Annotation>(
 
     final override fun render(sources: SourceFileSet) {
         if (!specific) {
-            annotateMany(sources)
+            sources.forEach {
+                annotate(it)
+            }
         } else {
             val file = this.file ?: subjectFileIn(sources)
             annotate(file)
@@ -107,11 +109,6 @@ public abstract class TypeAnnotation<T : Annotation>(
         }
         return file
     }
-
-    private fun annotateMany(sources: SourceFileSet) =
-        sources.forEach {
-            annotate(it)
-        }
 
     @VisibleForTesting
     internal fun annotate(file: SourceFile) {

--- a/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
+++ b/codegen/java/src/main/kotlin/io/spine/protodata/codegen/java/annotation/TypeAnnotation.kt
@@ -205,5 +205,11 @@ public abstract class TypeAnnotation<T : Annotation>(
 private val <T: Annotation> Class<T>.isRepeatable: Boolean
     get() = isAnnotationPresent(Repeatable::class.java)
 
+/**
+ * Obtains the code which is used for referencing this annotation class in Java code.
+ *
+ * @return a simple class name for the class beloging to `java.lang` package.
+ *          Otherwise, a fully qualified name is returned.
+ */
 internal val <T: Annotation> Class<T>.codeReference: String
     get() = if (isJavaLang) simpleName else name

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-api:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -926,12 +926,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:49 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-cli:0.17.5`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2024,12 +2024,12 @@ This report was generated on **Wed Jan 31 21:41:49 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2944,12 +2944,12 @@ This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-codegen-java:0.17.5`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4025,12 +4025,12 @@ This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-compiler:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-compiler:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4956,12 +4956,12 @@ This report was generated on **Wed Jan 31 21:41:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5880,12 +5880,12 @@ This report was generated on **Wed Jan 31 21:41:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6975,12 +6975,12 @@ This report was generated on **Wed Jan 31 21:41:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.17.5`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7754,12 +7754,12 @@ This report was generated on **Wed Jan 31 21:41:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.17.4`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.17.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8700,4 +8700,4 @@ This report was generated on **Wed Jan 31 21:41:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 31 21:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2024,7 +2024,7 @@ This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2944,7 +2944,7 @@ This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4025,7 +4025,7 @@ This report was generated on **Thu Feb 01 14:57:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4956,7 +4956,7 @@ This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5880,7 +5880,7 @@ This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6975,7 +6975,7 @@ This report was generated on **Thu Feb 01 14:57:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7754,7 +7754,7 @@ This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8700,4 +8700,4 @@ This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 01 14:57:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 01 16:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.17.4</version>
+<version>0.17.5</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.17.4")
+val protoDataVersion: String by extra("0.17.5")


### PR DESCRIPTION
This PR updates the `TypeAnnotation` class to simplify the check whether an annotation should be put into the code.

Previously, `shouldAnnotate()` method was called only when annotating multiple files. In some cases, the check is also needed when handling annotation of only one file (when calling `annotate(SourceFile)`). In such a case we need to see if a source code was _already_ annotated via another `Renderer` which delegates to `TypeAnnotation`. So, now `annotate()` calls `shouldAnnotate()` first.

### Other notable changes
  * A cache was introduced for avoiding repeated parsing when obtaining `PsiJavaFile` instance for a `Text` instance.
  * Kotlin-based line splitting is now used in `SourceAtLine` instead of using `TextFactory.lineSplitter()`. It is expected that `lineSplitter()` would be [deprecated ](https://github.com/SpineEventEngine/text/issues/7) in Text library soon.


