### PR TITLE
Keep parsed `PsiFile` under `SourceFile`

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
         Spine.text,
         Spine.CoreJava.server,
         Spine.toolBase,
+        Spine.psiJavaBundle
     ).forEach {
         api(it)
     }

--- a/api/src/main/kotlin/io/spine/protodata/renderer/CoordinatesFactory.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/CoordinatesFactory.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.renderer
+
+import com.google.protobuf.Empty
+import io.spine.annotation.Internal
+import io.spine.text.TextCoordinates
+import io.spine.text.cursor
+import io.spine.text.textCoordinates
+
+/**
+ * A factory of [TextCoordinates] instances.
+ *
+ * This interface serves as a trait for the [InsertionPoint] type.
+ * The methods it provides are meant to be used by the authors of custom insertion points.
+ */
+@Internal
+public sealed interface CoordinatesFactory {
+
+    /**
+     * Obtains coordinates pointing at a specific line and column in the file.
+     */
+    public fun at(line: Int, column: Int): TextCoordinates {
+        val cursor = cursor {
+            this.line = line
+            this.column = column
+        }
+        return textCoordinates {
+            inline = cursor
+        }
+    }
+
+    /**
+     * Obtains coordinates pointing at the beginning of a specific line in the text.
+     */
+    public fun atLine(line: Int): TextCoordinates = textCoordinates {
+        wholeLine = line
+    }
+
+    public companion object {
+
+        /**
+         * Obtains coordinates pointing at the beginning of the first line in the text.
+         */
+        @get:JvmName("startOfFile")
+        @get:JvmStatic
+        public val startOfFile: TextCoordinates = textCoordinates {
+            wholeLine = 0
+        }
+
+        /**
+         * Obtains coordinates pointing at the point after the last line in the text.
+         */
+        @get:JvmName("endOfFile")
+        @get:JvmStatic
+        public val endOfFile: TextCoordinates = textCoordinates {
+            endOfText = Empty.getDefaultInstance()
+        }
+
+        /**
+         * Obtains coordinates that do not point at anywhere in the text.
+         *
+         * The insertion point will NOT be placed in the file at question.
+         */
+        @get:JvmName("nowhere")
+        @get:JvmStatic
+        public val nowhere: TextCoordinates = textCoordinates {
+            nowhere = Empty.getDefaultInstance()
+        }
+    }
+}

--- a/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
@@ -26,15 +26,11 @@
 
 package io.spine.protodata.renderer
 
-import com.google.protobuf.Empty
-import io.spine.annotation.Internal
 import io.spine.logging.WithLogging
 import io.spine.protodata.TypeName
 import io.spine.protodata.qualifiedName
 import io.spine.text.Text
 import io.spine.text.TextCoordinates
-import io.spine.text.cursor
-import io.spine.text.textCoordinates
 
 /**
  * A point is a source file, where more code may be inserted.
@@ -124,68 +120,6 @@ public interface NonRepeatingInsertionPoint : InsertionPoint {
      */
     override fun locate(text: String): Set<TextCoordinates> =
         setOf(locateOccurrence(text))
-}
-
-/**
- * A factory of [TextCoordinates] instances.
- *
- * This interface serves as a trait for the [InsertionPoint] type.
- * The methods it provides are meant to be used by the authors of custom insertion points.
- */
-@Internal
-public sealed interface CoordinatesFactory {
-
-    /**
-     * Obtains coordinates pointing at a specific line and column in the file.
-     */
-    public fun at(line: Int, column: Int): TextCoordinates {
-        val cursor = cursor {
-            this.line = line
-            this.column = column
-        }
-        return textCoordinates {
-            inline = cursor
-        }
-    }
-
-    /**
-     * Obtains coordinates pointing at the beginning of a specific line in the text.
-     */
-    public fun atLine(line: Int): TextCoordinates = textCoordinates {
-        wholeLine = line
-    }
-
-    public companion object {
-
-        /**
-         * Obtains coordinates pointing at the beginning of the first line in the text.
-         */
-        @get:JvmName("startOfFile")
-        @get:JvmStatic
-        public val startOfFile: TextCoordinates = textCoordinates {
-            wholeLine = 0
-        }
-
-        /**
-         * Obtains coordinates pointing at the point after the last line in the text.
-         */
-        @get:JvmName("endOfFile")
-        @get:JvmStatic
-        public val endOfFile: TextCoordinates = textCoordinates {
-            endOfText = Empty.getDefaultInstance()
-        }
-
-        /**
-         * Obtains coordinates that do not point at anywhere in the text.
-         *
-         * The insertion point will NOT be placed in the file at question.
-         */
-        @get:JvmName("nowhere")
-        @get:JvmStatic
-        public val nowhere: TextCoordinates = textCoordinates {
-            nowhere = Empty.getDefaultInstance()
-        }
-    }
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPoint.kt
@@ -68,7 +68,13 @@ public interface InsertionPoint : CoordinatesFactory, WithLogging {
      * @see SourceFile.at
      * @see SourceFile.atInline
      */
-    public fun locate(text: Text): Set<TextCoordinates>
+    public fun locate(text: String): Set<TextCoordinates>
+
+    @Deprecated(
+        message = "Use `locate(String)` instead.",
+        replaceWith = ReplaceWith("locate(text.value)")
+    )
+    public fun locate(text: Text): Set<TextCoordinates> = locate(text.value)
 
     private fun logUnsupportedKind() =
         logger.atWarning().log {
@@ -99,7 +105,13 @@ public interface NonRepeatingInsertionPoint : InsertionPoint {
      * @see SourceFile.at
      * @see SourceFile.atInline
      */
-    public fun locateOccurrence(text: Text): TextCoordinates
+    public fun locateOccurrence(text: String): TextCoordinates
+
+    @Deprecated(
+        message = "Use `locateOccurrence(String)` instead.",
+        replaceWith = ReplaceWith("locateOccurrence(text.value)")
+    )
+    public fun locateOccurrence(text: Text): TextCoordinates = locateOccurrence(text.value)
 
     /**
      * Locates the site where the insertion point should be added.
@@ -110,7 +122,7 @@ public interface NonRepeatingInsertionPoint : InsertionPoint {
      *
      * @see locateOccurrence
      */
-    override fun locate(text: Text): Set<TextCoordinates> =
+    override fun locate(text: String): Set<TextCoordinates> =
         setOf(locateOccurrence(text))
 }
 
@@ -219,7 +231,7 @@ public class ProtocInsertionPoint(
      */
     public constructor(scope: String, type: TypeName) : this("$scope:${type.qualifiedName}")
 
-    override fun locate(text: Text): Set<TextCoordinates> = buildSet {
+    override fun locate(text: String): Set<TextCoordinates> = buildSet {
         text.lines().mapIndexed { index, line ->
             if (line.contains(codeLine)) {
                 add(atLine(index + 1))

--- a/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/InsertionPointPrinter.kt
@@ -90,7 +90,7 @@ public abstract class InsertionPointPrinter<L: Language>(
         file: SourceFile,
         point: InsertionPoint
     ) {
-        val text = file.text()
+        val text = file.code()
         val coords = point.locate(text)
         val precedent = coords.precedentType()
         if (precedent != null) {

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceAtLine.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceAtLine.kt
@@ -73,7 +73,7 @@ internal constructor(
      *         code lines.
      */
     public fun add(lines: Iterable<String>) {
-        val text = file.text()
+        val text = file.code()
         val sourceLines = text.lines()
         val locations = point.locate(text).map { it.wholeLine }
         val newCode = lines.indent(indent, indentLevel)

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFile.kt
@@ -109,10 +109,15 @@ private constructor(
     /**
      * Obtains an instance of [PsiFile] which corresponds to this source file.
      *
-     * The content of the source file is parsed using the language type obtained from
-     * the input file name.
+     * The content of the source file is parsed using the language type
+     * obtained from the input file name.
      *
-     * The returned value is cached until [overwrite]
+     * The returned value is cached until [overwrite] is called.
+     *
+     * Modifications made to the returned instance are <em>NOT</em>
+     * automatically reflected in the [code].
+     * If you intend to modify this source file via PSI, get the updated text
+     * via [PsiFile.getText] after modifications are applied, and then call [overwrite].
      */
     public fun psi(): PsiFile {
         if (psiFile != null) {
@@ -304,28 +309,28 @@ private constructor(
     /**
      * Obtains the entire content of this file.
      */
-    @Deprecated("Use `text()` instead.", ReplaceWith("text()"))
     public fun code(): String {
-        return text().value
+        initializeCode()
+        return code
     }
 
     /**
      * Obtains the entire content of this file as a list of lines.
      */
     public fun lines(): List<String> {
-        return text().lines()
+        return code.lines()
     }
 
     /**
      * Obtains the text content of this source file.
      */
+    @Deprecated("Use `code()` instead.", ReplaceWith("code()"))
     public fun text(): Text {
-        initializeCode()
         return text(code)
     }
 
     /**
-     * Adds an action to be executed before obtaining the [text] of this source file.
+     * Adds an action to be executed before obtaining the [code] of this source file.
      */
     internal fun beforeRead(action: (SourceFile) -> Unit) {
         preReadActions.add(action)

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -100,7 +100,7 @@ internal constructor(
     internal lateinit var querying: Querying
 
     /**
-     * Gets the project to which this source file set belongs.
+     * Obtains the project to which this source file set belongs.
      */
     public val project: Project by lazy {
         Environment.setUp()

--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 package io.spine.protodata.renderer
 
 import com.google.common.collect.ImmutableSet.toImmutableSet
+import com.intellij.openapi.project.Project
 import io.spine.annotation.Internal
 import io.spine.protodata.ProtoDeclarationName
 import io.spine.protodata.renderer.SourceFileSet.Companion.create
@@ -35,6 +36,7 @@ import io.spine.protodata.type.NameElement
 import io.spine.server.query.Querying
 import io.spine.string.ti
 import io.spine.tools.code.Language
+import io.spine.tools.psi.java.Environment
 import io.spine.util.theOnly
 import java.nio.charset.Charset
 import java.nio.file.Files.walk
@@ -96,6 +98,14 @@ internal constructor(
     private val deletedFiles = mutableSetOf<SourceFile>()
     private val preReadActions = mutableListOf<(SourceFile) -> Unit>()
     internal lateinit var querying: Querying
+
+    /**
+     * Gets the project to which this source file set belongs.
+     */
+    public val project: Project by lazy {
+        Environment.setUp()
+        Environment.project
+    }
 
     init {
         require(inputRoot.absolutePathString() != outputRoot.absolutePathString()) {

--- a/api/src/test/kotlin/io/spine/protodata/renderer/InsertionPointPrinterSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/InsertionPointPrinterSpec.kt
@@ -26,7 +26,6 @@
 
 package io.spine.protodata.renderer
 
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Java
 import org.junit.jupiter.api.DisplayName
@@ -58,5 +57,5 @@ class InsertionPointPrinterSpec {
 
 private class StubPoint: InsertionPoint {
     override val label: String = ""
-    override fun locate(text: Text): Set<TextCoordinates> = emptySet()
+    override fun locate(text: String): Set<TextCoordinates> = emptySet()
 }

--- a/api/src/test/kotlin/io/spine/protodata/renderer/SourceFileSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/SourceFileSpec.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.renderer
+
+import com.intellij.psi.PsiJavaFile
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.spine.string.ti
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`SourceFile` should")
+internal class SourceFileSpec {
+
+    private lateinit var sourceFile: SourceFile
+
+    @BeforeEach
+    fun createSourceFile(@TempDir input: Path, @TempDir output: Path) {
+        val className = "HelloWorld"
+        val fileName = "$className.java"
+        val file = input.resolve(fileName)
+        file.writeText("""
+            public class HelloWorld { }
+            """.ti()
+        )
+        val set = SourceFileSet.create(input, output)
+        sourceFile = set.file(file)
+        sourceFile shouldNotBe null
+    }
+
+    @Test
+    fun `provide 'PsiFile' instance`() {
+        val firstPsi = assertDoesNotThrow {
+            sourceFile.psi()
+        }
+
+        // The type of file was calculated by its name.
+        (firstPsi is PsiJavaFile) shouldBe true
+
+        // Repeated calls returns the same instance.
+        sourceFile.psi() shouldBe firstPsi
+        sourceFile.psi() shouldBe firstPsi
+
+        // Overwriting the code should result in getting a new instance of `PsiJavaFile`.
+        sourceFile.overwrite("""
+            public final class HelloWorld { 
+                System.out.println("Hello, World!"); 
+            }
+            """.ti()
+        )
+        val updatedPsi = assertDoesNotThrow {
+            sourceFile.psi()
+        }
+        updatedPsi shouldNotBe firstPsi
+        (updatedPsi is PsiJavaFile) shouldBe true
+    }
+}

--- a/backend/src/test/kotlin/io/spine/protodata/InsertionPointSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/InsertionPointSpec.kt
@@ -50,7 +50,6 @@ import io.spine.protodata.test.KotlinInsertionPoint.FILE_START
 import io.spine.protodata.test.KotlinInsertionPoint.LINE_FOUR_COL_THIRTY_THREE
 import io.spine.protodata.test.NonVoidMethodPrinter
 import io.spine.protodata.test.VariousKtInsertionPointsPrinter
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import java.lang.System.lineSeparator
 import java.nio.file.Path
@@ -167,7 +166,7 @@ class InsertionPointsSpec {
     fun `return empty 'codeLine' for empty 'label'`() {
         val insertionPoint = object: InsertionPoint {
             override val label: String = ""
-            override fun locate(text: Text): Set<TextCoordinates> = setOf()
+            override fun locate(text: String): Set<TextCoordinates> = setOf()
         }
         insertionPoint.codeLine shouldBe ""
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.212"
+        const val toolBase = "2.0.0-SNAPSHOT.213"
 
         /**
          * The version of [Spine.javadocTools].

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sat May 18 19:03:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2817,7 +2817,7 @@ This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3728,7 +3728,7 @@ This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4643,7 +4643,7 @@ This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5729,7 +5729,7 @@ This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6661,7 +6661,7 @@ This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7391,7 +7391,7 @@ This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8348,7 +8348,7 @@ This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9382,4 +9382,4 @@ This report was generated on **Sat May 18 19:03:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat May 18 19:03:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 02:22:58 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-api:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -926,12 +926,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-backend:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1858,12 +1858,12 @@ This report was generated on **Fri May 17 12:38:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -2817,12 +2817,12 @@ This report was generated on **Fri May 17 12:38:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -3728,12 +3728,12 @@ This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4643,12 +4643,12 @@ This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -5729,12 +5729,12 @@ This report was generated on **Fri May 17 12:38:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-java:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6661,12 +6661,12 @@ This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.24.0`
 
 ## Runtime
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
@@ -7391,12 +7391,12 @@ This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -8348,12 +8348,12 @@ This report was generated on **Fri May 17 12:38:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.23.0`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.24.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -9382,4 +9382,4 @@ This report was generated on **Fri May 17 12:38:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 17 12:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat May 18 19:03:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -926,7 +926,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2817,7 +2817,7 @@ This report was generated on **Sun May 19 02:22:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3728,7 +3728,7 @@ This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4643,7 +4643,7 @@ This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5729,7 +5729,7 @@ This report was generated on **Sun May 19 02:22:56 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6661,7 +6661,7 @@ This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7391,7 +7391,7 @@ This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8348,7 +8348,7 @@ This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9382,4 +9382,4 @@ This report was generated on **Sun May 19 02:22:57 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun May 19 02:22:58 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun May 19 15:12:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/annotation/TypeAnnotation.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/annotation/TypeAnnotation.kt
@@ -150,7 +150,7 @@ public abstract class TypeAnnotation<T : Annotation>(
      */
     @Suppress("ReturnCount") // Cannot go lower here.
     protected open fun shouldAnnotate(file: SourceFile): Boolean {
-        val coordinates = insertionPoint().locateOccurrence(file.text())
+        val coordinates = insertionPoint().locateOccurrence(file.code())
         if (coordinates == nowhere) {
             return false
         }

--- a/java/src/main/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclaration.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclaration.kt
@@ -61,7 +61,7 @@ public class BeforeNestedTypeDeclaration(
         logger.atWarning().log { """
             Cannot find a declaration of the nested type `$name` in the code:
             ```java
-            ${txt.printLines()}            
+            $text            
             ```
             """.ti()
         }

--- a/java/src/main/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclaration.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclaration.kt
@@ -30,8 +30,8 @@ import io.spine.protodata.java.ClassOrEnumName
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
 import io.spine.protodata.renderer.NonRepeatingInsertionPoint
 import io.spine.string.ti
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
+import io.spine.text.TextFactory.text
 import io.spine.tools.psi.java.lineNumber
 
 /**
@@ -51,8 +51,9 @@ public class BeforeNestedTypeDeclaration(
 
     override val label: String = ""
 
-    override fun locateOccurrence(text: Text): TextCoordinates {
-        val psiClass = text.locate(name)
+    override fun locateOccurrence(text: String): TextCoordinates {
+        val txt = text(text)
+        val psiClass = txt.locate(name)
         psiClass?.let {
             val lineNumber = it.lineNumber
             return atLine(lineNumber)
@@ -60,7 +61,7 @@ public class BeforeNestedTypeDeclaration(
         logger.atWarning().log { """
             Cannot find a declaration of the nested type `$name` in the code:
             ```java
-            ${text.printLines()}            
+            ${txt.printLines()}            
             ```
             """.ti()
         }

--- a/java/src/main/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclaration.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclaration.kt
@@ -64,7 +64,7 @@ internal object BeforePrimaryDeclaration : NonRepeatingInsertionPoint {
         logger.atWarning().log { """
             Could not find a primary declaration in the code:
             ```java
-            ${txt.printLines()}
+            $text
             ```    
             """.ti()
         }

--- a/java/src/main/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclaration.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclaration.kt
@@ -29,8 +29,8 @@ package io.spine.protodata.java.file
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
 import io.spine.protodata.renderer.NonRepeatingInsertionPoint
 import io.spine.string.ti
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
+import io.spine.text.TextFactory.text
 import io.spine.tools.psi.java.lineNumber
 
 /**
@@ -53,8 +53,9 @@ internal object BeforePrimaryDeclaration : NonRepeatingInsertionPoint {
     override val label: String
         get() = this.javaClass.simpleName
 
-    override fun locateOccurrence(text: Text): TextCoordinates {
-        val file = text.psiFile()
+    override fun locateOccurrence(text: String): TextCoordinates {
+        val txt = text(text)
+        val file = txt.psiFile()
         if (file.classes.isNotEmpty()) {
             val psiClass = file.classes.first()
             val lineNumber = psiClass.lineNumber
@@ -63,7 +64,7 @@ internal object BeforePrimaryDeclaration : NonRepeatingInsertionPoint {
         logger.atWarning().log { """
             Could not find a primary declaration in the code:
             ```java
-            ${text.printLines()}
+            ${txt.printLines()}
             ```    
             """.ti()
         }

--- a/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
@@ -44,6 +44,7 @@ import io.spine.tools.psi.java.locate
 /**
  * Prints the lines of the text into a single string using the system line separator.
  */
+@Deprecated(message = "Use plain string values instead.", ReplaceWith("value"))
 internal fun Text.printLines(): String =
         lines().joinToString(separator = Separator.system.value)
 

--- a/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
@@ -94,7 +94,9 @@ private object TextToPsiParser {
         return cache.get(text)
     }
 
+    @Deprecated(message = "Please use `SourceFile.psi()` instead.")
     fun get(file: SourceFile): PsiJavaFile {
+        @Suppress("DEPRECATION")
         return cache.get(file.text())
     }
 

--- a/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/ParsingExts.kt
@@ -70,11 +70,16 @@ public fun Text.locate(name: ClassOrEnumName): PsiClass? {
  * The content of the source file is parsed.
  * The instance of `PsiJavaFile` is not tied to a file on the disk.
  */
+@Deprecated(
+    message = "Please use `psi()` instead",
+    replaceWith = ReplaceWith("psi() as PsiJavaFile")
+)
 public fun SourceFile.toPsi(): PsiJavaFile {
     check(isJava) {
         "Unable to convert non-Java file `$relativePath` to ${PsiJavaFile::class.java.simpleName}."
     }
-    return TextToPsiParser.get(this)
+    val psiFile = psi()
+    return psiFile as PsiJavaFile
 }
 
 /**

--- a/java/src/main/kotlin/io/spine/protodata/java/style/JavaCodeStyleFormatter.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/style/JavaCodeStyleFormatter.kt
@@ -90,7 +90,7 @@ public class JavaCodeStyleFormatter : JavaRenderer() {
     }
 
     private fun reformat(file: SourceFile) {
-        val withAdjustedSeparators = file.text().value.convertLineSeparators()
+        val withAdjustedSeparators = file.code().convertLineSeparators()
         val outputFile = file.outputPath.toFile()
         val psiFile = parser.parse(withAdjustedSeparators, outputFile)
         execute {

--- a/java/src/test/kotlin/io/spine/protodata/java/SourceFileJavaSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/SourceFileJavaSpec.kt
@@ -94,7 +94,7 @@ internal class SourceFileJavaSpec : WithSourceFileSet() {
             val comment = "// This is Protoc standard insertion point."
             file.at(point)
                 .add(comment)
-            val code = file.text().value
+            val code = file.code()
             assertThat(code)
                 .contains(comment)
 

--- a/java/src/test/kotlin/io/spine/protodata/java/annotation/GeneratedTypeAnnotationSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/annotation/GeneratedTypeAnnotationSpec.kt
@@ -149,8 +149,7 @@ internal class GeneratedTypeAnnotationSpec : WithSourceFileSet() {
 
     private fun generatedCode() = sources.first()
         .file(Path(JAVA_FILE))
-        .text()
-        .value
+        .code()
 
     private fun createPipelineWith(generatedTypeAnnotation: GeneratedTypeAnnotation) {
         Pipeline(

--- a/java/src/test/kotlin/io/spine/protodata/java/annotation/SuppressWarningsAnnotationSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/annotation/SuppressWarningsAnnotationSpec.kt
@@ -51,8 +51,7 @@ internal class SuppressWarningsAnnotationSpec : WithSourceFileSet() {
 
     private fun loadCode() = sources.first()
         .file(Path(JAVA_FILE))
-        .text()
-        .value
+        .code()
 
     @Nested
     inner class `suppress ALL warnings ` {

--- a/java/src/test/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclarationSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/file/BeforeNestedTypeDeclarationSpec.kt
@@ -42,7 +42,6 @@ import io.spine.protodata.renderer.SourceFileSet
 import io.spine.protodata.settings.SettingsDirectory
 import io.spine.string.ti
 import io.spine.text.TextCoordinates
-import io.spine.text.text
 import java.nio.file.Path
 import javax.annotation.processing.Generated
 import kotlin.io.path.createFile
@@ -108,7 +107,7 @@ class BeforeNestedTypeDeclarationSpec {
             val inputClassSrc = input / "$TOP_CLASS.java"
             inputClassSrc.run {
                 createFile()
-                writeText(sourceCode.value)
+                writeText(sourceCode)
             }
 
             Pipeline(
@@ -172,8 +171,7 @@ private val deeplyNestedClassName = ClassName(PACKAGE_NAME, TOP_CLASS, NESTED, D
 private val nestedEnum = EnumName(PACKAGE_NAME, TOP_CLASS, NESTED_ENUM)
 private val nestedInterface = ClassName(PACKAGE_NAME, TOP_CLASS, NESTED_INTERFACE)
 
-private val sourceCode = text {
-    value = """
+private val sourceCode = """
     /* File header comment. */    
     package $PACKAGE_NAME;
 
@@ -204,7 +202,6 @@ private val sourceCode = text {
         } 
     }
     """.ti() // We deliberately use OS-specific line endings here to simulate loading from disk.
-}
 
 /**
  * Stub renderer which adds the [SuppressWarnings] annotation to the given type.

--- a/java/src/test/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclarationSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/file/BeforePrimaryDeclarationSpec.kt
@@ -34,7 +34,6 @@ import io.spine.protodata.java.annotation.GeneratedTypeAnnotation
 import io.spine.protodata.renderer.SourceFileSet
 import io.spine.protodata.settings.SettingsDirectory
 import io.spine.string.ti
-import io.spine.text.text
 import java.nio.file.Path
 import javax.annotation.processing.Generated
 import kotlin.io.path.createFile
@@ -89,17 +88,17 @@ class BeforePrimaryDeclarationSpec {
             val inputClassSrc = input / "TopLevelClass.java"
             inputClassSrc.run {
                 createFile()
-                writeText(classSource.value)
+                writeText(classSource)
             }
             val inputInterfaceSrc = input / "TopLevelInterface.java"
             inputInterfaceSrc.run {
                 createFile()
-                writeText(interfaceSource.value)
+                writeText(interfaceSource)
             }
             val inputEnumSrc = input / "TopLevelEnum.java"
             inputEnumSrc.run {
                 createFile()
-                writeText(enumSource.value)
+                writeText(enumSource)
             }
 
             Pipeline(
@@ -163,8 +162,7 @@ class BeforePrimaryDeclarationSpec {
 
 private const val PACKAGE_NAME = "given.java.file"
 
-private val classSource = text {
-    value = """
+private val classSource = """
     /* File header comment. */    
     package $PACKAGE_NAME;
 
@@ -178,20 +176,15 @@ private val classSource = text {
         }
     }
     """.ti()
-}
 
-private val interfaceSource = text {
-    value = """
+private val interfaceSource = """
     /** Top level interface Javadoc. */
     public interface TopLevelInterface {
     }
     """.ti()
-}
 
-private val enumSource = text {
-    value = """
+private val enumSource = """
     // File header comment.    
     package $PACKAGE_NAME;
     public enum TopLevelEnum { ONE, TWO }
     """.ti()
-}

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.213</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.213</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -176,7 +176,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.213</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -289,7 +289,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.213</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.23.0</version>
+<version>0.24.0</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/test-env/src/main/kotlin/io/spine/protodata/test/AnnotationInsertionPointPrinter.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/AnnotationInsertionPointPrinter.kt
@@ -29,7 +29,6 @@ package io.spine.protodata.test
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
 import io.spine.protodata.renderer.InsertionPointPrinter
 import io.spine.protodata.renderer.NonRepeatingInsertionPoint
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Java
 import kotlin.text.RegexOption.DOT_MATCHES_ALL
@@ -51,7 +50,7 @@ public enum class AnnotationInsertionPoint : NonRepeatingInsertionPoint {
      * This insertion point allows importing types into the Java file.
      */
     IMPORT {
-        override fun locateOccurrence(text: Text): TextCoordinates {
+        override fun locateOccurrence(text: String): TextCoordinates {
             val lines = text.lines()
             val packageLineIndex = lines.asSequence()
                 .mapIndexed { index, line -> index to line }
@@ -68,7 +67,7 @@ public enum class AnnotationInsertionPoint : NonRepeatingInsertionPoint {
      * This insertion point allows annotating the return type.
      */
     BEFORE_RETURN_TYPE_METHOD_FOO {
-        override fun locateOccurrence(text: Text): TextCoordinates {
+        override fun locateOccurrence(text: String): TextCoordinates {
             val lines = text.lines()
             val (lineIndex, line) = lines.asSequence()
                 .mapIndexed { index, line -> index to line }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/CatOutOfTheBoxEmancipator.kt
@@ -29,7 +29,6 @@ package io.spine.protodata.test
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceFileSet
 import io.spine.tools.code.AnyLanguage
-import io.spine.tools.code.Language
 
 /**
  * Reads every file in the source set and obtains its code, invoking the insertion point rendering,
@@ -42,7 +41,7 @@ public class CatOutOfTheBoxEmancipator : Renderer<AnyLanguage>(AnyLanguage) {
 
     override fun render(sources: SourceFileSet) {
         sources.forEach {
-            it.text()
+            it.code()
         }
     }
 }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/CompanionFramer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/CompanionFramer.kt
@@ -28,7 +28,6 @@ package io.spine.protodata.test
 
 import io.spine.protodata.renderer.InsertionPoint
 import io.spine.protodata.renderer.InsertionPointPrinter
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Kotlin
 
@@ -48,7 +47,7 @@ public class CompanionFrame : InsertionPoint {
     override val label: String
         get() = "CompanionFrame"
 
-    override fun locate(text: Text): Set<TextCoordinates> =
+    override fun locate(text: String): Set<TextCoordinates> =
         text.lines()
             .asSequence()
             .mapIndexed { index, line -> index to line }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/JavaGenericInsertionPointPrinter.kt
@@ -31,7 +31,6 @@ import io.spine.protodata.renderer.CoordinatesFactory.Companion.nowhere
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.startOfFile
 import io.spine.protodata.renderer.InsertionPointPrinter
 import io.spine.protodata.renderer.NonRepeatingInsertionPoint
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Java
 
@@ -41,16 +40,16 @@ public class JavaGenericInsertionPointPrinter :
 public enum class GenericInsertionPoint : NonRepeatingInsertionPoint {
 
     FILE_START {
-        override fun locateOccurrence(text: Text): TextCoordinates = startOfFile
+        override fun locateOccurrence(text: String): TextCoordinates = startOfFile
     },
     FILE_MIDDLE {
-        override fun locateOccurrence(text: Text): TextCoordinates = atLine(text.lines().size / 2)
+        override fun locateOccurrence(text: String): TextCoordinates = atLine(text.lines().size / 2)
     },
     FILE_END {
-        override fun locateOccurrence(text: Text): TextCoordinates = endOfFile
+        override fun locateOccurrence(text: String): TextCoordinates = endOfFile
     },
     OUTSIDE_FILE {
-        override fun locateOccurrence(text: Text): TextCoordinates = nowhere
+        override fun locateOccurrence(text: String): TextCoordinates = nowhere
     };
 
     override val label: String

--- a/test-env/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/JsRenderer.kt
@@ -29,13 +29,12 @@ package io.spine.protodata.test
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceFileSet
 import io.spine.tools.code.JavaScript
-import io.spine.tools.code.Language
 
 public class JsRenderer : Renderer<JavaScript>(JavaScript) {
 
     override fun render(sources: SourceFileSet) {
         sources.forEach {
-            it.overwrite(it.text().value.replace("Hello", "Hello JavaScript"))
+            it.overwrite(it.code().replace("Hello", "Hello JavaScript"))
         }
     }
 }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/KtRenderer.kt
@@ -29,13 +29,12 @@ package io.spine.protodata.test
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceFileSet
 import io.spine.tools.code.Kotlin
-import io.spine.tools.code.Language
 
 public class KtRenderer : Renderer<Kotlin>(Kotlin) {
 
     override fun render(sources: SourceFileSet) {
         sources.forEach {
-            it.overwrite(it.text().value.replace("Hello", "Hello Kotlin"))
+            it.overwrite(it.code().replace("Hello", "Hello Kotlin"))
         }
     }
 }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/NonExistingPoint.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/NonExistingPoint.kt
@@ -27,7 +27,6 @@
 package io.spine.protodata.test
 
 import io.spine.protodata.renderer.InsertionPoint
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 
 /**
@@ -37,5 +36,5 @@ public object NonExistingPoint : InsertionPoint {
 
     override val label: String = "NonExistingPoint"
 
-    override fun locate(text: Text): Set<TextCoordinates> = emptySet()
+    override fun locate(text: String): Set<TextCoordinates> = emptySet()
 }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/NonVoidMethod.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/NonVoidMethod.kt
@@ -28,7 +28,6 @@ package io.spine.protodata.test
 
 import io.spine.protodata.renderer.InsertionPoint
 import io.spine.protodata.renderer.InsertionPointPrinter
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Java
 import kotlin.text.RegexOption.DOT_MATCHES_ALL
@@ -49,7 +48,7 @@ public class NonVoidMethod : InsertionPoint {
     override val label: String
         get() = "NonVoidMethod"
 
-    override fun locate(text: Text): Set<TextCoordinates> =
+    override fun locate(text: String): Set<TextCoordinates> =
         text.lines()
             .asSequence()
             .mapIndexed { index, line -> index to line }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/UnderscorePrefixRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/UnderscorePrefixRenderer.kt
@@ -28,7 +28,6 @@ package io.spine.protodata.test
 
 import io.spine.protodata.renderer.Renderer
 import io.spine.protodata.renderer.SourceFileSet
-import io.spine.server.query.select
 import io.spine.tools.code.Java
 
 /**
@@ -42,7 +41,7 @@ public class UnderscorePrefixRenderer : SoloRenderer<Java>(Java) {
             val oldName = internalType.name.simpleName
             val newName = "_$oldName"
             sources.forEach {
-                it.overwrite(it.text().value.replace(oldName, newName))
+                it.overwrite(it.code().replace(oldName, newName))
             }
         }
     }

--- a/test-env/src/main/kotlin/io/spine/protodata/test/VariousKtInsertionPointsPrinter.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/VariousKtInsertionPointsPrinter.kt
@@ -30,7 +30,6 @@ import io.spine.protodata.renderer.CoordinatesFactory.Companion.endOfFile
 import io.spine.protodata.renderer.CoordinatesFactory.Companion.startOfFile
 import io.spine.protodata.renderer.InsertionPointPrinter
 import io.spine.protodata.renderer.NonRepeatingInsertionPoint
-import io.spine.text.Text
 import io.spine.text.TextCoordinates
 import io.spine.tools.code.Kotlin
 
@@ -40,13 +39,13 @@ public class VariousKtInsertionPointsPrinter :
 public enum class KotlinInsertionPoint : NonRepeatingInsertionPoint {
 
     FILE_START {
-        override fun locateOccurrence(text: Text): TextCoordinates = startOfFile
+        override fun locateOccurrence(text: String): TextCoordinates = startOfFile
     },
     FILE_END {
-        override fun locateOccurrence(text: Text): TextCoordinates = endOfFile
+        override fun locateOccurrence(text: String): TextCoordinates = endOfFile
     },
     LINE_FOUR_COL_THIRTY_THREE {
-        override fun locateOccurrence(text: Text): TextCoordinates = at(3, 33)
+        override fun locateOccurrence(text: String): TextCoordinates = at(3, 33)
     };
 
     override val label: String

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/FieldGetter.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/FieldGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.string.Strings.camelCase;
 import static java.lang.String.format;
 import static io.spine.protodata.renderer.CoordinatesFactory.nowhere;
+import static kotlin.text.StringsKt.lines;
 
 /**
  * An insertion point at the line right before a getter method of the given field.
@@ -62,11 +63,11 @@ final class FieldGetter implements NonRepeatingInsertionPoint {
 
     @NonNull
     @Override
-    public TextCoordinates locateOccurrence(Text text) {
+    public TextCoordinates locateOccurrence(String text) {
         var fieldName = camelCase(field.getField().getValue());
         var getterName = "get" + fieldName;
         var pattern = Pattern.compile("public .+ " + getterName);
-        var lines = text.lines();
+        var lines = lines(text);
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
             if (pattern.matcher(line).find()) {

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/MessageClass.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/annotation/MessageClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Set;
 
+import static kotlin.text.StringsKt.lines;
+
 /**
  * An insertion point at the line before a class declaration.
  */
@@ -45,8 +47,8 @@ final class MessageClass implements InsertionPoint {
     }
 
     @Override
-    public Set<TextCoordinates> locate(Text text) {
-        var lines = text.lines();
+    public Set<TextCoordinates> locate(String text) {
+        var lines = lines(text);
         var coords = ImmutableSet.<TextCoordinates>builder();
         for (int i = 0; i < lines.size(); i++) {
             if (lines.get(i).contains("final class ")) {

--- a/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScope.java
+++ b/tests/protodata-extension/src/main/java/io/spine/protodata/test/uuid/ClassScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protodata.TypeNames.getQualifiedName;
 import static io.spine.protodata.renderer.CoordinatesFactory.nowhere;
 import static java.lang.String.format;
+import static kotlin.text.StringsKt.lines;
 
 /**
  * An {@link InsertionPoint} in the scope of a generated Java class.
@@ -69,9 +70,9 @@ final class ClassScope implements NonRepeatingInsertionPoint {
      * is not added either.
      */
     @Override
-    public TextCoordinates locateOccurrence(Text text) {
+    public TextCoordinates locateOccurrence(String text) {
         String pattern = format(NATIVE_INSERTION_POINT_FMT, getQualifiedName(typeName));
-        List<String> lines = text.lines();
+        List<String> lines = lines(text);
         for (int lineNumber = 0; lineNumber < lines.size(); lineNumber++) {
             String line = lines.get(lineNumber);
             if (line.contains(pattern)) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.23.0")
+val protoDataVersion: String by extra("0.24.0")


### PR DESCRIPTION
This PR improves the way we work with parsing Java code into an instance of `PsiJavaFile` for further traversal and modifications.

## The problem
Before this PR we used to have a cache with the association of `Text` instances to `PsiJavaFile` instances that were created when parsing these texts. The problem with this approach is that it is error prone because of the following. When we get an instance of `PsiJavaFile` we can use it for both navigation and modification. Nothing prevents us from doing the latter. So, in order to keep the match `Text` to `PsiJavaFile` consistent, we need to re-parse the same text so that we can modify the code. This diminish the usefulness of the cache and puts additional burden on its users.

## The solution
Now the `SourceFile` is responsible for holding the reference to `PsiFile`. 

Unlike before this PR (via `SourceFile.toPsi()` ext. `fun`), the reference does no not have the `PsiJavaFile` type because `SourceFile` could be in any language. The language — and correspondingly `FileType` —  is detected when `psi()` method is called for the first time. The private `fileType` property is responsible for keeping it for repeated parsing calls.

When the code is updated by the `overwrite()` call, the `PsiFile` instance is discarded.

## Changes to other API
 * API calls that used to accept `Text` instances now accept `String`. `InsertionPoint` interface methods were deprecated accordingly. It turns out that having yet another intermediate abstraction is not convenient. `SourceFile` is good enough for our needs, especially assuming that we're going to use PSI more.

 * The `SourceFile.code()` method — which was deprecated — is now back in favour, and the `text()` method is deprecated.

 * `SourceFileSet` got the `project` property, which is lazily evaluated from `Environment.project`. This is a little step towards making our API more project-oriented, with the goal of being able to analyse the whole file tree of a software project based on Spine, eventually.

## Other notable changes
 * The `api` module now depends on `Spine.psiJavaBundle` at `api` level. Since we expose `PsiFile` — and indirectly — `PsiJavaFile` and all the “jungle” surrounds these types, it is more ergonomic for the users to get it all when adding ProtoData API module to their project.
 
## Some thoughts about future work
The whole story about the relation of `InsertionPoint` and `SourceFile` needs more attention. Now the points "hang" in the air. They insert into coordinates in a `String`. PSI looks like a way to make it more reasonable with coordinates being not "x,y" in a test, but `PsiElement` in a `PsiFile`. Now we have to deal with `Text` instances and its extensions just to be able to get the insertion coordinates.

Works in McJava, which drive the recent modifications in ProtoData, should give us more feedback on where improvements of the `InsertionPoint` API and other parts should be directed.
