### PR TITLE
Bump dependencies

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
+++ b/api/src/main/kotlin/io/spine/protodata/renderer/SourceFileSet.kt
@@ -305,7 +305,14 @@ internal constructor(
     /**
      * Returns a comma-separated list of all the files in this set.
      */
-    override fun toString(): String = toList().joinToString()
+    public fun enumerateFiles(): String = toList().joinToString()
+
+    /**
+     * Produces the diagnostic output for this source file set.
+     */
+    override fun toString(): String =
+        "SourceFileSet(inputRoot=$inputRoot, outputRoot=$outputRoot," +
+                " files=${files.size}, deletedFiles=${deletedFiles.size})"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.30.0"
+    private const val fallbackVersion = "0.50.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.27.0"
+    private const val fallbackDfVersion = "0.50.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.206"
+        const val mcJava = "2.0.0-SNAPSHOT.213"
 
         /**
          * The version of [Spine.baseTypes].
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.217"
+        const val toolBase = "2.0.0-SNAPSHOT.218"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -36,17 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.133"
-
-    /**
-     * The distinct version of the Validation library used by build tools during
-     * the transition from a previous version when breaking API changes are introduced.
-     *
-     * When Validation is used both for building the project and as a part of the project's
-     * transitional dependencies, this is the version used to build the project itself to
-     * avoid errors caused by incompatible API changes.
-     */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.133"
+    const val version = "2.0.0-SNAPSHOT.152"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-api:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1009,12 +1009,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-backend:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2027,12 +2027,12 @@ This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3068,12 +3068,12 @@ This report was generated on **Tue Jul 02 16:03:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4076,12 +4076,12 @@ This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5088,12 +5088,12 @@ This report was generated on **Tue Jul 02 16:03:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6277,12 +6277,12 @@ This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-java:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7295,12 +7295,12 @@ This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.51.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8121,12 +8121,12 @@ This report was generated on **Tue Jul 02 16:03:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -9162,12 +9162,12 @@ This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.50.0`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.51.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10268,4 +10268,4 @@ This report was generated on **Tue Jul 02 16:03:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 16:03:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 23:37:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/file/SourceFileExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/SourceFileExts.kt
@@ -37,16 +37,30 @@ public val SourceFile<*>.isJava: Boolean
     get() = relativePath.extension == "java"
 
 /**
- * Tells if this source file set produces files that reside under the "java" directory.
+ * Tells if this source file set produces files that reside under the `java` directory.
  */
-public val SourceFileSet.hasJavaOutput: Boolean
+public val SourceFileSet.hasJavaRoot: Boolean
     get() = outputRoot.endsWith("java")
 
 /**
- * Tells if this source file set produces files that reside under the "grpc" directory.
+ * Tells if this source file set produces files that reside under the `java` directory.
  */
-public val SourceFileSet.hasGrpcOutput: Boolean
+@Deprecated(message = "Please use `hasJavaRoot` instead.", ReplaceWith("hasJavaRoot"))
+public val SourceFileSet.hasJavaOutput: Boolean
+    get() = hasJavaRoot
+
+/**
+ * Tells if this source file set produces files that reside under the `grpc` directory.
+ */
+public val SourceFileSet.hasGrpcRoot: Boolean
     get() = outputRoot.endsWith("grpc")
+
+/**
+ * Tells if this source file set produces files that reside under the `grpc` directory.
+ */
+@Deprecated(message = "Please use `hasGrpcRoot` instead.", ReplaceWith("hasGrpcRoot"))
+public val SourceFileSet.hasGrpcOutput: Boolean
+    get() = hasGrpcRoot
 
 /**
  * Tells if this source file set has at least one Java file.

--- a/java/src/main/kotlin/io/spine/protodata/java/file/SourceFileExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/file/SourceFileExts.kt
@@ -38,12 +38,17 @@ public val SourceFile<*>.isJava: Boolean
 
 /**
  * Tells if this source file set produces files that reside under the `java` directory.
+ *
+ * @see hasGrpcRoot
  */
 public val SourceFileSet.hasJavaRoot: Boolean
     get() = outputRoot.endsWith("java")
 
 /**
  * Tells if this source file set produces files that reside under the `java` directory.
+ *
+ * @see hasJavaRoot
+ * @see hasGrpcRoot
  */
 @Deprecated(message = "Please use `hasJavaRoot` instead.", ReplaceWith("hasJavaRoot"))
 public val SourceFileSet.hasJavaOutput: Boolean
@@ -51,12 +56,17 @@ public val SourceFileSet.hasJavaOutput: Boolean
 
 /**
  * Tells if this source file set produces files that reside under the `grpc` directory.
+ *
+ * @see hasJavaRoot
  */
 public val SourceFileSet.hasGrpcRoot: Boolean
     get() = outputRoot.endsWith("grpc")
 
 /**
  * Tells if this source file set produces files that reside under the `grpc` directory.
+ *
+ * @see hasGrpcRoot
+ * @see hasJavaRoot
  */
 @Deprecated(message = "Please use `hasGrpcRoot` instead.", ReplaceWith("hasGrpcRoot"))
 public val SourceFileSet.hasGrpcOutput: Boolean

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.50.0</version>
+<version>0.51.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -122,7 +122,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.217</version>
+    <version>2.0.0-SNAPSHOT.218</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -134,7 +134,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.133</version>
+    <version>2.0.0-SNAPSHOT.152</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -182,7 +182,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.217</version>
+    <version>2.0.0-SNAPSHOT.218</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -261,12 +261,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.21.3</version>
+    <version>0.50.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.21.3</version>
+    <version>0.50.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -275,39 +275,24 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-mc-java-annotation</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-mc-java-base</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <version>2.0.0-SNAPSHOT.213</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-mc-java-entity</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <version>2.0.0-SNAPSHOT.213</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-mc-java-rejection</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <artifactId>spine-mc-java-protoc</artifactId>
+    <version>2.0.0-SNAPSHOT.213</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.217</version>
+    <version>2.0.0-SNAPSHOT.218</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -317,7 +302,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.132</version>
+    <version>2.0.0-SNAPSHOT.152</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.50.0")
+val protoDataVersion: String by extra("0.51.0")


### PR DESCRIPTION
This PR updates dependencies on `tool-base`, Validation, and McJava.

## Other notable changes
 * `SourceFileSet.toString()` now produces diagnostic output. Previously, the method enumerated files. It was too too much of information if there are many files. It was also confusing in case when there's only one file. The output gave only one file in a diagnostic message where a source file set was supposed to be.
 * `SourceFileSet.enumerateFiles()` method was introduced to allow list files when in diagnostics when necessary.
