### PR TITLE
Implement `ClassName.outer()` function

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:18 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Tue Sep 10 15:33:18 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:18 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Tue Sep 10 15:33:18 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Tue Sep 10 15:33:19 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Tue Sep 10 15:33:20 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:21 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Tue Sep 10 15:33:21 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 15:33:21 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 17:42:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
@@ -107,7 +107,7 @@ public class ClassName(
      * The method is useful for obtaining names for outer classes,
      * e.g. `Message` from `Message.Builder`.
      *
-     * @throws IllegalStateException when the current class name is the top level class name.
+     * @throws IllegalStateException When the current class name is the top level class name.
      */
     public fun outer(): ClassName {
         check(simpleNames.size > 1) {

--- a/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
@@ -107,13 +107,13 @@ public class ClassName(
      * The method is useful for obtaining names for outer classes,
      * e.g. `Message` from `Message.Builder`.
      *
-     * @throws IllegalStateException When the current class name is the top level class name.
+     * @return  A new `ClassName` if the current class name is not the top-level class.
+     *          Otherwise, `null` is returned.
      */
-    public fun outer(): ClassName {
-        check(simpleNames.size > 1) {
-            "Cannot obtain outer class name for the top level class name."
-        }
-        return ClassName(packageName, simpleNames.dropLast(1))
+    public fun outer(): ClassName? {
+        return if (simpleNames.size > 1)
+            ClassName(packageName, simpleNames.dropLast(1))
+        else null
     }
 
     override fun equals(other: Any?): Boolean {

--- a/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
@@ -101,6 +101,21 @@ public class ClassName(
     public fun nested(simpleClassName: String): ClassName =
         ClassName(packageName, simpleNames + simpleClassName)
 
+    /**
+     * Obtains a new `ClassName` with the last element removed from the list of simple names.
+     *
+     * The method is useful for obtaining names for outer classes,
+     * e.g. `Message` from `Message.Builder`.
+     *
+     * @throws IllegalStateException when the current class name is the top level class name.
+     */
+    public fun outer(): ClassName {
+        check(simpleNames.size > 1) {
+            "Cannot obtain outer class name for the top level class name."
+        }
+        return ClassName(packageName, simpleNames.dropLast(1))
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ClassName) return false

--- a/java/src/test/kotlin/io/spine/protodata/java/ClassNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/ClassNameSpec.kt
@@ -28,7 +28,6 @@ package io.spine.protodata.java
 
 import assertCode
 import com.google.protobuf.Timestamp
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.test.Incarnation
@@ -94,13 +93,7 @@ internal class ClassNameSpec {
     @Test
     fun `obtain an outer name`() {
         ClassName(Timestamp.Builder::class).outer() shouldBe ClassName(Timestamp::class)
-    }
-
-    @Test
-    fun `fail obtaining an outer name`() {
-        shouldThrow<IllegalStateException> {
-            ClassName(Timestamp::class).outer()
-        }
+        ClassName(Timestamp::class).outer() shouldBe null
     }
 
     @Nested inner class

--- a/java/src/test/kotlin/io/spine/protodata/java/ClassNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/ClassNameSpec.kt
@@ -28,6 +28,7 @@ package io.spine.protodata.java
 
 import assertCode
 import com.google.protobuf.Timestamp
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.test.Incarnation
@@ -88,6 +89,18 @@ internal class ClassNameSpec {
     @Test
     fun `obtain a nested name`() {
         ClassName(Timestamp::class).nested("Builder") shouldBe ClassName(Timestamp.Builder::class)
+    }
+
+    @Test
+    fun `obtain an outer name`() {
+        ClassName(Timestamp.Builder::class).outer() shouldBe ClassName(Timestamp::class)
+    }
+
+    @Test
+    fun `fail obtaining an outer name`() {
+        shouldThrow<IllegalStateException> {
+            ClassName(Timestamp::class).outer()
+        }
     }
 
     @Nested inner class

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.60.2</version>
+<version>0.60.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.60.2")
+val protoDataVersion: String by extra("0.60.3")


### PR DESCRIPTION
This PR adds `ClassName.outer()` function, which allows obtaining a new `ClassName` with the last element removed from the list of simple names.

The ProtoData version is set to `0.60.3`.