### PR TITLE
`RenderAction` with parameters, `TypeAction` and descendants

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Member.kt
@@ -107,7 +107,7 @@ protected constructor(public val language: L) : LoadsSettings, ContextAware {
      * @see [io.spine.protodata.backend.Pipeline]
      */
     @Internal
-    public override fun registerWith(context: CodegenContext) {
+    public final override fun registerWith(context: CodegenContext) {
         if (isRegistered()) {
             check(_context == context) {
                 "Unable to register `$this` with `${context}` because" +

--- a/api/src/main/kotlin/io/spine/protodata/ProtoDeclaration.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ProtoDeclaration.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -50,3 +50,10 @@ public interface ProtoDeclaration : Message {
     public val typeUrl: String
         get() = name.typeUrl
 }
+
+/**
+ * A Protobuf declaration of a data type, such as a message or an enum.
+ */
+@Internal
+@GeneratedMixin
+public interface TypeDeclaration : ProtoDeclaration

--- a/api/src/main/kotlin/io/spine/protodata/ProtoDeclarationName.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ProtoDeclarationName.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
@@ -45,15 +45,20 @@ import io.spine.tools.code.Language
  * @param P the type of the Protobuf declaration served by this action,
  *   such as [MessageType][io.spine.protodata.MessageType],
  *   [EnumType][io.spine.protodata.EnumType] or [Service][io.spine.protodata.Service].
+ *
  * @param language the programming language served by this action.
- * @property subject the Protobuf declaration served by this action.
  * @param context the code generation context in which this action runs.
+ *
+ * @property subject the Protobuf declaration served by this action.
+ * @property file the source code file to be modified by this action.
+ *
  * @see Renderer
  */
 public abstract class RenderAction<L : Language, P : ProtoDeclaration>
 protected constructor(
     language: L,
     protected val subject: P,
+    protected val file: SourceFile<L>,
     context: CodegenContext
 ) : Member<L>(language) {
 
@@ -63,10 +68,8 @@ protected constructor(
 
     /**
      * Renders the code in the given source file.
-     *
-     * @param file the source code file to be modified by this action.
      */
-    public abstract fun render(file: SourceFile<L>)
+    public abstract fun render()
 }
 
 /**
@@ -75,9 +78,13 @@ protected constructor(
  *
  * @param L the programming language supported by this action.
  * @param T the type of the Protobuf declaration served by this action.
+ *
  * @param language the programming language served by this action.
- * @property type the same as [subject], added for readability in generated code templates.
  * @param context the code generation context in which this action runs.
+ *
+ * @property type the same as [subject], added for readability in generated code templates.
+ * @property file the source code file to be modified by this action.
+ *
  * @see MessageAction
  * @see EnumAction
  */
@@ -85,52 +92,70 @@ public abstract class TypeAction<L : Language, T : TypeDeclaration>
 protected constructor(
     language: L,
     protected val type: T,
+    file: SourceFile<L>,
     context: CodegenContext
-) : RenderAction<L, T>(language, type, context)
+) : RenderAction<L, T>(language, type, file, context)
 
 /**
  * A render action performed for a [MessageType][io.spine.protodata.MessageType].
  *
  * @param L the programming language supported by this action.
  * @param language the programming language served by this action.
+ *
  * @param type the message type served by this action.
  * @param context the code generation context in which this action runs.
+ *
+ * @property type the message type served by this action.
+ * @property file the source code file to be modified by this action.
+ *
  * @see EnumAction
  * @see ServiceAction
  */
 public abstract class MessageAction<L : Language>(
     language: L,
     type: MessageType,
+    file: SourceFile<L>,
     context: CodegenContext
-) : TypeAction<L, MessageType>(language, type, context)
+) : TypeAction<L, MessageType>(language, type, file, context)
 
 /**
  * A render action performed for an [EnumType][io.spine.protodata.EnumType].
  *
  * @param L the programming language supported by this action.
+ *
  * @param language the programming language served by this action.
- * @param type the enum type served by this action.
+ * @param context the code generation context in which this action runs.
+ *
+ * @property type the enum type served by this action.
+ * @property file the source code file to be modified by this action.
+ *
  * @see MessageAction
  * @see ServiceAction
  */
 public abstract class EnumAction<L : Language>(
     language: L,
     type: EnumType,
+    file: SourceFile<L>,
     context: CodegenContext
-) : TypeAction<L, EnumType>(language, type, context)
+) : TypeAction<L, EnumType>(language, type, file, context)
 
 /**
  * A render action performed for a [Service][io.spine.protodata.Service].
  *
  * @param L the programming language supported by this action.
+ *
  * @param language the programming language served by this action.
- * @property service the same as [subject], added for readability in generated code templates.
  * @param context the code generation context in which this action runs.
+ *
+ * @property service the same as [subject], added for readability in generated code templates.
+ * @property file the source code file to be modified by this action.
+ *
  * @see MessageAction
  * @see EnumAction
  */
 public abstract class ServiceAction<L : Language>(
     language: L,
     protected val service: Service,
+    file: SourceFile<L>,
     context: CodegenContext
-) : RenderAction<L, Service>(language, service, context)
+) : RenderAction<L, Service>(language, service, file, context)

--- a/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
@@ -26,8 +26,12 @@
 
 package io.spine.protodata.renderer
 
+import io.spine.protodata.EnumType
 import io.spine.protodata.Member
+import io.spine.protodata.MessageType
 import io.spine.protodata.ProtoDeclaration
+import io.spine.protodata.Service
+import io.spine.protodata.TypeDeclaration
 import io.spine.tools.code.Language
 
 /**
@@ -54,3 +58,53 @@ protected constructor(language: L, protected val subject: P) : Member<L>(languag
      */
     public abstract fun run(file: SourceFile<L>)
 }
+
+/**
+ * A render action performed for a Protobuf type,
+ * such as [MessageType][io.spine.protodata.MessageType] or [EnumType][io.spine.protodata.EnumType].
+ *
+ * @param L the programming language supported by this action.
+ * @param T the type of the Protobuf declaration served by this action.
+ * @param language the programming language served by this action.
+ * @property type the same as [subject], added for readability in generated code templates.
+ * @see MessageAction
+ * @see EnumAction
+ */
+public abstract class TypeAction<L : Language, T : TypeDeclaration>
+protected constructor(language: L, protected val type: T) : RenderAction<L, T>(language, type)
+
+/**
+ * A render action performed for a [MessageType][io.spine.protodata.MessageType].
+ *
+ * @param L the programming language supported by this action.
+ * @param language the programming language served by this action.
+ * @param type the message type served by this action.
+ * @see EnumAction
+ * @see ServiceAction
+ */
+public abstract class MessageAction<L : Language>(language: L, type: MessageType) :
+    TypeAction<L, MessageType>(language, type)
+
+/**
+ * A render action performed for an [EnumType][io.spine.protodata.EnumType].
+ *
+ * @param L the programming language supported by this action.
+ * @param language the programming language served by this action.
+ * @param type the enum type served by this action.
+ * @see MessageAction
+ * @see ServiceAction
+ */
+public abstract class EnumAction<L : Language>(language: L, type: EnumType) :
+    TypeAction<L, EnumType>(language, type)
+
+/**
+ * A render action performed for a [Service][io.spine.protodata.Service].
+ *
+ * @param L the programming language supported by this action.
+ * @param language the programming language served by this action.
+ * @property service the same as [subject], added for readability in generated code templates.
+ * @see MessageAction
+ * @see EnumAction
+ */
+public abstract class ServiceAction<L : Language>(language: L, protected val service: Service) :
+    RenderAction<L, Service>(language, service)

--- a/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
@@ -56,7 +56,7 @@ protected constructor(language: L, protected val subject: P) : Member<L>(languag
      *
      * @param file the source code file to be modified by this action.
      */
-    public abstract fun run(file: SourceFile<L>)
+    public abstract fun render(file: SourceFile<L>)
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
@@ -38,20 +38,19 @@ import io.spine.tools.code.Language
  *
  * @param L the programming language supported by this action.
  * @param P the type of the Protobuf declaration served by this action,
- *          such as [MessageType][io.spine.protodata.MessageType],
- *          [EnumType][io.spine.protodata.EnumType] or [Service][io.spine.protodata.Service].
+ *   such as [MessageType][io.spine.protodata.MessageType],
+ *   [EnumType][io.spine.protodata.EnumType] or [Service][io.spine.protodata.Service].
+ * @param language the programming language served by this action.
+ * @property subject the Protobuf declaration served by this action.
  * @see Renderer
  */
 public abstract class RenderAction<L : Language, P : ProtoDeclaration>
-protected constructor(language: L) : Member<L>(language) {
+protected constructor(language: L, protected val subject: P) : Member<L>(language) {
 
     /**
      * Renders the code in the given source file.
      *
-     * @param subject
-     *         the Protobuf declaration served by this action.
-     * @param file
-     *         the source code file to be modified by this action.
+     * @param file the source code file to be modified by this action.
      */
-    public abstract fun run(subject: P, file: SourceFile<L>)
+    public abstract fun run(file: SourceFile<L>)
 }

--- a/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/RenderAction.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.renderer
 
+import io.spine.protodata.CodegenContext
 import io.spine.protodata.EnumType
 import io.spine.protodata.Member
 import io.spine.protodata.MessageType
@@ -46,10 +47,19 @@ import io.spine.tools.code.Language
  *   [EnumType][io.spine.protodata.EnumType] or [Service][io.spine.protodata.Service].
  * @param language the programming language served by this action.
  * @property subject the Protobuf declaration served by this action.
+ * @param context the code generation context in which this action runs.
  * @see Renderer
  */
 public abstract class RenderAction<L : Language, P : ProtoDeclaration>
-protected constructor(language: L, protected val subject: P) : Member<L>(language) {
+protected constructor(
+    language: L,
+    protected val subject: P,
+    context: CodegenContext
+) : Member<L>(language) {
+
+    init {
+        registerWith(context)
+    }
 
     /**
      * Renders the code in the given source file.
@@ -67,11 +77,16 @@ protected constructor(language: L, protected val subject: P) : Member<L>(languag
  * @param T the type of the Protobuf declaration served by this action.
  * @param language the programming language served by this action.
  * @property type the same as [subject], added for readability in generated code templates.
+ * @param context the code generation context in which this action runs.
  * @see MessageAction
  * @see EnumAction
  */
 public abstract class TypeAction<L : Language, T : TypeDeclaration>
-protected constructor(language: L, protected val type: T) : RenderAction<L, T>(language, type)
+protected constructor(
+    language: L,
+    protected val type: T,
+    context: CodegenContext
+) : RenderAction<L, T>(language, type, context)
 
 /**
  * A render action performed for a [MessageType][io.spine.protodata.MessageType].
@@ -79,11 +94,15 @@ protected constructor(language: L, protected val type: T) : RenderAction<L, T>(l
  * @param L the programming language supported by this action.
  * @param language the programming language served by this action.
  * @param type the message type served by this action.
+ * @param context the code generation context in which this action runs.
  * @see EnumAction
  * @see ServiceAction
  */
-public abstract class MessageAction<L : Language>(language: L, type: MessageType) :
-    TypeAction<L, MessageType>(language, type)
+public abstract class MessageAction<L : Language>(
+    language: L,
+    type: MessageType,
+    context: CodegenContext
+) : TypeAction<L, MessageType>(language, type, context)
 
 /**
  * A render action performed for an [EnumType][io.spine.protodata.EnumType].
@@ -94,8 +113,11 @@ public abstract class MessageAction<L : Language>(language: L, type: MessageType
  * @see MessageAction
  * @see ServiceAction
  */
-public abstract class EnumAction<L : Language>(language: L, type: EnumType) :
-    TypeAction<L, EnumType>(language, type)
+public abstract class EnumAction<L : Language>(
+    language: L,
+    type: EnumType,
+    context: CodegenContext
+) : TypeAction<L, EnumType>(language, type, context)
 
 /**
  * A render action performed for a [Service][io.spine.protodata.Service].
@@ -103,8 +125,12 @@ public abstract class EnumAction<L : Language>(language: L, type: EnumType) :
  * @param L the programming language supported by this action.
  * @param language the programming language served by this action.
  * @property service the same as [subject], added for readability in generated code templates.
+ * @param context the code generation context in which this action runs.
  * @see MessageAction
  * @see EnumAction
  */
-public abstract class ServiceAction<L : Language>(language: L, protected val service: Service) :
-    RenderAction<L, Service>(language, service)
+public abstract class ServiceAction<L : Language>(
+    language: L,
+    protected val service: Service,
+    context: CodegenContext
+) : RenderAction<L, Service>(language, service, context)

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -107,7 +107,7 @@ message TypeName {
 
 // A Protobuf message type.
 message MessageType {
-    option (is).java_type = "ProtoDeclaration";
+    option (is).java_type = "TypeDeclaration";
 
     TypeName name = 1 [(required) = true];
 
@@ -157,7 +157,7 @@ message MessageType {
 
 // A Protobuf enum type.
 message EnumType {
-    option (is).java_type = "ProtoDeclaration";
+    option (is).java_type = "TypeDeclaration";
 
     TypeName name = 1 [(required) = true];
 

--- a/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
@@ -43,7 +43,14 @@ import org.junit.jupiter.api.assertDoesNotThrow
 @DisplayName("`RenderAction` should")
 internal class RenderActionSpec {
 
-    private val action: RenderAction<Java, MessageType> = StubAction()
+    private val typeName = "MyType"
+
+    private val subject = messageType {
+        name = typeName { simpleName = typeName }
+        file = io.spine.protodata.file { path = "acme/example/my_type.proto" }
+    }
+
+    private val action: RenderAction<Java, MessageType> = StubAction(subject)
 
     @Test
     fun `be language-specific`() {
@@ -52,24 +59,19 @@ internal class RenderActionSpec {
 
     @Test
     fun `accept 'ProtoDeclaration' and 'SourceFile' as parameters for rendering`() {
-        val typeName = "MyType"
-        val subject = messageType {
-            name = typeName { simpleName = typeName }
-            file = io.spine.protodata.file { path = "acme/example/my_type.proto" }
-        }
         val sourceFile = SourceFile.byCode<Java>(Path("$typeName.java"), """
             public class $typeName {}
             """.trimIndent()
         )
         assertDoesNotThrow {
-            action.run(subject, sourceFile)
+            action.run(sourceFile)
         }
     }
 }
 
-private class StubAction: RenderAction<Java, MessageType>(Java) {
+private class StubAction(type: MessageType): RenderAction<Java, MessageType>(Java, type) {
 
-    override fun run(subject: MessageType, file: SourceFile<Java>) {
+    override fun run(file: SourceFile<Java>) {
         // Do nothing.
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
  * The purpose of this test suite is to document the signature of the [RenderAction] class and
  * prevent accidental removal of this abstract class which is not (yet) otherwise used in the code.
  */
-@DisplayName("`RenderAction` should")
+@DisplayName("`MessageAction` should")
 internal class RenderActionSpec {
 
     private val typeName = "MyType"
@@ -50,7 +50,7 @@ internal class RenderActionSpec {
         file = io.spine.protodata.file { path = "acme/example/my_type.proto" }
     }
 
-    private val action: RenderAction<Java, MessageType> = StubAction(subject)
+    private val action: MessageAction<Java> = StubAction(subject)
 
     @Test
     fun `be language-specific`() {
@@ -69,7 +69,7 @@ internal class RenderActionSpec {
     }
 }
 
-private class StubAction(type: MessageType): RenderAction<Java, MessageType>(Java, type) {
+private class StubAction(type: MessageType): MessageAction<Java>(Java, type) {
 
     override fun run(file: SourceFile<Java>) {
         // Do nothing.

--- a/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
@@ -28,6 +28,7 @@ package io.spine.protodata.renderer
 
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.MessageType
+import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.messageType
 import io.spine.protodata.typeName
 import io.spine.tools.code.Java
@@ -69,7 +70,9 @@ internal class RenderActionSpec {
     }
 }
 
-private class StubAction(type: MessageType): MessageAction<Java>(Java, type) {
+private val context = CodeGenerationContext("fiz-buz")
+
+private class StubAction(type: MessageType): MessageAction<Java>(Java, type, context) {
 
     override fun render(file: SourceFile<Java>) {
         // Do nothing.

--- a/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
@@ -51,7 +51,12 @@ internal class RenderActionSpec {
         file = io.spine.protodata.file { path = "acme/example/my_type.proto" }
     }
 
-    private val action: MessageAction<Java> = StubAction(subject)
+    val sourceFile = SourceFile.byCode<Java>(Path("$typeName.java"), """
+            public class $typeName {}
+            """.trimIndent()
+    )
+
+    private val action: MessageAction<Java> = StubAction(subject, sourceFile)
 
     @Test
     fun `be language-specific`() {
@@ -60,21 +65,18 @@ internal class RenderActionSpec {
 
     @Test
     fun `accept 'ProtoDeclaration' and 'SourceFile' as parameters for rendering`() {
-        val sourceFile = SourceFile.byCode<Java>(Path("$typeName.java"), """
-            public class $typeName {}
-            """.trimIndent()
-        )
         assertDoesNotThrow {
-            action.render(sourceFile)
+            action.render()
         }
     }
 }
 
 private val context = CodeGenerationContext("fiz-buz")
 
-private class StubAction(type: MessageType): MessageAction<Java>(Java, type, context) {
+private class StubAction(type: MessageType, file: SourceFile<Java>) :
+    MessageAction<Java>(Java, type, file, context) {
 
-    override fun render(file: SourceFile<Java>) {
+    override fun render() {
         // Do nothing.
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/renderer/RenderActionSpec.kt
@@ -64,14 +64,14 @@ internal class RenderActionSpec {
             """.trimIndent()
         )
         assertDoesNotThrow {
-            action.run(sourceFile)
+            action.render(sourceFile)
         }
     }
 }
 
 private class StubAction(type: MessageType): MessageAction<Java>(Java, type) {
 
-    override fun run(file: SourceFile<Java>) {
+    override fun render(file: SourceFile<Java>) {
         // Do nothing.
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -52,7 +52,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.186"
+        const val reflect = "2.0.0-SNAPSHOT.187"
 
         /**
          * The version of [Spine.Logging].

--- a/dependencies.md
+++ b/dependencies.md
@@ -1009,7 +1009,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2027,7 +2027,7 @@ This report was generated on **Tue Jul 02 15:02:25 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3068,7 +3068,7 @@ This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4076,7 +4076,7 @@ This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5088,7 +5088,7 @@ This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6277,7 +6277,7 @@ This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7295,7 +7295,7 @@ This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8121,7 +8121,7 @@ This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9162,7 +9162,7 @@ This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10268,4 +10268,4 @@ This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 16:03:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1009,7 +1009,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2027,7 +2027,7 @@ This report was generated on **Tue Jul 02 00:54:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3068,7 +3068,7 @@ This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:26 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4076,7 +4076,7 @@ This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5088,7 +5088,7 @@ This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6277,7 +6277,7 @@ This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7295,7 +7295,7 @@ This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8121,7 +8121,7 @@ This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9162,7 +9162,7 @@ This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10268,4 +10268,4 @@ This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 15:02:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-api:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1009,12 +1009,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-backend:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2027,12 +2027,12 @@ This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3068,12 +3068,12 @@ This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4076,12 +4076,12 @@ This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5088,12 +5088,12 @@ This report was generated on **Mon Jul 01 17:24:45 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6277,12 +6277,12 @@ This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-java:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7295,12 +7295,12 @@ This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.50.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8121,12 +8121,12 @@ This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -9162,12 +9162,12 @@ This report was generated on **Mon Jul 01 17:24:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.40.0`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.50.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10268,4 +10268,4 @@ This report was generated on **Mon Jul 01 17:24:47 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 01 17:24:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 02 00:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.40.0</version>
+<version>0.50.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -98,7 +98,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-reflect</artifactId>
-    <version>2.0.0-SNAPSHOT.186</version>
+    <version>2.0.0-SNAPSHOT.187</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.40.0")
+val protoDataVersion: String by extra("0.50.0")


### PR DESCRIPTION
This PR adds the parameter called `subject` to `RenderAction`. It turned out that migrating existing rendering code in McJava to `RenderAction` API is awkward because of inability to continue using lazily evaluated properties. Those properties used to be derived from the `type` property passed to the constructors.

This PR addresses the need by introducing the `subject` property which is a grouping word for all the things covered by code generation in ProtoData. Not all those things are types. `MessageType` and `EnumType` are types, while `Service` is not.

### New `TypeDeclaration` mixin interface

In order to address the commonality of `MessageType` and `EnumType` in terms of rendering, a new marker interface called `TypeDeclaration` was introduced. 

## New render action classes

Having the `TypeDeclaration`  interface allowed to add `TypeAction` abstract class, which is derived from `RenderAction` and simply narrows down the generic parameter. More convenience classes were also added:
 * `MessageAction` is a `TypeAction` on `MessageType`.
 * `EnumActipon` is a `TypeAction` on `EnumType`.
 * `ServiceAction` is `RenderAction` on `Service`.

## `type` and `service` properties
The `type` property was introduced in `MessageAction` and `EnumAction` as an alias for `subject`.
Similarly, the `service` property was introduced in `ServiceAction`.

## Added `file` property to `RenderAction`

We want render actions to be narrowly focused on specific kinds of files. So, it's always one `subject` (or `type` or service) and `file` per rendering action.

## `RenderAction.run` renamed back to `render`
When the method is called `run`, it does not look nice in c ode like this:

```kotlin
FieldClass(type, sourceFile, fieldSupertype).run {
    run()
}
```
We do need such contracts for easier debugging of the rendering process. With the method named as `render` it reads better:

```kotlin
FieldClass(type, sourceFile, fieldSupertype).run {
    render()
}
```

## Other notable changes
 * The method `Member.registerWith` made final so that 1) it's not overridden by the derived classes 2) can be called from constructors of classes derived from `Member` without warnings.

