### PR TITLE
Starting adoption of `EveryIsOption`

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -66,3 +66,5 @@ dependencies {
     // For using `CodeGenerationContext` in stubs.
     testImplementation(project(":backend"))
 }
+
+protoDataRemoteDebug(enabled = false)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,9 +41,18 @@ import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 buildscript {
     standardSpineSdkRepositories()
+    val baseForBuildScript = io.spine.internal.dependency.Spine.baseForBuildScript
     dependencies {
         classpath(io.spine.internal.dependency.Protobuf.GradlePlugin.lib)
-        classpath(io.spine.internal.dependency.Spine.McJava.pluginLib)
+        classpath(baseForBuildScript)
+        classpath(mcJava.pluginLib) {
+            excludeSpineBase()
+        }
+    }
+    configurations.all {
+        resolutionStrategy {
+            force(baseForBuildScript)
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -38,6 +38,7 @@ import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.standardToSpineSdk
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.JavaExec
 import org.gradle.kotlin.dsl.ScriptHandlerScope
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
@@ -205,3 +206,42 @@ fun Project.configureTaskDependencies() {
  */
 val Project.productionModules: Iterable<Project>
     get() = rootProject.subprojects.filter { !it.name.contains("-tests") }
+
+
+/**
+ * Sets the remote debug option for this task.
+ *
+ * The port number is `5566`.
+ *
+ * @param enabled If `true` the task will be suspended.
+ */
+fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
+    debugOptions {
+        this@debugOptions.enabled.set(enabled)
+        port.set(5566)
+        server.set(true)
+        suspend.set(true)
+    }
+}
+
+/**
+ * Sets remote debug options for the `launchProtoData` task.
+ *
+ * @param enabled if `true` the task will be suspended.
+ *
+ * @see remoteDebug
+ */
+fun Project.protoDataRemoteDebug(enabled: Boolean = true) {
+    tasks.findByName("launchProtoData")?.remoteDebug(enabled)
+}
+
+/**
+ * Sets remote debug options for the `launchTestProtoData` task.
+ *
+ * @param enabled if `true` the task will be suspended.
+ *
+ * @see remoteDebug
+ */
+fun Project.testProtoDataRemoteDebug(enabled: Boolean = true) {
+    tasks.findByName("launchTestProtoData")?.remoteDebug(enabled)
+}

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -31,23 +31,16 @@ import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Kover
 import io.spine.internal.dependency.Ksp
+import io.spine.internal.dependency.McJava
 import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.ProtoTap
 import io.spine.internal.dependency.Protobuf
-import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.standardToSpineSdk
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.kotlin.dsl.ScriptHandlerScope
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
-
-/**
- * Applies [standard][standardToSpineSdk] repositories to this `buildscript`.
- */
-fun ScriptHandlerScope.standardSpineSdkRepositories() {
-    repositories.standardToSpineSdk()
-}
 
 /**
  * Provides shortcuts to reference our dependency objects.
@@ -63,28 +56,47 @@ fun ScriptHandlerScope.standardSpineSdkRepositories() {
  *     get() = id(GradleDoctor.pluginId).version(GradleDoctor.version)
  * ```
  *
- * But for some plugins, it's impossible to apply them directly to a project.
+ * But for some plugins, it is impossible to apply them directly to a project.
  * For example, when a plugin is not published to Gradle Portal, it can only be
- * applied with the buildscript's classpath. Thus, it's needed to leave some freedom
+ * applied with the buildscript's classpath. Thus, it is necessary to leave some freedom
  * upon how to apply them. In such cases, just a shortcut to a dependency object
  * can be declared without applying the plugin in-place.
  */
 private const val ABOUT_DEPENDENCY_EXTENSIONS = ""
 
 /**
- * Shortcut to [Spine.McJava] dependency object.
+ * Applies [standard][standardToSpineSdk] repositories to this `buildscript`.
+ */
+fun ScriptHandlerScope.standardSpineSdkRepositories() {
+    repositories.standardToSpineSdk()
+}
+
+/**
+ * Shortcut to [McJava] dependency object for using under `buildScript`.
+ */
+val ScriptHandlerScope.mcJava: McJava
+    get() = McJava
+
+/**
+ * Shortcut to [McJava] dependency object.
  *
  * This plugin is not published to Gradle Portal and cannot be applied directly to a project.
  * Firstly, it should be put to buildscript's classpath and then applied by ID only.
  */
-val PluginDependenciesSpec.mcJava: Spine.McJava
-    get() = Spine.McJava
+val PluginDependenciesSpec.mcJava: McJava
+    get() = McJava
+
+/**
+ * Shortcut to [ProtoData] dependency object for using under `buildScript`.
+ */
+val ScriptHandlerScope.protoData: ProtoData
+    get() = ProtoData
 
 /**
  * Shortcut to [ProtoData] dependency object.
  *
- * This plugin is published at Gradle Portal. But when used in a pair with [mcJava],
- * it cannot be applied directly to a project.
+ * This plugin is published at Gradle Plugin Portal.
+ * But when used in a pair with [mcJava], it cannot be applied directly to a project.
  * It is so, because [mcJava] uses [protoData] as its dependency.
  * And buildscript's classpath ends up with both of them.
  */
@@ -187,10 +199,9 @@ fun Project.configureTaskDependencies() {
 }
 
 /**
- * Obtains all modules of the root project to which this project belongs that
- * do not have `"-tests"` in their names.
+ * Obtains all modules names of which do not have `"-tests"` as the suffix.
  *
- * By convention such modules are for integration tests and should be treated differently.
+ * By convention, such modules are for integration tests and should be treated differently.
  */
 val Project.productionModules: Iterable<Project>
     get() = rootProject.subprojects.filter { !it.name.contains("-tests") }

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -50,11 +50,15 @@ import io.spine.internal.dependency.OpenTest4J
 import io.spine.internal.dependency.Plexus
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Slf4J
+import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Truth
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.kotlin.dsl.exclude
 
 /**
  * The function to be used in `buildscript` when a fully qualified call must be made.
@@ -165,4 +169,24 @@ fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     excludeProtoLite("runtimeOnly")
     excludeProtoLite("testRuntimeOnly")
+}
+
+/**
+ * Excludes `spine-base` from the dependencies.
+ */
+@Suppress("unused")
+fun ModuleDependency.excludeSpineBase() {
+    exclude(group = Spine.group, module = "spine-base")
+}
+
+/**
+ * Forces the version of [Spine.base] in the given project.
+ */
+@Suppress("unused")
+fun Project.forceSpineBase() {
+    configurations.all {
+        resolutionStrategy {
+            force(Spine.base)
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
@@ -27,7 +27,8 @@
 @file:Suppress("RemoveRedundantQualifierName")
 
 import io.spine.internal.dependency.Protobuf
-import io.spine.internal.dependency.Spine.McJava
+import io.spine.internal.dependency.McJava
+import io.spine.internal.dependency.Spine
 
 /**
  * The dependency onto Spine Validation causes the circular dependency in this Gradle project.
@@ -42,4 +43,13 @@ apply {
 
 dependencies {
     Protobuf.libs.forEach { "api"(it) }
+}
+
+configurations.all {
+    if(name.endsWith("ProtoPath")) {
+        System.err.println(" --- Configuring `$name` with `${Spine.baseForBuildScript}`. ---")
+        resolutionStrategy.force(
+            Spine.baseForBuildScript
+        )
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -35,7 +35,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.9.20"
+    const val version = "1.9.10"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -27,12 +27,32 @@
 package io.spine.internal.dependency
 
 /**
- * Helps optimize Gradle Builds by ensuring recommendations at build time.
+ * Dependencies on Spine Model Compiler for Java.
  *
- * See [plugin site](https://runningcode.github.io/gradle-doctor) for features and usage.
+ * See [mc-java](https://github.com/SpineEventEngine/mc-java).
  */
-@Suppress("unused", "ConstPropertyName")
-object GradleDoctor {
-    const val version = "0.10.0"
-    const val pluginId = "com.osacky.doctor"
+@Suppress(
+    "MemberVisibilityCanBePrivate" /* `pluginLib()` is used by subprojects. */,
+    "ConstPropertyName"
+)
+object McJava {
+    const val group = Spine.toolsGroup
+
+    /** The version used to in the build classpath. */
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.241"
+
+    /** The version to be used for integration tests. */
+    const val version = "2.0.0-SNAPSHOT.241"
+
+    const val pluginId = "io.spine.mc-java"
+
+    val pluginLib = pluginLib(dogfoodingVersion)
+    fun pluginLib(version: String): String = "$group:spine-mc-java-plugins:$version:all"
+
+    /** The artifact reference for forcing in configurations. */
+    @Suppress("unused")
+    const val pluginsArtifact: String = "$group:spine-mc-java-plugins:$version"
+
+    val base = base(version)
+    fun base(version: String): String = "$group:spine-mc-java-base:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -58,14 +58,22 @@ package io.spine.internal.dependency
     "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
 )
 object ProtoData {
+    const val pluginGroup = Spine.group
     const val group = "io.spine.protodata"
     const val pluginId = "io.spine.protodata"
+
+    /**
+     * Identifies ProtoData as a `classpath` dependency under `buildScript` block.
+     *
+     * The dependency is obtained from https://plugins.gradle.org/m2/.
+     */
+    const val module = "io.spine:protodata"
 
     /**
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.60.3"
+    private const val fallbackVersion = "0.61.2"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,14 +82,19 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.54.2"
+    private const val fallbackDfVersion = "0.61.2"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
      */
     val pluginLib: String
 
-    fun pluginLib(version: String): String =
+    /**
+     * The artifact to be used during experiments when publishing locally.
+     *
+     * @see ProtoData
+     */
+    private fun pluginLib(version: String): String =
         "$group:gradle-plugin:$version"
 
     fun api(version: String): String =
@@ -89,10 +102,6 @@ object ProtoData {
 
     val api
         get() = api(version)
-
-    @Deprecated("Use `backend` instead", ReplaceWith("backend"))
-    val compiler
-        get() = backend
 
     val backend
         get() = "$group:protodata-backend:$version"
@@ -106,16 +115,8 @@ object ProtoData {
     val cliApi
         get() = "$group:protodata-cli-api:$version"
 
-    @Deprecated("Use `java()` instead", ReplaceWith("java(version)"))
-    fun codegenJava(version: String): String =
-        java(version)
-
     fun java(version: String): String =
         "$group:protodata-java:$version"
-
-    @Deprecated("Use `java` instead.", ReplaceWith("java"))
-    val codegenJava
-        get() = java(version)
 
     val java
         get() = java(version)
@@ -167,7 +168,7 @@ object ProtoData {
         } else {
             version = fallbackVersion
             dogfoodingVersion = fallbackDfVersion
-            pluginLib = "${Spine.group}:protodata:$version"
+            pluginLib = "$pluginGroup:protodata:$version"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -33,7 +33,7 @@ object Roaster {
     /**
      * This is the last version build with Java 11.
      *
-     * Starting from version
+     * Starting from the version
      * [2.29.0.Final](https://github.com/forge/roaster/releases/tag/2.29.0.Final),
      * Roaster requires Java 17.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.208"
+        const val base = "2.0.0-SNAPSHOT.211"
+        const val dogfoodingBase = "2.0.0-SNAPSHOT.208"
 
         /**
          * The version of [Spine.reflect].
@@ -85,13 +86,6 @@ object Spine {
         const val mc = "2.0.0-SNAPSHOT.133"
 
         /**
-         * The version of [McJava].
-         *
-         * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
-         */
-        const val mcJava = "2.0.0-SNAPSHOT.221"
-
-        /**
          * The version of [Spine.baseTypes].
          *
          * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
@@ -124,10 +118,10 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.224"
+        const val toolBase = "2.0.0-SNAPSHOT.225"
 
         /**
-         * The version of [Spine.javadocTools].
+         * The version of [Spine.javadocFilter].
          *
          * @see <a href="https://github.com/SpineEventEngine/doc-tools">spine-javadoc-tools</a>
          */
@@ -135,6 +129,7 @@ object Spine {
     }
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
+    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.dogfoodingBase}"
 
     const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
@@ -150,6 +145,9 @@ object Spine {
     const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
     const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
     const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
+
+    @Deprecated(message = "Please use top level `McJava` object instead.")
+    val McJava = io.spine.internal.dependency.McJava
 
     /**
      * Dependencies on the artifacts of the Spine Logging library.
@@ -171,35 +169,8 @@ object Spine {
         internal const val middleware = "$group:spine-logging-middleware:$version"
         internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
         internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
-
-        @Deprecated(
-            message = "Please use `Logging.lib` instead.",
-            replaceWith = ReplaceWith("lib")
-        )
-        const val floggerApi = "$group:spine-flogger-api:$version"
-
-        @Deprecated(
-            message = "Please use `grpcContext` instead.",
-            replaceWith = ReplaceWith("grpcContext")
-        )
-        const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
     }
 
-    /**
-     * Dependencies on Spine Model Compiler for Java.
-     *
-     * See [mc-java](https://github.com/SpineEventEngine/mc-java).
-     */
-    @Suppress("MemberVisibilityCanBePrivate") // `pluginLib()` is used by subprojects.
-    object McJava {
-        const val version = ArtifactVersion.mcJava
-        const val pluginId = "io.spine.mc-java"
-        val pluginLib = pluginLib(version)
-        fun pluginLib(version: String): String = "$toolsGroup:spine-mc-java-plugins:$version:all"
-    }
-
-    @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))
-    const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
     const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"
 
     const val client = CoreJava.client // Added for brevity.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.154"
+    const val version = "2.0.0-SNAPSHOT.160"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,15 +24,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.dependency
+package io.spine.internal.gradle.dokka
+
+import java.io.File
+import org.gradle.api.file.FileCollection
+import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
 
 /**
- * Helps optimize Gradle Builds by ensuring recommendations at build time.
+ * Returns only Java source roots out of all present in the source set.
  *
- * See [plugin site](https://runningcode.github.io/gradle-doctor) for features and usage.
+ * It is a helper method for generating documentation by Dokka only for Java code.
+ * It is helpful when both Java and Kotlin source files are present in a source set.
+ * Dokka can properly generate documentation for either Kotlin or Java depending on
+ * the configuration, but not both.
  */
-@Suppress("unused", "ConstPropertyName")
-object GradleDoctor {
-    const val version = "0.10.0"
-    const val pluginId = "com.osacky.doctor"
+@Suppress("unused")
+internal fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
+    return sourceRoots.filter(File::isJavaSourceDirectory)
+}
+
+private fun File.isJavaSourceDirectory(): Boolean {
+    return isDirectory && name == "java"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,15 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.dependency
+package io.spine.internal.gradle.dokka
+
+import org.gradle.api.tasks.TaskContainer
+import org.jetbrains.dokka.gradle.DokkaTask
 
 /**
- * Helps optimize Gradle Builds by ensuring recommendations at build time.
- *
- * See [plugin site](https://runningcode.github.io/gradle-doctor) for features and usage.
+ * Finds the `dokkaHtml` Gradle task.
  */
-@Suppress("unused", "ConstPropertyName")
-object GradleDoctor {
-    const val version = "0.10.0"
-    const val pluginId = "com.osacky.doctor"
-}
+@Suppress("unused")
+fun TaskContainer.dokkaHtmlTask() = this.getByName("dokkaHtml") as DokkaTask

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
@@ -54,9 +54,8 @@ internal class MarkdownReportRenderer(
     }
 
     private fun outputFile(project: Project): File {
-        val config =
-            project.extensions.findByName("licenseReport") as LicenseReportExtension
-        return File(config.outputDir).resolve(filename)
+        val ext = project.extensions.findByName("licenseReport") as LicenseReportExtension
+        return File(ext.outputDir).resolve(filename)
     }
 }
 

--- a/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
@@ -25,11 +25,6 @@
  */
 
 import io.spine.internal.gradle.buildDirectory
-import java.io.File
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.getting
-import org.gradle.kotlin.dsl.jacoco
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
     jacoco

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-api:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.3`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Mon Sep 23 20:07:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-backend:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Mon Sep 23 20:07:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-cli:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Mon Sep 23 20:07:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Mon Sep 23 20:07:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-java:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.61.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10099,12 +10099,12 @@ This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.61.2`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.61.3`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11213,4 +11213,4 @@ This report was generated on **Mon Sep 23 20:07:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 23 20:07:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Wed Sep 25 17:38:59 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Wed Sep 25 17:39:00 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Wed Sep 25 17:39:01 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 25 17:39:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 25 18:45:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -43,6 +43,15 @@ dependencies {
     testImplementation(JavaX.annotations)
     testImplementation(Spine.testUtilTime)
     testImplementation(project(":test-env"))
+}
+
+// Temporarily force the previous version of Base so that tests for `IsOption` could pass.
+configurations.all {
+    if(name in arrayOf("testCompileClasspath", "testRuntimeClasspath")) {
+        resolutionStrategy.force(
+            Spine.baseForBuildScript
+        )
+    }
 }
 
 // Allows test suites to fetch generated Java files as resources.

--- a/java/src/main/kotlin/io/spine/protodata/java/OptionExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/OptionExts.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.java
 
+import io.spine.option.EveryIsOption
 import io.spine.option.IsOption
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.java.JavaTypeName.Companion.PACKAGE_SEPARATOR
@@ -33,23 +34,36 @@ import org.checkerframework.checker.signature.qual.FullyQualifiedName
 
 /**
  * Obtains a fully qualified name of a Java type corresponding the value
- * of the `java_type` property of `is` or `every_is` options.
+ * of the `java_type` property of the `is` option.
  *
- * @param header the header of the proto file to resolve the Java package if
+ * @param header The header of the proto file to resolve the Java package if
  *   a simple type name is specified.
- * @throws IllegalStateException if the `java_type` property is empty or blank.
+ * @throws IllegalStateException If the `java_type` property is empty or blank.
  * @see IsOption
  */
-public fun IsOption.qualifiedJavaType(header: ProtoFileHeader): @FullyQualifiedName String {
+public fun IsOption.qualifiedJavaType(header: ProtoFileHeader): @FullyQualifiedName String =
+    header.toQualified(javaType)
+
+/**
+ * Obtains a fully qualified name of a Java type corresponding the value
+ * of the `java_type` property of the `every_is` option.
+ *
+ * @param header The header of the proto file to resolve the Java package if
+ *   a simple type name is specified.
+ * @throws IllegalStateException If the `java_type` property is empty or blank.
+ * @see EveryIsOption
+ */
+public fun EveryIsOption.qualifiedJavaType(header: ProtoFileHeader): @FullyQualifiedName String =
+    header.toQualified(javaType)
+
+private fun ProtoFileHeader.toQualified(javaType: String): @FullyQualifiedName String {
     check(javaType.isNotEmpty() && javaType.isNotBlank()) {
         "The value of `java_type` must not be empty or blank. Got: `\"$javaType\"`."
     }
-    return if (javaType.isQualified) {
+    val isQualified = javaType.contains(PACKAGE_SEPARATOR)
+    return if (isQualified) {
         javaType
     } else {
-        "${header.javaPackage()}.$javaType"
+        "${javaPackage()}.$javaType"
     }
 }
-
-private val String.isQualified: Boolean
-    get() = contains(PACKAGE_SEPARATOR)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.61.2</version>
+<version>0.61.3</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.208</version>
+    <version>2.0.0-SNAPSHOT.211</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -122,19 +122,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.224</version>
+    <version>2.0.0-SNAPSHOT.225</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.224</version>
+    <version>2.0.0-SNAPSHOT.225</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.154</version>
+    <version>2.0.0-SNAPSHOT.160</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -182,7 +182,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.224</version>
+    <version>2.0.0-SNAPSHOT.225</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -261,12 +261,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.60.4</version>
+    <version>0.61.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.60.4</version>
+    <version>0.61.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -276,18 +276,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.221</version>
+    <version>2.0.0-SNAPSHOT.241</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.221</version>
+    <version>2.0.0-SNAPSHOT.241</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.224</version>
+    <version>2.0.0-SNAPSHOT.225</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -297,7 +297,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.154</version>
+    <version>2.0.0-SNAPSHOT.160</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.2")
+val protoDataVersion: String by extra("0.61.3")


### PR DESCRIPTION
This PR starts the migration to new types backing `(is)` and `(every_is)` options.

The builds were adjusted to use older version of Base, while new version is added to compile dependencies. It is still required to force the previous version of Base for `testCompileClasspath` and `testRuntimeClasspath` tasks because tests deal with the descriptors generated during compile time (which is based on older Base version).

## `buildSrc` changes
 * Introduced `Project.protoDataRemoteDebug()` function to ease the arrangement of remote debug sessions.
 * Copied recent improvements from McJava.

