### PR TITLE
Allow more than one cardinality when calculating message type dependencies

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -146,11 +146,13 @@
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
     <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
@@ -192,6 +194,7 @@
       <option name="ignoreLocalVariables" value="false" />
       <option name="ignorePrivateMethodsAndFields" value="false" />
     </inspection_tool>
+    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -575,6 +578,7 @@
     </inspection_tool>
     <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -619,9 +623,6 @@
     </inspection_tool>
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Production" level="WARNING" enabled="true" />
-    </inspection_tool>
     <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInconvertibleTypes" value="true" />
     </inspection_tool>
@@ -689,6 +690,7 @@
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
+    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -709,6 +711,7 @@
     <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
@@ -747,10 +750,13 @@
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -784,6 +790,7 @@
     <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="3" />
     </inspection_tool>
@@ -804,6 +811,7 @@
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Problems" level="INFO" enabled="true">

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
@@ -37,14 +37,14 @@ import io.spine.protodata.type.TypeSystem
  * recursively in one of the immediate or nested fields.
  *
  * @param messageType The type for which we collect dependencies.
- * @param cardinality The cardinality of fields taken into account when traversing the types.
- *    `null` value means that all fields, including `repeated` and `map` ones will be
+ * @param cardinalities The cardinalities of fields taken into account when traversing the types.
+ *    Empty set means that all fields, including `repeated` and `map` ones will be
  *    taken into account when collecting types.
  * @param typeSystem The type system to obtain a `MessageType` by its name.
  */
 public class MessageTypeDependencies(
     private val messageType: MessageType,
-    private val cardinality: CardinalityCase?,
+    private val cardinalities: Set<CardinalityCase>,
     private val typeSystem: TypeSystem
 ) {
     /**
@@ -71,8 +71,8 @@ public class MessageTypeDependencies(
             .toSet()
 
     private fun Field.matchesCardinality(): Boolean =
-        if (cardinality != null) {
-            cardinalityCase == cardinality
+        if (cardinalities.isNotEmpty()) {
+            cardinalities.contains(cardinalityCase)
         } else {
             true
         }

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
@@ -47,6 +47,25 @@ public class MessageTypeDependencies(
     private val cardinalities: Set<CardinalityCase>,
     private val typeSystem: TypeSystem
 ) {
+
+    /**
+     * Creates an instance for collecting all the dependencies of the given
+     * [messageType] using the given [typeSystem].
+     */
+    public constructor(messageType: MessageType, typeSystem: TypeSystem) :
+            this(messageType, emptySet(), typeSystem)
+
+    /**
+     * Creates an instance for collecting the dependencies of the given
+     * [messageType] for fields with the specified [cardinality] using
+     * the given [typeSystem].
+     */
+    public constructor(
+        messageType: MessageType,
+        cardinality: CardinalityCase,
+        typeSystem: TypeSystem
+    ) : this(messageType, setOf(cardinality), typeSystem)
+
     /**
      * The guard set against recursive type definitions.
      */

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeDependencies.kt
@@ -62,26 +62,6 @@ public class MessageTypeDependencies(
         return seq.toSet()
     }
 
-    /**
-     * Obtains the dependencies found in the [messageType].
-     */
-    @Deprecated(
-        message = "Please use `asSet()` instead.",
-        replaceWith = ReplaceWith("asSet()")
-    )
-    public val set: Set<MessageType> by lazy {
-        asSet()
-    }
-
-    /**
-     * Obtains the dependencies found in the [messageType].
-     */
-    @Deprecated(
-        message = "Please use `asSet()` instead.",
-        replaceWith = ReplaceWith("asSet()")
-    )
-    public fun scan(): Set<MessageType> = asSet()
-
     private fun MessageType.matchingFieldTypes(): Iterable<MessageType> =
         fieldList.asSequence()
             .filter { it.matchesCardinality() }

--- a/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("DEPRECATION") /* The deprecated types are still the dependencies. */
+
+package io.spine.protodata.ast
+
+import com.google.protobuf.AnyProto
+import com.google.protobuf.Duration
+import com.google.protobuf.DurationProto
+import com.google.protobuf.Timestamp
+import com.google.protobuf.TimestampProto
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.spine.core.ActorContext
+import io.spine.core.ActorContextProto
+import io.spine.core.Command
+import io.spine.core.CommandContext
+import io.spine.core.CommandId
+import io.spine.core.CommandProto
+import io.spine.core.DiagnosticsProto
+import io.spine.core.Enrichment
+import io.spine.core.EnrichmentProto
+import io.spine.core.EventContext
+import io.spine.core.EventId
+import io.spine.core.EventProto
+import io.spine.core.MessageId
+import io.spine.core.Origin
+import io.spine.core.RejectionEventContext
+import io.spine.core.TenantId
+import io.spine.core.TenantIdProto
+import io.spine.core.UserId
+import io.spine.core.UserIdProto
+import io.spine.core.Version
+import io.spine.core.VersionProto
+import io.spine.protodata.ast.Field.CardinalityCase.ONEOF_NAME
+import io.spine.protodata.ast.Field.CardinalityCase.SINGLE
+import io.spine.protodata.protobuf.toPbSourceFile
+import io.spine.protodata.type.TypeSystem
+import io.spine.time.TimeProto
+import io.spine.time.ZoneId
+import io.spine.time.ZoneOffset
+import io.spine.ui.LanguageProto
+import org.junit.jupiter.api.Test
+import com.google.protobuf.Any as ProtoAny
+
+/**
+ * Tests that dependencies of [EventContext] are calculated in full.
+ */
+internal class EventContextDependenciesTest {
+
+    private val typeSystem: TypeSystem by lazy {
+        val protoSources = setOf(
+            AnyProto.getDescriptor(),
+            UserIdProto.getDescriptor(),
+            TenantIdProto.getDescriptor(),
+            TimeProto.getDescriptor(),
+            LanguageProto.getDescriptor(),
+            CommandProto.getDescriptor(),
+            EnrichmentProto.getDescriptor(),
+            EventProto.getDescriptor(),
+            TimestampProto.getDescriptor(),
+            DurationProto.getDescriptor(),
+            ActorContextProto.getDescriptor(),
+            DiagnosticsProto.getDescriptor(),
+            VersionProto.getDescriptor(),
+        ).map { it.toPbSourceFile() }.toSet()
+        TypeSystem(protoSources)
+    }
+
+    @Test
+    fun `full dependencies`() {
+        val eventContext = messageTypeOf<EventContext>()
+        val deps = MessageTypeDependencies(eventContext, SINGLE, typeSystem).asSet()
+            .union(MessageTypeDependencies(eventContext, ONEOF_NAME, typeSystem).asSet())
+
+        val expected = setOf(
+            messageTypeOf<ActorContext>(),
+            messageTypeOf<Command.SystemProperties>(),
+            messageTypeOf<Command>(),
+            messageTypeOf<CommandContext.Schedule>(),
+            messageTypeOf<CommandContext>(),
+            messageTypeOf<CommandId>(),
+            messageTypeOf<Duration>(),
+            messageTypeOf<Enrichment.Container>(),
+            messageTypeOf<Enrichment>(),
+            messageTypeOf<EventContext>(),
+            messageTypeOf<EventId>(),
+            messageTypeOf<MessageId>(),
+            messageTypeOf<Origin>(),
+            messageTypeOf<ProtoAny>(),
+            messageTypeOf<RejectionEventContext>(),
+            messageTypeOf<TenantId>(),
+            messageTypeOf<Timestamp>(),
+            messageTypeOf<UserId>(),
+            messageTypeOf<Version>(),
+            messageTypeOf<ZoneId>(),
+            messageTypeOf<ZoneOffset>(),
+        ).map { it.qualifiedName }.toSet()
+
+        val dependencies = deps.map { it.qualifiedName }
+
+        dependencies.minus(expected).shouldBeEmpty()
+    }
+}

--- a/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
@@ -55,6 +55,8 @@ import io.spine.core.UserId
 import io.spine.core.UserIdProto
 import io.spine.core.Version
 import io.spine.core.VersionProto
+import io.spine.net.EmailAddress
+import io.spine.net.InternetDomain
 import io.spine.protodata.ast.Field.CardinalityCase.ONEOF_NAME
 import io.spine.protodata.ast.Field.CardinalityCase.SINGLE
 import io.spine.protodata.protobuf.toPbSourceFile
@@ -104,10 +106,12 @@ internal class EventContextDependenciesTest {
             messageTypeOf<CommandContext>(),
             messageTypeOf<CommandId>(),
             messageTypeOf<Duration>(),
+            messageTypeOf<EmailAddress>(),
             messageTypeOf<Enrichment.Container>(),
             messageTypeOf<Enrichment>(),
             messageTypeOf<EventContext>(),
             messageTypeOf<EventId>(),
+            messageTypeOf<InternetDomain>(),
             messageTypeOf<MessageId>(),
             messageTypeOf<Origin>(),
             messageTypeOf<ProtoAny>(),

--- a/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
@@ -56,7 +56,9 @@ import io.spine.core.UserIdProto
 import io.spine.core.Version
 import io.spine.core.VersionProto
 import io.spine.net.EmailAddress
+import io.spine.net.EmailAddressProto
 import io.spine.net.InternetDomain
+import io.spine.net.InternetDomainProto
 import io.spine.protodata.ast.Field.CardinalityCase.ONEOF_NAME
 import io.spine.protodata.ast.Field.CardinalityCase.SINGLE
 import io.spine.protodata.protobuf.toPbSourceFile
@@ -75,18 +77,20 @@ internal class EventContextDependenciesTest {
 
     private val typeSystem: TypeSystem by lazy {
         val protoSources = setOf(
+            ActorContextProto.getDescriptor(),
             AnyProto.getDescriptor(),
-            UserIdProto.getDescriptor(),
-            TenantIdProto.getDescriptor(),
-            TimeProto.getDescriptor(),
-            LanguageProto.getDescriptor(),
             CommandProto.getDescriptor(),
+            DiagnosticsProto.getDescriptor(),
+            DurationProto.getDescriptor(),
+            EmailAddressProto.getDescriptor(),
             EnrichmentProto.getDescriptor(),
             EventProto.getDescriptor(),
+            InternetDomainProto.getDescriptor(),
+            LanguageProto.getDescriptor(),
+            TenantIdProto.getDescriptor(),
+            TimeProto.getDescriptor(),
             TimestampProto.getDescriptor(),
-            DurationProto.getDescriptor(),
-            ActorContextProto.getDescriptor(),
-            DiagnosticsProto.getDescriptor(),
+            UserIdProto.getDescriptor(),
             VersionProto.getDescriptor(),
         ).map { it.toPbSourceFile() }.toSet()
         TypeSystem(protoSources)

--- a/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/EventContextDependenciesTest.kt
@@ -93,8 +93,8 @@ internal class EventContextDependenciesTest {
     @Test
     fun `full dependencies`() {
         val eventContext = messageTypeOf<EventContext>()
-        val deps = MessageTypeDependencies(eventContext, SINGLE, typeSystem).asSet()
-            .union(MessageTypeDependencies(eventContext, ONEOF_NAME, typeSystem).asSet())
+        val deps =
+            MessageTypeDependencies(eventContext, setOf(SINGLE, ONEOF_NAME), typeSystem).asSet()
 
         val expected = setOf(
             messageTypeOf<ActorContext>(),

--- a/api/src/test/kotlin/io/spine/protodata/ast/MessageTypeDependenciesSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/MessageTypeDependenciesSpec.kt
@@ -26,21 +26,29 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.Empty
+import com.google.protobuf.EmptyProto
+import com.google.protobuf.Timestamp
+import com.google.protobuf.TimestampProto
 import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.ast.Field.CardinalityCase.LIST
 import io.spine.protodata.ast.Field.CardinalityCase.MAP
+import io.spine.protodata.ast.Field.CardinalityCase.ONEOF_NAME
 import io.spine.protodata.ast.Field.CardinalityCase.SINGLE
 import io.spine.protodata.protobuf.toPbSourceFile
 import io.spine.protodata.type.TypeSystem
 import io.spine.test.type.Article
 import io.spine.test.type.Author
 import io.spine.test.type.AuthorName
+import io.spine.test.type.Issue
 import io.spine.test.type.Jungle
+import io.spine.test.type.Magazine
 import io.spine.test.type.MagazineCover
+import io.spine.test.type.MagazineNumber
+import io.spine.test.type.MagazineTitle
 import io.spine.test.type.MessageTypeDependenciesSpecProto
 import io.spine.test.type.OopFun
 import io.spine.test.type.Photo
@@ -63,12 +71,14 @@ internal class MessageTypeDependenciesSpec {
         val protoSources = setOf(
             MessageTypeDependenciesSpecProto.getDescriptor().toPbSourceFile(),
             ProjectProto.getDescriptor().toPbSourceFile(),
+            EmptyProto.getDescriptor().toPbSourceFile(),
+            TimestampProto.getDescriptor().toPbSourceFile(),
         )
         TypeSystem(protoSources)
     }
 
     private fun allDependenciesOf(type: MessageType): Set<MessageType> =
-        MessageTypeDependencies(type, null, typeSystem).asSet()
+        MessageTypeDependencies(type, emptySet(), typeSystem).asSet()
 
     @Test
     fun `collect no types if there are no fields with message type`() {
@@ -81,7 +91,6 @@ internal class MessageTypeDependenciesSpec {
     fun `collect nested types`() {
         val coverType = messageTypeOf<MagazineCover>()
         val found = allDependenciesOf(coverType)
-        found shouldHaveSize 4
         found.shouldContainExactlyInAnyOrder(
             messageTypeOf<MagazineCover.Headline>(),
             messageTypeOf<Photo>(),
@@ -93,7 +102,7 @@ internal class MessageTypeDependenciesSpec {
     @Test
     fun `obtain the same result in repeated calls`() {
         val coverType = messageTypeOf<MagazineCover>()
-        val deps = MessageTypeDependencies(coverType, null, typeSystem)
+        val deps = MessageTypeDependencies(coverType, emptySet(), typeSystem)
         val found = deps.asSet()
         val foundNextTime = deps.asSet()
         found shouldBe foundNextTime
@@ -102,8 +111,7 @@ internal class MessageTypeDependenciesSpec {
     @Test
     fun `collect types referenced from types of fields`() {
         val projectView = messageTypeOf<ProjectView>()
-        val deps = MessageTypeDependencies(projectView, SINGLE, typeSystem).asSet()
-        deps shouldHaveSize 5
+        val deps = MessageTypeDependencies(projectView, setOf(SINGLE), typeSystem).asSet()
         deps.shouldContainExactlyInAnyOrder(
             messageTypeOf<ProjectId>(),
             messageTypeOf<ProjectName>(),
@@ -117,7 +125,6 @@ internal class MessageTypeDependenciesSpec {
     fun `collect a single instance of type in case of circular field references`() {
         val authorType = messageTypeOf<Author>()
         val found = allDependenciesOf(authorType)
-        found shouldHaveSize 2
         found.shouldContainExactlyInAnyOrder(
             authorType,
             messageTypeOf<AuthorName>()
@@ -135,9 +142,8 @@ internal class MessageTypeDependenciesSpec {
 
         @Test
         fun `all fields`() {
-            val allTypes = MessageTypeDependencies(funnyType, null, typeSystem).asSet()
+            val allTypes = MessageTypeDependencies(funnyType, emptySet(), typeSystem).asSet()
 
-            allTypes shouldHaveSize 4
             allTypes.shouldContainExactlyInAnyOrder(
                 jungleType,
                 treeType,
@@ -148,23 +154,41 @@ internal class MessageTypeDependenciesSpec {
 
         @Test
         fun `single fields`() {
-            val singleTypes = MessageTypeDependencies(funnyType, SINGLE, typeSystem).asSet()
-            singleTypes shouldHaveSize 1
-            singleTypes shouldContain jungleType
+            val singleTypes = MessageTypeDependencies(funnyType, setOf(SINGLE), typeSystem).asSet()
+            singleTypes.shouldContainExactly(jungleType)
         }
 
         @Test
         fun `map fields`() {
-            val mapTypes = MessageTypeDependencies(funnyType, MAP, typeSystem).asSet()
-            mapTypes shouldHaveSize 1
-            mapTypes shouldContain gorillaType
+            val mapTypes = MessageTypeDependencies(funnyType, setOf(MAP), typeSystem).asSet()
+            mapTypes.shouldContainExactly(gorillaType)
         }
+
         @Test
         fun `repeated fields`() {
-            val repeatedTypes = MessageTypeDependencies(funnyType, LIST, typeSystem).asSet()
-            repeatedTypes shouldHaveSize 2
-            repeatedTypes shouldContain treeType
-            repeatedTypes shouldContain bananaType
+            val repeatedTypes = MessageTypeDependencies(funnyType, setOf(LIST), typeSystem).asSet()
+
+            repeatedTypes.shouldContainExactlyInAnyOrder(treeType, bananaType)
+        }
+
+        @Test
+        fun `combination of fields`() {
+            val magazine = messageTypeOf<Magazine>()
+            val combination =
+                MessageTypeDependencies(magazine, setOf(SINGLE, ONEOF_NAME), typeSystem)
+                    .asSet().map { it.qualifiedName }
+
+            val expected = setOf(
+                messageTypeOf<Magazine>(),
+                messageTypeOf<Empty>(),
+                messageTypeOf<Volume>(),
+                messageTypeOf<Issue>(),
+                messageTypeOf<Timestamp>(),
+                messageTypeOf<MagazineTitle>(),
+                messageTypeOf<MagazineNumber>(),
+            ).map { it.qualifiedName }
+
+            combination.shouldContainExactlyInAnyOrder(expected)
         }
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/MessageTypeDependenciesSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/MessageTypeDependenciesSpec.kt
@@ -111,7 +111,7 @@ internal class MessageTypeDependenciesSpec {
     @Test
     fun `collect types referenced from types of fields`() {
         val projectView = messageTypeOf<ProjectView>()
-        val deps = MessageTypeDependencies(projectView, setOf(SINGLE), typeSystem).asSet()
+        val deps = MessageTypeDependencies(projectView, SINGLE, typeSystem).asSet()
         deps.shouldContainExactlyInAnyOrder(
             messageTypeOf<ProjectId>(),
             messageTypeOf<ProjectName>(),
@@ -142,7 +142,7 @@ internal class MessageTypeDependenciesSpec {
 
         @Test
         fun `all fields`() {
-            val allTypes = MessageTypeDependencies(funnyType, emptySet(), typeSystem).asSet()
+            val allTypes = MessageTypeDependencies(funnyType, typeSystem).asSet()
 
             allTypes.shouldContainExactlyInAnyOrder(
                 jungleType,
@@ -154,19 +154,19 @@ internal class MessageTypeDependenciesSpec {
 
         @Test
         fun `single fields`() {
-            val singleTypes = MessageTypeDependencies(funnyType, setOf(SINGLE), typeSystem).asSet()
+            val singleTypes = MessageTypeDependencies(funnyType, SINGLE, typeSystem).asSet()
             singleTypes.shouldContainExactly(jungleType)
         }
 
         @Test
         fun `map fields`() {
-            val mapTypes = MessageTypeDependencies(funnyType, setOf(MAP), typeSystem).asSet()
+            val mapTypes = MessageTypeDependencies(funnyType, MAP, typeSystem).asSet()
             mapTypes.shouldContainExactly(gorillaType)
         }
 
         @Test
         fun `repeated fields`() {
-            val repeatedTypes = MessageTypeDependencies(funnyType, setOf(LIST), typeSystem).asSet()
+            val repeatedTypes = MessageTypeDependencies(funnyType, LIST, typeSystem).asSet()
 
             repeatedTypes.shouldContainExactlyInAnyOrder(treeType, bananaType)
         }

--- a/api/src/testFixtures/proto/given/type/message_type_dependencies_spec.proto
+++ b/api/src/testFixtures/proto/given/type/message_type_dependencies_spec.proto
@@ -36,11 +36,18 @@ option java_outer_classname = "MessageTypeDependenciesSpecProto";
 option java_multiple_files = true;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
 // A message type with multi-level nested `Message`-typed fields structure.
 message Magazine {
     MagazineTitle name = 1;
     MagazineNumber number = 2;
+
+    oneof inlay {
+        google.protobuf.Empty none = 3;
+        Magazine promo = 4;
+        string coupon_code = 5;
+    }
 }
 
 message MagazineTitle {

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -88,7 +88,7 @@ val PluginDependenciesSpec.mcJava: McJava
     get() = McJava
 
 /**
- * Shortcut to [ProtoData] dependency object for using under `buildScript`.
+ * Shortcut to [ProtoData] dependency object for using under `buildscript`.
  */
 val ScriptHandlerScope.protoData: ProtoData
     get() = ProtoData
@@ -211,14 +211,14 @@ val Project.productionModules: Iterable<Project>
 /**
  * Sets the remote debug option for this task.
  *
- * The port number is `5566`.
+ * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].
  *
  * @param enabled If `true` the task will be suspended.
  */
 fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
     debugOptions {
         this@debugOptions.enabled.set(enabled)
-        port.set(5566)
+        port.set(BuildSettings.REMOTE_DEBUG_PORT)
         server.set(true)
         suspend.set(true)
     }

--- a/buildSrc/src/main/kotlin/BuildSettings.kt
+++ b/buildSrc/src/main/kotlin/BuildSettings.kt
@@ -27,10 +27,11 @@
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 /**
- * This object provides high-level constants, like version of JVM, to be used
+ * This object provides high-level constants, like the version of JVM, to be used
  * throughout the project.
  */
 object BuildSettings {
     private const val JVM_VERSION = 11
     val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(JVM_VERSION)
+    const val REMOTE_DEBUG_PORT = 5566
 }

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -190,3 +190,17 @@ fun Project.forceSpineBase() {
         }
     }
 }
+
+/**
+ * Forces configurations containing `"proto"` in their names (disregarding the case) to
+ * use [Spine.baseForBuildScript].
+ */
+fun Project.forceBaseInProtoTasks() {
+    configurations.configureEach {
+        if (name.toLowerCase().contains("proto")) {
+            resolutionStrategy {
+                force(Spine.baseForBuildScript)
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -35,7 +35,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.9.10"
+    const val version = "1.9.20"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -39,10 +39,10 @@ object McJava {
     const val group = Spine.toolsGroup
 
     /** The version used to in the build classpath. */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.241"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.242"
 
     /** The version to be used for integration tests. */
-    const val version = "2.0.0-SNAPSHOT.241"
+    const val version = "2.0.0-SNAPSHOT.243"
 
     const val pluginId = "io.spine.mc-java"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.2"
+    private const val fallbackVersion = "0.61.4"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.2"
+    private const val fallbackDfVersion = "0.61.4"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -46,7 +46,7 @@ object Spine {
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
         const val base = "2.0.0-SNAPSHOT.212"
-        const val dogfoodingBase = "2.0.0-SNAPSHOT.208"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.212"
 
         /**
          * The version of [Spine.reflect].
@@ -129,7 +129,7 @@ object Spine {
     }
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
-    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.dogfoodingBase}"
+    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.baseForBuildScript}"
 
     const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-api:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.5`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Mon Oct 07 19:59:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-backend:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-cli:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Mon Oct 07 19:59:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Mon Oct 07 19:59:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Mon Oct 07 19:59:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-java:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.61.5`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10099,12 +10099,12 @@ This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.61.4`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.61.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11213,4 +11213,4 @@ This report was generated on **Mon Oct 07 19:59:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:59:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 09 18:04:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/test/kotlin/io/spine/protodata/java/OptionExtsSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/OptionExtsSpec.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata.java
 
 import io.kotest.matchers.shouldBe
+import io.spine.option.EveryIsOption
 import io.spine.option.IsOption
 import io.spine.protodata.ast.find
 import io.spine.protodata.protobuf.toHeader
@@ -47,7 +48,7 @@ internal class OptionExtsSpec {
 
         @Test
         fun `'every_is' option`() {
-            val isOption = fileHeader.optionList.find<IsOption>()
+            val isOption = fileHeader.optionList.find<EveryIsOption>()
 
             isOption!!.qualifiedJavaType(fileHeader) shouldBe "life.earth.Animal"
         }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.61.4</version>
+<version>0.61.5</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -261,12 +261,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.61.2</version>
+    <version>0.61.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.61.2</version>
+    <version>0.61.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -276,13 +276,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.241</version>
+    <version>2.0.0-SNAPSHOT.242</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.241</version>
+    <version>2.0.0-SNAPSHOT.242</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.4")
+val protoDataVersion: String by extra("0.61.5")


### PR DESCRIPTION
This PR extends the `MessageTypeDependencies` class allowing to pass more than one `CardinalityCase` for filtering. 

The change is needed to allow gathering combination of `SINGLE` and `ONEOF_NAME` cardinalities. It is needed to gather deeper dependencies when nested fields has an alternative cardinality than a field of with the outer message type.

Convenience `MessageTypeDependencies` constructors covering non-combination cases were also provided.

## Other notable changes
 * Previously deprecated `set` property and `scan()` method of `MessageTypeDependencies` were removed.
 * Added `EventContextDependenciesTest` which documents expected dependencies of the `spine.core.EventContext` type. 
 * `buildSrc` was updated from latest `config`.
