### PR TITLE
Trim licenses and unnecessary files from `protodata-fat-cli` publication

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -86,9 +86,6 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     </codeStyleSettings>
     <codeStyleSettings language="protobuf">
       <indentOptions>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -198,15 +198,16 @@ dependencies {
 dependOnBuildSrcJar()
 
 /**
- * Adds a dependency on a `buildSrc.jar`, iff `src` folder is missing,
- * and `buildSrc.jar` is present in `buildSrc/` folder instead.
+ * Adds a dependency on a `buildSrc.jar`, iff:
+ *  1) the `src` folder is missing, and
+ *  2) `buildSrc.jar` is present in `buildSrc/` folder instead.
  *
- * This approach is used in scope of integration testing.
+ * This approach is used in the scope of integration testing.
  */
 fun Project.dependOnBuildSrcJar() {
     val srcFolder = this.rootDir.resolve("src")
     val buildSrcJar = rootDir.resolve("buildSrc.jar")
-    if(!srcFolder.exists() && buildSrcJar.exists()) {
+    if (!srcFolder.exists() && buildSrcJar.exists()) {
         logger.info("Adding the pre-compiled 'buildSrc.jar' to 'implementation' dependencies.")
         dependencies {
             implementation(files("buildSrc.jar"))

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,9 +132,9 @@ val PluginDependenciesSpec.kover: PluginDependencySpec
  * Configures the dependencies between third-party Gradle tasks
  * and those defined via ProtoData and Spine Model Compiler.
  *
- * It is required to avoid warnings in build logs, detecting the undeclared
+ * It is required in order to avoid warnings in build logs, detecting the undeclared
  * usage of Spine-specific task output by other tasks,
- * e.g., the output of `launchProtoData` is used by `compileKotlin`.
+ * e.g. the output of `launchProtoData` is used by `compileKotlin`.
  */
 @Suppress("unused")
 fun Project.configureTaskDependencies() {

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -168,6 +168,19 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
 }
 
 /**
+ * Tells if this task belongs to the execution graph which contains publishing tasks.
+ *
+ * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
+ * the local testing workflow.
+ */
+fun DokkaTask.isInPublishingGraph(): Boolean =
+    project.gradle.taskGraph.allTasks.any {
+        with(it.name) {
+            startsWith("publish") && !startsWith("publishToMavenLocal")
+        }
+    }
+
+/**
  * Locates or creates `dokkaJavaJar` task in this [Project].
  *
  * The output of this task is a `jar` archive. The archive contains the Dokka output, generated upon

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -168,19 +168,6 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains publishing tasks.
- *
- * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
- * the local testing workflow.
- */
-fun DokkaTask.isInPublishingGraph(): Boolean =
-    project.gradle.taskGraph.allTasks.any {
-        with(it.name) {
-            startsWith("publish") && !startsWith("publishToMavenLocal")
-        }
-    }
-
-/**
  * Locates or creates `dokkaJavaJar` task in this [Project].
  *
  * The output of this task is a `jar` archive. The archive contains the Dokka output, generated upon
@@ -195,6 +182,19 @@ fun Project.dokkaJavaJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaJavaJar"
         this@getOrCreate.dependsOn(dokkaTask)
     }
 }
+
+/**
+ * Tells if this task belongs to the execution graph which contains publishing tasks.
+ *
+ * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
+ * the local testing workflow.
+ */
+fun DokkaTask.isInPublishingGraph(): Boolean =
+    project.gradle.taskGraph.allTasks.any {
+        with(it.name) {
+            startsWith("publish") && !startsWith("publishToMavenLocal")
+        }
+    }
 
 /**
  * Disables Dokka and Javadoc tasks in this `Project`.

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -184,19 +184,6 @@ fun Project.dokkaJavaJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaJavaJar"
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains publishing tasks.
- *
- * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
- * the local testing workflow.
- */
-fun DokkaTask.isInPublishingGraph(): Boolean =
-    project.gradle.taskGraph.allTasks.any {
-        with(it.name) {
-            startsWith("publish") && !startsWith("publishToMavenLocal")
-        }
-    }
-
-/**
  * Disables Dokka and Javadoc tasks in this `Project`.
  *
  * This function could be useful to improve build speed when building subprojects containing

--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+@file:Suppress("unused")
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository

--- a/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,4 +37,7 @@ dependencies {
 
 tasks.withType<DokkaTask>().configureEach {
     configureForJava()
+    onlyIf {
+        (it as DokkaTask).isInPublishingGraph()
+    }
 }

--- a/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
@@ -37,7 +37,4 @@ dependencies {
 
 tasks.withType<DokkaTask>().configureEach {
     configureForJava()
-    onlyIf {
-        (it as DokkaTask).isInPublishingGraph()
-    }
 }

--- a/buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,4 +36,7 @@ dependencies {
 
 tasks.withType<DokkaTask>().configureEach {
     configureForKotlin()
+    onlyIf {
+        (it as DokkaTask).isInPublishingGraph()
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,16 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.jetbrains.dokka.gradle.DokkaTask
+package io.spine.internal.dependency
 
-plugins {
-    id("org.jetbrains.dokka") // Cannot use `Dokka` dependency object here yet.
-}
-
-dependencies {
-    useDokkaWithSpineExtensions()
-}
-
-tasks.withType<DokkaTask>().configureEach {
-    configureForKotlin()
+/**
+ * Kotlin Coroutines.
+ * 
+ * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub projecet</a>
+ */
+@Suppress("unused")
+object Coroutines {
+    const val version = "1.6.4"
+    const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
+    const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
+    const val bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:$version"
+    const val coreJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,16 +24,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.jetbrains.dokka.gradle.DokkaTask
+package io.spine.internal.dependency
 
-plugins {
-    id("org.jetbrains.dokka") // Cannot use `Dokka` dependency object here yet.
-}
+/**
+ * gRPC-Kotlin/JVM.
+ *
+ * @see <a href="https://github.com/grpc/grpc-kotlin">GitHub project</a>
+ */
+@Suppress("unused")
+object GrpcKotlin {
+    const val version = "1.3.0"
+    const val stub = "io.grpc:grpc-kotlin-stub:$version"
 
-dependencies {
-    useDokkaWithSpineExtensions()
-}
-
-tasks.withType<DokkaTask>().configureEach {
-    configureForKotlin()
+    object ProtocPlugin {
+        const val id = "grpckt"
+        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version:jdk8@jar"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -50,11 +50,40 @@ object IntelliJ {
         private const val group = "com.jetbrains.intellij.platform"
         const val core = "$group:core:$version"
         const val util = "$group:util:$version"
+        const val coreImpl = "$group:core-impl:$version"
+        const val codeStyle = "$group:code-style:$version"
+        const val codeStyleImpl = "$group:code-style-impl:$version"
+        const val projectModel = "$group:project-model:$version"
+        const val projectModelImpl = "$group:project-model-impl:$version"
+        const val lang = "$group:lang:$version"
+        const val langImpl = "$group:lang-impl:$version"
+        const val ideImpl = "$group:ide-impl:$version"
+        const val ideCoreImpl = "$group:ide-core-impl:$version"
+        const val analysisImpl = "$group:analysis-impl:$version"
+        const val indexingImpl = "$group:indexing-impl:$version"
+    }
+
+    object Jsp {
+        private const val group = "com.jetbrains.intellij.jsp"
+        @Suppress("MemberNameEqualsClassName")
+        const val jsp = "$group:jsp:$version"
+    }
+
+    object Xml {
+        private const val group = "com.jetbrains.intellij.xml"
+        const val xmlPsiImpl = "$group:xml-psi-impl:$version"
     }
 
     object JavaPsi {
         private const val group = "com.jetbrains.intellij.java"
         const val api = "$group:java-psi:$version"
         const val impl = "$group:java-psi-impl:$version"
+    }
+
+    object Java {
+        private const val group = "com.jetbrains.intellij.java"
+        @Suppress("MemberNameEqualsClassName")
+        const val java = "$group:java:$version"
+        const val impl = "$group:java-impl:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.19.0"
+    private const val fallbackVersion = "0.20.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.19.0"
+    private const val fallbackDfVersion = "0.20.1"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -80,13 +80,25 @@ internal sealed class PublicationHandler(
     }
 
     /**
-     * Takes a group name and a version from the given [project] and assigns
-     * them to this publication.
+     * Copies the attributes of Gradle [Project] to this [MavenPublication].
+     *
+     * The following project attributes are copied:
+     *  * [group][Project.getGroup];
+     *  * [version][Project.getVersion];
+     *  * [description][Project.getDescription].
+     *
+     * Also, this function adds the [artifactPrefix][SpinePublishing.artifactPrefix] to
+     * the [artifactId][MavenPublication.setArtifactId] of this publication,
+     * if the prefix is not added yet.
      */
-    protected fun MavenPublication.assignMavenCoordinates() {
+    protected fun MavenPublication.copyProjectAttributes() {
         groupId = project.group.toString()
-        artifactId = project.spinePublishing.artifactPrefix + artifactId
+        val prefix = project.spinePublishing.artifactPrefix
+        if (!artifactId.startsWith(prefix)) {
+            artifactId = prefix + artifactId
+        }
         version = project.version.toString()
+        pom.description.set(project.description)
     }
 }
 
@@ -110,7 +122,7 @@ private fun RepositoryHandler.register(project: Project, repository: Repository)
 /**
  * A publication for a typical Java project.
  *
- * In Gradle, in order to publish something somewhere one should create a publication.
+ * In Gradle, to publish something, one should create a publication.
  * A publication has a name and consists of one or more artifacts plus information about
  * those artifacts – the metadata.
  *
@@ -142,7 +154,7 @@ internal class StandardJavaPublicationHandler(
         val jars = project.artifacts(jarFlags)
         val publications = project.publications
         publications.create<MavenPublication>("mavenJava") {
-            assignMavenCoordinates()
+            copyProjectAttributes()
             specifyArtifacts(jars)
         }
     }
@@ -191,14 +203,14 @@ internal class StandardJavaPublicationHandler(
  *
  * Such publications should be treated differently than [StandardJavaPublicationHandler],
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
- * this class only [assigns maven coordinates][assignMavenCoordinates].
+ * this class only [assigns maven coordinates][copyProjectAttributes].
  *
  * A module which declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,
  * it may cause a name clash between an artifact produced by the [standard][MavenPublication]
- * publication, and custom ones. In order to have both standard and custom publications,
+ * publication, and custom ones. To have both standard and custom publications,
  * please specify custom artifact IDs or classifiers for each custom publication.
  */
 internal class CustomPublicationHandler(project: Project, destinations: Set<Repository>) :
@@ -206,7 +218,7 @@ internal class CustomPublicationHandler(project: Project, destinations: Set<Repo
 
     override fun handlePublications() {
         project.publications.forEach {
-            (it as MavenPublication).assignMavenCoordinates()
+            (it as MavenPublication).copyProjectAttributes()
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +142,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * Set of modules to be published.
      *
-     * Both module's name or path can be used.
+     * Both the module's name or path can be used.
      *
      * Use this property if the extension is configured from a root project's build file.
      *
@@ -180,7 +180,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * A prefix to be added before the name of each artifact.
      *
-     * Default value is "spine-".
+     * The default value is "spine-".
      */
     var artifactPrefix: String = "spine-"
 
@@ -188,7 +188,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows disabling publishing of [protoJar] artifact, containing all Proto sources
      * from `sourceSets.main.proto`.
      *
-     * Here's an example of how to disable it for some of published modules:
+     * Here's an example of how to disable it for some of the published modules:
      *
      * ```
      * spinePublishing {
@@ -214,8 +214,8 @@ open class SpinePublishing(private val project: Project) {
      * }
      * ```
      *
-     * The resulting artifact is available under "proto" classifier. I.e., in Gradle 7+, one could
-     * depend on it like this:
+     * The resulting artifact is available under "proto" classifier.
+     * For example, in Gradle 7+, one could depend on it like this:
      *
      * ```
      * implementation("io.spine:spine-client:$version@proto")
@@ -227,7 +227,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows enabling publishing of [testJar] artifact, containing compilation output
      * of "test" source set.
      *
-     * Here's an example of how to enable it for some of published modules:
+     * Here's an example of how to enable it for some of the published modules:
      *
      * ```
      * spinePublishing {

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -45,6 +45,8 @@ import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
 import io.spine.internal.gradle.report.license.LicenseReporter
 import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.kotlin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -53,11 +55,11 @@ plugins {
     id("net.ltgt.errorprone")
     id("pmd-settings")
     id("project-report")
+    id("dokka-for-java")
     kotlin("jvm")
     id("io.kotest")
     id("org.jetbrains.kotlinx.kover")
     id("detekt-code-analysis")
-    id("dokka-for-java")
     id("dokka-for-kotlin")
 }
 

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -111,7 +111,7 @@ val exposeManifestForTests by tasks.creating {
         val manifest = Manifest()
 
         // The manifest version attribute is crucial for writing.
-        // It it's absent nothing would be written.
+        // If it's absent, nothing would be written.
         manifest.mainAttributes[MANIFEST_VERSION] = "1.0"
 
         manifestAttributes.forEach { entry ->

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,6 +184,26 @@ tasks.shadowJar {
     mergeServiceFiles("desc.ref")
     mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
     isZip64 = true
+    exclude(
+        // Exclude license files that cause or may cause issues with LicenseReport.
+        // We analyze these files when building artifacts we depend on.
+        "about_files/**",
+        "license/**",
+
+        "ant_tasks/**", // `resource-ant.jar` is of no use here.
+
+        /* Exclude `https://github.com/JetBrains/pty4j`.
+          We don't need the terminal. */
+        "resources/com/pty4j/**",
+
+        // Protobuf files.
+        "google/**",
+        "spine/**",
+        "src/**",
+
+        // Java source code files of the package `org.osgi`.
+        "OSGI-OPT/**"
+    )
 }
 
 // See https://github.com/johnrengelman/shadow/issues/153.

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:51:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1857,7 +1857,7 @@ This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:51:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2815,7 +2815,7 @@ This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:51:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3735,7 +3735,7 @@ This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:51:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4659,7 +4659,7 @@ This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:51:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5754,7 +5754,7 @@ This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:52:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6685,7 +6685,7 @@ This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:52:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7475,7 +7475,7 @@ This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:52:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8431,4 +8431,4 @@ This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:52:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -926,12 +926,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-backend:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1857,12 +1857,12 @@ This report was generated on **Sat Mar 16 16:33:13 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2815,12 +2815,12 @@ This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -3735,12 +3735,12 @@ This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4659,12 +4659,12 @@ This report was generated on **Sat Mar 16 16:33:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5754,12 +5754,12 @@ This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-java:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6685,12 +6685,12 @@ This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.20.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7475,12 +7475,12 @@ This report was generated on **Sat Mar 16 16:33:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.20.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.20.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8431,4 +8431,4 @@ This report was generated on **Sat Mar 16 16:33:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 16 16:33:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 19 17:07:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.20.1</version>
+<version>0.20.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.20.1")
+val protoDataVersion: String by extra("0.20.2")


### PR DESCRIPTION
This PR trims license files that cause recent problems with LicenseReport. The trimming won't cause loosing the license information because we get the licenses from dependencies in the `cli` module anyway.

Some obviously irrelevant files were excluded too.
Latest `config` was also applied.
