### PR TITLE
Support field reference in `Value`

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -67,4 +67,6 @@ dependencies {
     testImplementation(project(":backend"))
 }
 
+forceSpineBase()
+
 protoDataRemoteDebug(enabled = false)

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
@@ -48,8 +48,7 @@ public val MessageType.columns: List<Field>
 /**
  * Obtains message types nested into this one.
  *
- * @param typeSystem
- *         the type system used to resolve types by their names.
+ * @param typeSystem The type system used to resolve types by their names.
  */
 public fun MessageType.nestedMessageTypes(typeSystem: TypeSystem): List<MessageType> =
     nestedMessagesList.map { typeName ->

--- a/api/src/main/kotlin/io/spine/protodata/ast/PrimitiveTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/PrimitiveTypeExts.kt
@@ -28,9 +28,33 @@
 
 package io.spine.protodata.ast
 
+import io.spine.protodata.ast.PrimitiveType.TYPE_BOOL
+
 /**
  * Obtains a [Type] wrapping this `PrimitiveType`.
  */
-public fun PrimitiveType.asType(): Type = type {
-    primitive = this@asType
+public fun PrimitiveType.toType(): Type = type {
+    primitive = this@toType
 }
+
+/**
+ * Obtains a [Type] wrapping this `PrimitiveType`.
+ */
+@Deprecated(message = "Please use `toType()` instead.", replaceWith = ReplaceWith("toType()"))
+public fun PrimitiveType.asType(): Type = toType()
+
+/**
+ * Obtains a name of a field type declared in a message.
+ */
+public val PrimitiveType.protoName: String
+    get() {
+        if (this == TYPE_BOOL) {
+            return "boolean"
+        }
+        val knownPrefix = "TYPE_"
+        return if (name.startsWith(knownPrefix)) {
+            name.removePrefix(knownPrefix).lowercase()
+        } else {
+            name
+        }
+    }

--- a/api/src/main/kotlin/io/spine/protodata/ast/ProtobufSourceFileExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ProtobufSourceFileExts.kt
@@ -38,6 +38,28 @@ public fun ProtobufSourceFile.messages(): Collection<MessageInFile> =
     }
 
 /**
+ * Finds a message type declared in this Protobuf file.
+ *
+ * @param simpleName The simple name of the type.
+ * @param nestedNames If the type with [simpleName] is nested, the list types enclosing it,
+ *  starting from the outermost.
+ * @return The message type or `null`, if there is no such declaration.
+ * @see TypeName.getNestingTypeNameList
+ */
+public fun ProtobufSourceFile.findMessage(
+    simpleName: String,
+    vararg nestedNames: String
+): MessageType? =
+    typeMap.values.find {
+        val simpleNamesMatch = (it.name.simpleName == simpleName)
+        if (nestedNames.isEmpty()) {
+            it.isTopLevel && simpleNamesMatch
+        } else {
+            simpleNamesMatch && it.name.nestingTypeNameList.toList() == nestedNames.toList()
+        }
+    }
+
+/**
  * Obtains a collection of enum types from this source file paired with the file header.
  */
 public fun ProtobufSourceFile.enums(): Collection<EnumInFile> =

--- a/api/src/main/kotlin/io/spine/protodata/ast/TypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/TypeExts.kt
@@ -28,22 +28,38 @@
 
 package io.spine.protodata.ast
 
+import io.spine.protodata.ast.Type.KindCase.MESSAGE
+import io.spine.protodata.ast.Type.KindCase.ENUMERATION
+import io.spine.protodata.ast.Type.KindCase.PRIMITIVE
 import io.spine.protodata.type.TypeSystem
 import io.spine.type.shortDebugString
 
 /**
  * Obtains a simple name of the type if represents a message or an enum.
  *
- * @throws IllegalStateException If this is a primitive type.
+ * @throws IllegalStateException if this is a primitive type.
  */
 public val Type.simpleName: String
     get() = typeName.simpleName
 
 /**
+ * Obtains a human-readable name of this type.
+ *
+ * For message and enum types it would be a qualified name of the type.
+ * For primitive types it would be a name of the type as used when declaring fields.
+ */
+public val Type.name: String
+    get() = when (kindCase) {
+        MESSAGE -> message.qualifiedName
+        ENUMERATION -> enumeration.qualifiedName
+        PRIMITIVE -> primitive.protoName
+        else -> kindCase.name
+    }
+
+/**
  * Converts a message or an enum type to its [TypeName].
  *
- * @throws IllegalStateException
- *          if this type is not a message or an enum type.
+ * @throws IllegalStateException if this type is not a message or an enum type.
  */
 public val Type.typeName: TypeName
     get() {
@@ -101,9 +117,8 @@ public val Type.isAny: Boolean
 /**
  * Converts this type to an instance of [MessageType] finding it using the given [typeSystem].
  *
- * @throws IllegalStateException
- *          - if this type is not a message type.
- *          - if the type system does not have a corresponding `MessageType.
+ * @throws IllegalStateException if this type is not a message type, or
+ *   if the type system does not have a corresponding `MessageType`.
  */
 public fun Type.toMessageType(typeSystem: TypeSystem): MessageType {
     check(isMessage)

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -33,9 +33,11 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import io.spine.protodata.ast.Documentation
 import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.MessageType
+import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.messageType
 import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.type
 
 /**
  * Obtains documentation of this [GenericDescriptor].
@@ -67,10 +69,17 @@ public fun Descriptor.toMessageType(): MessageType =
     }
 
 /**
+ * Converts the `Descriptor` into [Type] instance with the [message][Type.getMessage]
+ * property initialized.
+ */
+public fun Descriptor.toType(): Type = type {
+    message = name()
+}
+
+/**
  * Obtains a field with the given [name].
  *
- * @throws IllegalStateException
- *          if there is no such a field in this message type.
+ * @throws IllegalStateException If there is no such a field in this message type.
  */
 public fun Descriptor.field(name: String): Field {
     val field: FieldDescriptor? = findFieldByName(name)
@@ -84,12 +93,10 @@ public fun Descriptor.field(name: String): Field {
 /**
  * Create a type name for a type with the given [simpleName].
  *
- * @param simpleName
- *         a simple name of the type.
- * @param file
- *         the file in which the type is declared.
- * @param containingDeclaration
- *         if specified, a descriptor of a message type under which the type is declared.
+ * @param simpleName The simple name of the type.
+ * @param file The file in which the type is declared.
+ * @param containingDeclaration If specified, a descriptor of a message type under
+ *   which the type is declared.
  */
 internal fun buildTypeName(
     simpleName: String,
@@ -115,10 +122,10 @@ internal fun buildTypeName(
 /**
  * Produces a sequence by walking through all the nested message definitions staring with [type].
  *
- * @param type
- *         the message definition which may contain nested message definition to walk through.
- * @param extractorFun
- *         a function that, given a message definition, extracts the items of interest.
+ * @param type The message definition which may contain a nested message definition
+ *   to walk through.
+ * @param extractorFun The function that, given a message definition, extracts
+ *   the items of interest.
  * @return results of the calls to [extractorFun] flattened into one sequence.
  */
 internal fun <T> walkMessage(

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -31,12 +31,14 @@ import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
 import io.spine.protodata.ast.EnumConstant
 import io.spine.protodata.ast.EnumType
+import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.constantName
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.enumConstant
 import io.spine.protodata.ast.enumType
 import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.type
 
 /**
  * Obtains the name of this enum type as a [TypeName].
@@ -45,6 +47,8 @@ public fun EnumDescriptor.name(): TypeName = buildTypeName(name, file, containin
 
 /**
  * Converts this enum descriptor into [EnumType] instance.
+ *
+ * @see toType
  */
 public fun EnumDescriptor.toEnumType(): EnumType =
     enumType {
@@ -59,6 +63,15 @@ public fun EnumDescriptor.toEnumType(): EnumType =
         }
         doc = docs.forEnum(this@toEnumType)
     }
+
+/**
+ * Converts this enum descriptor into an instance of [Type].
+ *
+ * @see toEnumType
+ */
+public fun EnumDescriptor.toType(): Type = type {
+    enumeration = name()
+}
 
 /**
  * Converts this enum value descriptor into an [EnumConstant] with options.

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -67,11 +67,11 @@ import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
 import io.spine.protodata.ast.PrimitiveType.TYPE_UINT32
 import io.spine.protodata.ast.PrimitiveType.TYPE_UINT64
 import io.spine.protodata.ast.Type
-import io.spine.protodata.ast.asType
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.field
 import io.spine.protodata.ast.fieldName
 import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.toType
 import io.spine.protodata.ast.type
 
 /**
@@ -142,7 +142,7 @@ public fun FieldDescriptor.type(): Type {
         ENUM -> enum(this)
         MESSAGE -> message(this)
         GROUP -> error("Cannot process the field `$fullName` of type `$type`.")
-        else -> primitiveType().asType()
+        else -> primitiveType().toType()
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/value/Options.kt
+++ b/api/src/main/kotlin/io/spine/protodata/value/Options.kt
@@ -87,6 +87,15 @@ private class OptionValue(
     private companion object {
         private val INTEGER = Regex("^-?\\d+$")
         private val DOUBLE = Regex("^-?\\d+\\.\\d+$")
+
+        /**
+         * The regex for field references which could be fields in the same type or
+         * nested fields.
+         *
+         * We deliberately relax the expression to allow references starting from capital
+         * letters as well. This is to allow users to use custom field conventions should
+         * they have such a need.
+         */
         private val REFERENCE = Regex("^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
     }
 }

--- a/api/src/main/kotlin/io/spine/protodata/value/Options.kt
+++ b/api/src/main/kotlin/io/spine/protodata/value/Options.kt
@@ -117,7 +117,7 @@ private class OptionValue(
                     " of the field `$sourceFieldName` of the type `$messageTypeName`" +
                     " is of type `${referencedField.type.name}`" +
                     " but the field `$sourceFieldName` is of type `${field.type.name}`." +
-                    " Please correct the field reference of change the type of `$sourceFieldName`."
+                    " Please correct the field reference or change the type of `$sourceFieldName`."
         }
         return path
     }

--- a/api/src/main/kotlin/io/spine/protodata/value/Options.kt
+++ b/api/src/main/kotlin/io/spine/protodata/value/Options.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:JvmName("Options")
+
+package io.spine.protodata.value
+
+import io.spine.base.FieldPath
+import io.spine.base.fieldPath
+import io.spine.option.MaxOption
+import io.spine.option.MinOption
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.qualifiedName
+
+/**
+ * Parses the value of this `(min)` option into an instance of [Value].
+ *
+ * The value could be an integer, double, or a reference to another field.
+ */
+public fun MinOption.parse(field: Field): Value = OptionValue("min", value, field).parse()
+
+/**
+ * Parses the value of this `(min)` option into an instance of [Value].
+ *
+ * The value could be an integer, double, or a reference to another field.
+ */
+public fun MaxOption.parse(field: Field): Value = OptionValue("max", value, field).parse()
+
+/**
+ * Parses the value of the option into an instance of [Value].
+ *
+ * Supported value formats are [INTEGER], [DOUBLE], and [REFERENCE].
+ * Values in other formats will cause [IllegalStateException].
+ */
+private class OptionValue(
+    private val optionName: String,
+    private val value: String,
+    private val field: Field
+) {
+    init {
+        check(value.isNotEmpty()) {
+            "${optionPath()} cannot be empty."
+        }
+    }
+
+    fun parse(): Value {
+        return when {
+            value.matches(INTEGER) -> value { intValue = value.toLong() }
+            value.matches(DOUBLE) -> value { doubleValue = value.toDouble() }
+            value.matches(REFERENCE) -> value {
+                reference = reference {
+                    type = field.type
+                    target = value.toFieldPath()
+                }
+            }
+            else -> error("${optionPath()} has the value with unexpected format (`$value`).")
+        }
+    }
+
+    private fun optionPath() =
+        "The `($optionName)` option declared in the field `${field.name.value}` of" +
+                " the type `${field.type.message.qualifiedName}`"
+
+    private companion object {
+        private val INTEGER = Regex("^-?\\d+$")
+        private val DOUBLE = Regex("^-?\\d+\\.\\d+$")
+        private val REFERENCE = Regex("^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
+    }
+}
+
+private fun String.toFieldPath(): FieldPath = fieldPath {
+    split(".").forEach { fieldName.add(it) }
+}

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -180,13 +180,22 @@ message FieldOptionDiscovered {
     File file = 1 [(required) = true];
 
     // The type in which the field is defined.
-    TypeName type = 2 [(required) = true];
+    //
+    // Deprecated: please use `subject` instead.
+    //
+    TypeName type = 2 [deprecated = true];
 
     // The field in which the option is discovered.
-    FieldName field = 3 [(required) = true];
+    //
+    // Deprecated: please use `subject` instead.
+    //
+    FieldName field = 3 [deprecated = true];
+
+    // The field in which the option is discovered.
+    Field subject = 6 [(required) = true];
 
     // The option discovered.
-    Option option = 4 [(required) = true];
+    Option option = 5 [(required) = true];
 }
 
 // Emitted when a field is completely discovered including the options.

--- a/api/src/main/proto/spine/protodata/value.proto
+++ b/api/src/main/proto/spine/protodata/value.proto
@@ -35,6 +35,7 @@ option java_package = "io.spine.protodata.value";
 option java_outer_classname = "ValueProto";
 option java_multiple_files = true;
 
+import "spine/base/field_path.proto";
 import "spine/protodata/ast.proto";
 
 // This file contains definitions which describe Protobuf message, enum, and scalar
@@ -45,8 +46,8 @@ import "spine/protodata/ast.proto";
 //
 // These definitions are inspired by the `google/protobuf/struct.proto`.
 //
-// Unlike types defined in `struct.proto`, these definitions keep strict typing at runtime.
-// Values are bound to their precise types.
+// Unlike types defined in `struct.proto`, these definitions keep type
+// information using `Type` fields.
 //
 // Also, unlike `struct.proto`, these definitions do not have special treatment
 // when converting to JSON. Consider using Google's types when JSON printing is required.
@@ -57,43 +58,47 @@ import "spine/protodata/ast.proto";
 // Absence of any kind of value indicates an error.
 //
 message Value {
-    // The kind of value.
+    // The kind of the value.
     oneof kind {
         option (is_required) = true;
 
-        // Represents a `null` value.
+        // The `null` value.
         NullValue null_value = 1;
 
-        // Represents a boolean value.
+        // The boolean value.
         bool bool_value = 2;
 
-        // Represents a floating point number.
+        // The floating point number.
         double double_value = 3;
 
-        // Represents an integer number.
+        // The integer number.
         int64 int_value = 4;
 
-        // Represents a string value.
+        // The string value.
         string string_value = 5;
 
+        // The byte array value.
         bytes bytes_value = 6;
 
-        // Represents a structured value.
+        // The structured value.
         MessageValue message_value = 7;
 
-        // Represents an enum constant `Value`.
+        // The enum constant `Value`.
         EnumValue enum_value = 8;
 
-        // Represents a repeated `Value`.
+        // The repeated `Value`.
         ListValue list_value = 9;
 
-        // Represents a map `Value`.
+        // The map `Value`.
         MapValue map_value = 10;
+
+        // The reference to a value of the field with the given path.
+        base.FieldPath reference = 11;
     }
 
-    reserved 11 to 20; // For possible extra options in the `kind` oneof.
+    reserved 12 to 20; // For possible extra options in the `kind` oneof.
 
-    // The concrete Protobuf type of this value.
+    // The Protobuf type of this value.
     //
     // Can be used, for example, to distinguish between number values.
     //

--- a/api/src/main/proto/spine/protodata/value.proto
+++ b/api/src/main/proto/spine/protodata/value.proto
@@ -180,7 +180,9 @@ message Reference {
 
     // The type of the referenced value.
     //
-    // If the reference is obtained by parsing a "source" field option, it is the type of the field.
+    // If the reference is obtained by parsing a "source" field option.
+    // The referenced field must have the same type as the field where the option is used.
+    // If this is not the case, a compilation error will occur.
     //
     protodata.Type type = 1 [(required) = true];
 

--- a/api/src/main/proto/spine/protodata/value.proto
+++ b/api/src/main/proto/spine/protodata/value.proto
@@ -93,7 +93,7 @@ message Value {
         MapValue map_value = 10;
 
         // The reference to a value of the field with the given path.
-        base.FieldPath reference = 11;
+        Reference reference = 11;
     }
 
     reserved 12 to 20; // For possible extra options in the `kind` oneof.
@@ -170,4 +170,20 @@ message MapValue {
         // A map value.
         Value value = 2 [(required) = true];
     }
+}
+
+// A reference to a value in the field specified in the [target] property.
+//
+// Typically such a reference is obtained by parsing an option of a "source" field.
+//
+message Reference {
+
+    // The type of the referenced value.
+    //
+    // If the reference is obtained by parsing a "source" field option, it is the type of the field.
+    //
+    protodata.Type type = 1 [(required) = true];
+
+    // The path to the referenced field.
+    base.FieldPath target = 2 [(required) = true];
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtobufSourceFileExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtobufSourceFileExtsSpec.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+import com.google.protobuf.Empty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.spine.protodata.given.type.DeeplyNestedProto
+import io.spine.protodata.protobuf.toPbSourceFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ProtobufSourceFile` extensions should")
+internal class ProtobufSourceFileExtsSpec {
+
+    @Test
+    fun `find a top level message type by its simple name`() {
+        val protoFile = Empty.getDescriptor().file.toPbSourceFile()
+        val simpleName = "Empty"
+        val messageType = protoFile.findMessage(simpleName)
+
+        messageType shouldNotBe null
+        messageType!!.name.simpleName shouldBe simpleName
+    }
+
+    @Test
+    fun `find a nested message by its nesting path`() {
+        val protoFile = DeeplyNestedProto.getDescriptor().toPbSourceFile()
+
+        val outer = "Outer"
+        val inner = "Inner"
+        val yetInner = "YetInner"
+
+        // Positive cases.
+        protoFile.findMessage(outer)!!.name.simpleName shouldBe outer
+        protoFile.findMessage(inner, outer)!!.name.simpleName shouldBe inner
+        protoFile.findMessage(yetInner, outer, inner)!!.name.simpleName shouldBe yetInner
+
+        // Negative cases.
+
+        // The nested message does not have a full path to it.
+        protoFile.findMessage(yetInner) shouldBe null
+
+        // Not a full path given.
+        protoFile.findMessage(yetInner, outer) shouldBe null
+
+        // Wrong order of enclosing types.
+        protoFile.findMessage(yetInner, inner, outer) shouldBe null
+    }
+}

--- a/api/src/test/kotlin/io/spine/protodata/ast/TypeExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/TypeExtsSpec.kt
@@ -26,10 +26,15 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.Empty
 import com.google.protobuf.Value
 import io.kotest.matchers.shouldBe
 import io.spine.base.ListOfAnys
+import io.spine.protodata.ast.PrimitiveType.TYPE_BOOL
+import io.spine.protodata.ast.PrimitiveType.TYPE_DOUBLE
+import io.spine.protodata.ast.PrimitiveType.TYPE_SFIXED64
 import io.spine.protodata.protobuf.field
+import io.spine.protodata.protobuf.toType
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -39,7 +44,7 @@ import org.junit.jupiter.api.assertThrows
 internal class TypeExtsSpec {
 
     @Nested inner class
-    `Obtain simple type name` {
+    `obtain simple type name` {
 
         private val messageType: Type
         private val enumType: Type
@@ -71,6 +76,29 @@ internal class TypeExtsSpec {
             assertThrows<IllegalStateException> {
                 primitiveType.simpleName
             }
+        }
+    }
+
+    @Nested inner class
+    `obtain a type name of` {
+
+        @Test
+        fun message() {
+            val msg = Empty.getDescriptor()
+            msg.toType().name shouldBe msg.fullName
+        }
+
+        @Test
+        fun enum() {
+            val enum = PrimitiveType.getDescriptor()
+            enum.toType().name shouldBe enum.fullName
+        }
+
+        @Test
+        fun primitive() {
+            TYPE_BOOL.toType().name shouldBe "boolean"
+            TYPE_DOUBLE.toType().name shouldBe "double"
+            TYPE_SFIXED64.toType().name shouldBe "sfixed64"
         }
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/value/OptionsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/value/OptionsSpec.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.value
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.spine.base.fieldPath
+import io.spine.option.MaxOption
+import io.spine.option.MinOption
+import io.spine.protodata.ast.find
+import io.spine.protodata.given.value.DiceRoll
+import io.spine.protodata.given.value.KelvinTemperature
+import io.spine.protodata.given.value.NumberGenerated
+import io.spine.protodata.given.value.Range
+import io.spine.protodata.protobuf.toField
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Extensions for option types should")
+internal class OptionsSpec {
+
+    @Test
+    fun `parse integer values`() {
+        val field = DiceRoll.getDescriptor().fields[0].toField()
+        val minOption = field.optionList.find<MinOption>()
+        val maxOption = field.optionList.find<MaxOption>()
+
+        minOption shouldNotBe null
+        maxOption shouldNotBe null
+
+        minOption!!.parse(field) shouldBe value {
+            intValue = 1
+        }
+        maxOption!!.parse(field) shouldBe value {
+            intValue = 6
+        }
+    }
+
+    @Test
+    fun `parse floating point values`() {
+        val field = KelvinTemperature.getDescriptor().fields[0].toField()
+        val option = field.optionList.find<MinOption>()
+
+        option shouldNotBe null
+        option!!.parse(field) shouldBe value {
+            doubleValue = 0.0
+        }
+    }
+
+    @Test
+    fun `parse reference in the same type`() {
+        val field = Range.getDescriptor().fields[0].toField()
+        val option = field.optionList.find<MaxOption>()
+
+        option shouldNotBe null
+        option!!.parse(field) shouldBe value {
+            reference = reference {
+                type = field.type
+                target = fieldPath {
+                    fieldName.add("max_value")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `parse references to nested fields`() {
+        val field = NumberGenerated.getDescriptor().fields[0].toField()
+        val minOption = field.optionList.find<MinOption>()
+        val maxOption = field.optionList.find<MaxOption>()
+
+        minOption shouldNotBe null
+        maxOption shouldNotBe null
+
+        minOption!!.parse(field) shouldBe value {
+            reference = reference {
+                type = field.type
+                target = fieldPath {
+                    fieldName.add("range")
+                    fieldName.add("min_value")
+                }
+            }
+        }
+
+        maxOption!!.parse(field) shouldBe value {
+            reference = reference {
+                type = field.type
+                target = fieldPath {
+                    fieldName.add("range")
+                    fieldName.add("max_value")
+                }
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/io/spine/protodata/value/OptionsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/value/OptionsSpec.kt
@@ -28,6 +28,7 @@ package io.spine.protodata.value
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.spine.base.fieldPath
 import io.spine.option.MaxOption
 import io.spine.option.MinOption
@@ -137,6 +138,7 @@ internal class OptionsSpec {
         fun `of top level fields`() {
             val field = Misreferences.getDescriptor().fields[0].toField()
             val option = field.optionList.find<MinOption>()
+            field.name.value shouldBe "wrong_direct"
 
             assertThrows<IllegalStateException> {
                 option!!.parse(field, typeSystem)
@@ -147,10 +149,30 @@ internal class OptionsSpec {
         fun `of top nested fields`() {
             val field = Misreferences.getDescriptor().fields[1].toField()
             val option = field.optionList.find<MaxOption>()
+            field.name.value shouldBe "wrong_indirect"
 
             assertThrows<IllegalStateException> {
                 option!!.parse(field, typeSystem)
             }
+        }
+    }
+
+    @Test
+    fun `require same field type for reference`() {
+        val field = Misreferences.getDescriptor().fields[2].toField()
+        field.name.value shouldBe "wrong_type"
+
+        val option = field.optionList.find<MaxOption>()
+
+        val e = assertThrows<IllegalStateException> {
+            option!!.parse(field, typeSystem)
+        }
+        e.message.let {
+            it shouldContain "(max).value"
+            it shouldContain field.name.value
+            it shouldContain "range.max_value"
+            it shouldContain "int64"
+            it shouldContain "int32"
         }
     }
 }

--- a/api/src/test/proto/protodata/given/deeply_nested.proto
+++ b/api/src/test/proto/protodata/given/deeply_nested.proto
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package spine.protodata.given;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.given.type";
+option java_outer_classname = "DeeplyNestedProto";
+option java_multiple_files = true;
+
+message Outer {
+    message Inner {
+        message YetInner {
+        }
+    }
+}

--- a/api/src/test/proto/protodata/given/field_options.proto
+++ b/api/src/test/proto/protodata/given/field_options.proto
@@ -72,6 +72,19 @@ message NumberGenerated {
 // Types with negative cases
 //
 
+// The cases of wrong field references.
+message Misreferences {
+
+    // Here the option references the field which is not declared in this message type.
+    int32 wrongDirect = 1 [(min).value = "missing"];
+
+    // Here the option references the missing nested field.
+    int32 wrongIndirect = 2 [(max).value = "range.top"];
+
+    // The field for checking nested paths.
+    Range range = 10 [(required) = true];
+}
+
 // See https://protobuf.dev/programming-guides/proto3/#scalar
 message IntBucket {
     int32 int32_value = 1;

--- a/api/src/test/proto/protodata/given/field_options.proto
+++ b/api/src/test/proto/protodata/given/field_options.proto
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package spine.protodata.given;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.given.value";
+option java_outer_classname = "FieldOptionsProto";
+option java_multiple_files = true;
+
+// The message with integer option values.
+message DiceRoll {
+    int32 result = 1 [(min).value = "1", (max).value = "6"];
+}
+
+// The message type which uses `(min)` option with the floating point value.
+message KelvinTemperature {
+     double value = 1 [(min) = {
+         value: "0.0",
+         exclusive: true,
+         error_msg: "Temperature cannot reach {other}K, but provided {value}."
+     }];
+ }
+
+// A range of integer values.
+//
+// The range is empty if `min_value == max_value`.
+// The option here references the field in the same type.
+//
+message Range {
+    int32 min_value = 1 [(max).value = "max_value"];
+    int32 max_value = 2;
+}
+
+// A [number] was generated within the requested [range].
+//
+// The options here reference nested fields.
+//
+message NumberGenerated {
+    int32 number = 1 [(min).value = "range.min_value", (max).value = "range.max_value"];
+    Range range = 2 [(required) = true];
+}
+

--- a/api/src/test/proto/protodata/given/field_options.proto
+++ b/api/src/test/proto/protodata/given/field_options.proto
@@ -76,29 +76,15 @@ message NumberGenerated {
 message Misreferences {
 
     // Here the option references the field which is not declared in this message type.
-    int32 wrongDirect = 1 [(min).value = "missing"];
+    int32 wrong_direct = 1 [(min).value = "missing"];
 
     // Here the option references the missing nested field.
-    int32 wrongIndirect = 2 [(max).value = "range.top"];
+    int32 wrong_indirect = 2 [(max).value = "range.top"];
+
+    // Even though the type of this field is wider than that of the referenced,
+    // this field should generate the error because we require same types.
+    int64 wrong_type = 3 [(max).value = "range.max_value"];
 
     // The field for checking nested paths.
     Range range = 10 [(required) = true];
-}
-
-// See https://protobuf.dev/programming-guides/proto3/#scalar
-message IntBucket {
-    int32 int32_value = 1;
-    int64 int64_value = 2;
-
-    uint32 uint32_value = 3;
-    uint64 uint64_value = 4;
-
-    sint32 sing32_value = 5;
-    sint64 sint64_value = 6;
-
-    fixed32 fixed32_value = 7;
-    fixed64 fixed64_value = 8;
-
-    sfixed32 sfixed32_value = 9;
-    sfixed64 sfixed64_value = 10;
 }

--- a/api/src/test/proto/protodata/given/field_options.proto
+++ b/api/src/test/proto/protodata/given/field_options.proto
@@ -68,3 +68,24 @@ message NumberGenerated {
     Range range = 2 [(required) = true];
 }
 
+//
+// Types with negative cases
+//
+
+// See https://protobuf.dev/programming-guides/proto3/#scalar
+message IntBucket {
+    int32 int32_value = 1;
+    int64 int64_value = 2;
+
+    uint32 uint32_value = 3;
+    uint64 uint64_value = 4;
+
+    sint32 sing32_value = 5;
+    sint64 sint64_value = 6;
+
+    fixed32 fixed32_value = 7;
+    fixed64 fixed64_value = 8;
+
+    sfixed32 sfixed32_value = 9;
+    sfixed64 sfixed64_value = 10;
+}

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -174,9 +174,11 @@ internal class MessageCompilerEvents(
      * Yields compiler events for the given field.
      *
      * Opens with an [FieldEntered] event.
-     * Then go the events regarding the field options.
+     * Then events regarding the field options are emitted.
      * At last, closes with an [FieldExited] event.
      */
+    @Suppress("DEPRECATION") /* Populate deprecated fields in `FieldOptionDiscovered`
+        for backward compatibility. */
     private suspend fun SequenceScope<EventMessage>.produceFieldEvents(
         desc: FieldDescriptor
     ) {
@@ -196,6 +198,7 @@ internal class MessageCompilerEvents(
                 file = path
                 type = typeName
                 field = fieldName
+                subject = theField
                 option = it
             }
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -39,10 +39,10 @@ object McJava {
     const val group = Spine.toolsGroup
 
     /** The version used to in the build classpath. */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.242"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.244"
 
     /** The version to be used for integration tests. */
-    const val version = "2.0.0-SNAPSHOT.243"
+    const val version = "2.0.0-SNAPSHOT.244"
 
     const val pluginId = "io.spine.mc-java"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.6"
+    private const val fallbackVersion = "0.61.7"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.6"
+    private const val fallbackDfVersion = "0.61.7"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.4"
+    private const val fallbackVersion = "0.61.6"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.4"
+    private const val fallbackDfVersion = "0.61.6"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,8 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.213"
-        const val baseForBuildScript = "2.0.0-SNAPSHOT.213"
+        const val base = "2.0.0-SNAPSHOT.214"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.214"
 
         /**
          * The version of [Spine.reflect].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,8 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.212"
-        const val baseForBuildScript = "2.0.0-SNAPSHOT.212"
+        const val base = "2.0.0-SNAPSHOT.213"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.213"
 
         /**
          * The version of [Spine.reflect].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,8 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.214"
-        const val baseForBuildScript = "2.0.0-SNAPSHOT.214"
+        const val base = "2.0.0-SNAPSHOT.215"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.215"
 
         /**
          * The version of [Spine.reflect].

--- a/cli/src/test/kotlin/io/spine/protodata/cli/given/CustomFieldView.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/given/CustomFieldView.kt
@@ -44,7 +44,7 @@ class CustomFieldView : View<FieldName, CustomField, CustomField.Builder>() {
     internal fun on(@External @Where(field = "option.name", equals = "custom")
                         event: FieldOptionDiscovered
     ) = alter {
-        field = event.field
+        field = event.subject.name
     }
 
     class Repository : ViewRepository<FieldName, CustomFieldView, CustomField>() {
@@ -52,7 +52,7 @@ class CustomFieldView : View<FieldName, CustomField, CustomField.Builder>() {
         override fun setupEventRouting(routing: EventRouting<FieldName>) {
             super.setupEventRouting(routing)
             routing.route(FieldOptionDiscovered::class.java) { event, _ ->
-                withId(event.field)
+                withId(event.subject.name)
             }
         }
     }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/given/DefaultOptionsCounterView.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/given/DefaultOptionsCounterView.kt
@@ -78,7 +78,7 @@ class DefaultOptionsCounterView
         override fun setupEventRouting(routing: EventRouting<TypeName>) {
             super.setupEventRouting(routing)
             routing.route(FieldOptionDiscovered::class.java) { event, _ ->
-                EventRoute.withId(event.subject.type.typeName)
+                EventRoute.withId(event.subject.declaringType)
             }
         }
     }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/given/DefaultOptionsCounterView.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/given/DefaultOptionsCounterView.kt
@@ -32,6 +32,7 @@ import io.spine.core.Where
 import io.spine.protobuf.AnyPacker
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.event.FieldOptionDiscovered
+import io.spine.protodata.ast.typeName
 import io.spine.protodata.cli.test.DefaultOptionsCounter
 import io.spine.protodata.plugin.View
 import io.spine.protodata.plugin.ViewRepository
@@ -65,7 +66,7 @@ class DefaultOptionsCounterView
         event: FieldOptionDiscovered
     ) = alter {
         requiredFieldForTestEncountered = requiredFieldForTestEncountered ||
-                event.field.value.equals("required_field_for_test")
+                event.subject.name.value.equals("required_field_for_test")
     }
 
     private fun readTimeOption(event: FieldOptionDiscovered): TimeOption =
@@ -77,7 +78,7 @@ class DefaultOptionsCounterView
         override fun setupEventRouting(routing: EventRouting<TypeName>) {
             super.setupEventRouting(routing)
             routing.route(FieldOptionDiscovered::class.java) { event, _ ->
-                EventRoute.withId(event.type)
+                EventRoute.withId(event.subject.type.typeName)
             }
         }
     }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Tue Oct 15 19:49:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:49:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-api:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:25 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.8`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Tue Oct 15 10:57:25 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:29 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-backend:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Tue Oct 15 10:57:29 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:30 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-cli:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Tue Oct 15 10:57:30 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:32 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Tue Oct 15 10:57:32 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:33 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Tue Oct 15 10:57:33 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:34 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Tue Oct 15 10:57:34 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:50 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-java:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Tue Oct 15 10:57:50 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:53 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.61.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Tue Oct 15 10:57:53 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:54 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10099,12 +10099,12 @@ This report was generated on **Tue Oct 15 10:57:54 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:55 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.61.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11213,4 +11213,4 @@ This report was generated on **Tue Oct 15 10:57:55 CEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 10:57:58 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 19:49:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Tue Oct 15 19:58:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Tue Oct 15 19:58:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Tue Oct 15 19:58:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 19:58:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 20:43:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Wed Oct 16 17:54:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-api:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.7`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Thu Oct 10 15:41:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-backend:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-cli:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-java:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.61.7`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10099,12 +10099,12 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.61.6`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.61.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11213,4 +11213,4 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 19:57:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Wed Oct 16 17:05:27 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Wed Oct 16 17:05:28 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Wed Oct 16 17:05:29 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 17:05:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:54:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Thu Oct 10 19:57:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Thu Oct 10 19:57:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Thu Oct 10 19:57:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Thu Oct 10 19:57:43 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 19:57:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 14 19:02:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
@@ -113,12 +113,9 @@ public class Literal(value: Any) : Expression(value.toString())
 /**
  * Constructs a call to a static method of this class.
  *
- * @param name
- *         the name of the method.
- * @param arguments
- *         the method arguments.
- * @param generics
- *         the method type parameters.
+ * @param name The name of the method.
+ * @param arguments The method arguments.
+ * @param generics The method type parameters.
  */
 @JvmOverloads
 public fun ClassOrEnumName.call(
@@ -176,7 +173,7 @@ public class MessageReference(label: String) : Expression(label) {
 /**
  * A selector for an access method for a Protobuf message field.
  *
- * Depending on the field type, may allow to generate getters and setters for the field.
+ * Depending on the field type, may allow generating getters and setters for the field.
  */
 public class FieldAccess
 internal constructor(
@@ -186,7 +183,7 @@ internal constructor(
 ) : FieldConventions(name, cardinality) {
 
     /**
-     * Constructs a field access for the given [message] and [name].
+     * Constructs field access for the given [message] and [name].
      */
     internal constructor(
         message: Expression,
@@ -261,15 +258,11 @@ public class MethodCall
 /**
  * Creates a new `MethodCall`.
  *
- * @param scope
- *         the scope of the method invocation: an instance receiving the method call, or
- *         the name of the class declaring a static method.
- * @param name
- *         the name of the method.
- * @param arguments
- *         the list of the arguments passed to the method.
- * @param generics
- *         the list of the type arguments passed to the method.
+ * @param scope The scope of the method invocation: an instance receiving the method call, or
+ *   the name of the class declaring a static method.
+ * @param name The name of the method.
+ * @param arguments The list of the arguments passed to the method.
+ * @param generics The list of the type arguments passed to the method.
  */
 @JvmOverloads constructor(
     scope: JavaElement,
@@ -283,13 +276,10 @@ public class MethodCall
     /**
      * Creates a new, non-generified, method call with the given [arguments].
      *
-     * @param scope
-     *         the scope of the method invocation: an instance receiving the method call, or
-     *         the name of the class declaring a static method.
-     * @param name
-     *         the name of the method.
-     * @param arguments
-     *         the list of the arguments passed to the method.
+     * @param scope The scope of the method invocation: an instance receiving the method call, or
+     *   the name of the class declaring a static method.
+     * @param name The name of the method.
+     * @param arguments The list of the arguments passed to the method.
      */
     public constructor(
         scope: JavaElement,
@@ -356,14 +346,11 @@ public fun listExpression(vararg expressions: Expression): MethodCall =
  *
  * The resulting expression always yields an instance of Guava `ImmutableMap`.
  *
- * @param expressions
- *         the expressions representing the entries.
- * @param keyType
- *         the type of the keys of the map;
- *         must be non-`null` if the map is not empty, may be `null` otherwise.
- * @param valueType
- *         the type of the values of the map;
- *         must be non-`null` if the map is not empty, may be `null` otherwise.
+ * @param expressions The expressions representing the entries.
+ * @param keyType The type of the keys of the map;
+ *   must be non-`null` if the map is not empty, may be `null` otherwise.
+ * @param valueType The type of the values of the map;
+ *   must be non-`null` if the map is not empty, may be `null` otherwise.
  */
 public fun mapExpression(
     expressions: Map<Expression, Expression>,

--- a/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
@@ -128,7 +128,8 @@ public fun ClassOrEnumName.call(
 /**
  * Constructs an expression which creates a new builder for this class.
  *
- * Example: `ClassName("com.acme.Bird").newBuilder()` yields "`com.acme.Bird.newBuilder()`".
+ * Example: `ClassName("com.acme.Bird").newBuilder()` yields
+ * `"com.acme.Bird.newBuilder()"`.
  */
 public fun ClassName.newBuilder(): MethodCall =
     call("newBuilder")
@@ -137,17 +138,17 @@ public fun ClassName.newBuilder(): MethodCall =
  * Constructs an expression which obtains the default instance for this class.
  *
  * Example: `ClassName("com.acme.Bird").getDefaultInstance()` yields
- * "`com.acme.Bird.getDefaultInstance()`".
+ * `"com.acme.Bird.getDefaultInstance()"`.
  */
 public fun ClassName.getDefaultInstance(): MethodCall =
     call("getDefaultInstance")
 
 /**
- * Constructs an expression which obtains the Protobuf enum value by the given number from this
- * class.
+ * Constructs an expression which obtains the Protobuf enum value by
+ * the given number from this class.
  *
  * Example: `ClassName("com.acme.Bird").enumValue(1)` yields
- * "`com.acme.Bird.forNumber(1)`".
+ * `"com.acme.Bird.forNumber(1)"`.
  */
 public fun EnumName.enumValue(number: Int): MethodCall =
     call("forNumber", listOf(Literal(number)))
@@ -291,28 +292,28 @@ public class MethodCall
      * Constructs an expression of calling another method on the result of this method call.
      */
     @JvmOverloads
-    public fun chain(name: String, arguments: List<Expression> = listOf()): MethodCall =
-        MethodCall(this, name, arguments)
+    public fun chain(method: String, arguments: List<Expression> = listOf()): MethodCall =
+        MethodCall(this, method, arguments)
 
     /**
      * Constructs an expression chaining a setter call.
      */
-    public fun chainSet(name: String, value: Expression): MethodCall =
-        fieldAccess(name).setter(value)
+    public fun chainSet(field: String, value: Expression): MethodCall =
+        fieldAccess(field).setter(value)
 
     /**
      * Constructs an expression chaining a call of an `addField(...)` method.
      */
-    public fun chainAdd(name: String, value: Expression): MethodCall =
-        fieldAccess(name).add(value)
+    public fun chainAdd(field: String, value: Expression): MethodCall =
+        fieldAccess(field).add(value)
 
     /**
      * Constructs an expression chaining a call of an `addAllField(...)` method.
      */
-    public fun chainAddAll(name: String, value: Expression): MethodCall =
-        fieldAccess(name).addAll(value)
+    public fun chainAddAll(field: String, value: Expression): MethodCall =
+        fieldAccess(field).addAll(value)
 
-    private fun fieldAccess(name: String) = FieldAccess(this, name)
+    private fun fieldAccess(fieldName: String) = FieldAccess(this, fieldName)
 
     /**
      * Constructs an expression chaining a call of the `build()` method.
@@ -347,9 +348,9 @@ public fun listExpression(vararg expressions: Expression): MethodCall =
  * The resulting expression always yields an instance of Guava `ImmutableMap`.
  *
  * @param expressions The expressions representing the entries.
- * @param keyType The type of the keys of the map;
+ * @param keyType The type of the keys in the map;
  *   must be non-`null` if the map is not empty, may be `null` otherwise.
- * @param valueType The type of the values of the map;
+ * @param valueType The type of the values in the map;
  *   must be non-`null` if the map is not empty, may be `null` otherwise.
  */
 public fun mapExpression(

--- a/java/src/main/kotlin/io/spine/protodata/java/MessageTypeExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MessageTypeExts.kt
@@ -62,3 +62,18 @@ public fun MessageType.javaClassName(typeSystem: TypeSystem): ClassName {
     val className = javaClassName(header)
     return className
 }
+
+/**
+ * Returns the [Class] instance for this [MessageType], if any.
+ *
+ * The function returns a non-`null` result if a class denoted by this [ClassName]
+ * is present on the classpath.
+ */
+public fun MessageType.javaClass(accordingTo: ProtoFileHeader): Class<*>? {
+    val name = name.javaClassName(accordingTo)
+    return try {
+        Class.forName(name.canonical)
+    } catch (ignored: ClassNotFoundException) {
+        null
+    }
+}

--- a/java/src/test/kotlin/io/spine/protodata/java/MessageTypeExtsSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/MessageTypeExtsSpec.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.java
+
+import com.google.protobuf.Empty
+import io.kotest.matchers.shouldBe
+import io.spine.protodata.ast.file
+import io.spine.protodata.ast.findMessage
+import io.spine.protodata.ast.messageType
+import io.spine.protodata.ast.protoFileHeader
+import io.spine.protodata.ast.typeName
+import io.spine.protodata.java.file.javaOuterClassName
+import io.spine.protodata.java.file.javaPackage
+import io.spine.protodata.protobuf.toPbSourceFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MessageType` extensions for Java should")
+internal class MessageTypeExtsSpec {
+
+    @Nested inner class
+    `find its class` {
+
+        @Test
+        fun `if its present`() {
+            val protoFile = Empty.getDescriptor().file.toPbSourceFile()
+            val messageType = protoFile.findMessage("Empty")!!
+
+            messageType.javaClass(protoFile.header) shouldBe Empty::class.java
+        }
+
+        @Test
+        fun `return 'null' if not present`() {
+            val fileName = file {
+                path = "given/types/synthetic.proto"
+            }
+            val type = messageType {
+                name = typeName {
+                    packageName = "given.types"
+                    simpleName = "Synthetic"
+                }
+                file = fileName
+            }
+            val header = protoFileHeader {
+                file = fileName
+                option.apply {
+                    add(javaPackage("org.example.given.types"))
+                    add(javaOuterClassName("SyntheticProto"))
+                }
+            }
+
+            type.javaClass(header) shouldBe null
+        }
+    }
+}

--- a/java/src/test/kotlin/io/spine/protodata/java/MessageTypeExtsSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/MessageTypeExtsSpec.kt
@@ -37,44 +37,39 @@ import io.spine.protodata.java.file.javaOuterClassName
 import io.spine.protodata.java.file.javaPackage
 import io.spine.protodata.protobuf.toPbSourceFile
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`MessageType` extensions for Java should")
 internal class MessageTypeExtsSpec {
 
-    @Nested inner class
-    `find its class` {
+    @Test
+    fun `find its class, if it is present`() {
+        val protoFile = Empty.getDescriptor().file.toPbSourceFile()
+        val messageType = protoFile.findMessage("Empty")!!
 
-        @Test
-        fun `if its present`() {
-            val protoFile = Empty.getDescriptor().file.toPbSourceFile()
-            val messageType = protoFile.findMessage("Empty")!!
+        messageType.javaClass(protoFile.header) shouldBe Empty::class.java
+    }
 
-            messageType.javaClass(protoFile.header) shouldBe Empty::class.java
+    @Test
+    fun `return 'null', if the class is not available`() {
+        val fileName = file {
+            path = "given/types/synthetic.proto"
+        }
+        val type = messageType {
+            name = typeName {
+                packageName = "given.types"
+                simpleName = "Synthetic"
+            }
+            file = fileName
+        }
+        val header = protoFileHeader {
+            file = fileName
+            option.apply {
+                add(javaPackage("org.example.given.types"))
+                add(javaOuterClassName("SyntheticProto"))
+            }
         }
 
-        @Test
-        fun `return 'null' if not present`() {
-            val fileName = file {
-                path = "given/types/synthetic.proto"
-            }
-            val type = messageType {
-                name = typeName {
-                    packageName = "given.types"
-                    simpleName = "Synthetic"
-                }
-                file = fileName
-            }
-            val header = protoFileHeader {
-                file = fileName
-                option.apply {
-                    add(javaPackage("org.example.given.types"))
-                    add(javaOuterClassName("SyntheticProto"))
-                }
-            }
-
-            type.javaClass(header) shouldBe null
-        }
+        type.javaClass(header) shouldBe null
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.214</version>
+    <version>2.0.0-SNAPSHOT.215</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.61.6</version>
+<version>0.61.7</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.160</version>
+    <version>2.0.0-SNAPSHOT.161</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -261,12 +261,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -276,13 +276,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.242</version>
+    <version>2.0.0-SNAPSHOT.244</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.242</version>
+    <version>2.0.0-SNAPSHOT.244</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -297,7 +297,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.160</version>
+    <version>2.0.0-SNAPSHOT.161</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.61.7</version>
+<version>0.61.8</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.214</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.6")
+val protoDataVersion: String by extra("0.61.7")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.7")
+val protoDataVersion: String by extra("0.61.8")


### PR DESCRIPTION
This PR extends `Value` type with the ability to carry a reference to a value in another field. 

One of the usage scenarios for such a feature is validation options using references to another field. For example, consider the following proto type `Range` in which the `min_value` can have a value not bigger than `max_value`.
```proto
message Range {
    int32 min_value = 1 [(max).value = "max_value"];
    int32 max_value = 2;
}
```
A reference could made to a nested field using dot-separated fields names in the path.

## Changes to `Value` and related code
 * The type `Reference` was introduced.
 * The type `Value` got the new field `reference`.
 * `MinOption` and `MaxOption` got extensions `parse()` for obtaining corresponding instances of `Value`.

## Other notable changes
 * The event `FieldOptionDiscovered` got a new field called `subject` with type `Field`. The new field is aimed to replace now deprecated fields `type` and `field`.
 * The creation of a singular value via `FieldDescriptor` made stricter, failing with `IllegalStateException` when unsupported `JavaType` enum item is encountered. This is an unlikely case, but it's still better to throw rather than silently return `NULL`.
 * `ProtobufSourceFile` type got extension for finding a message type by its simple name and possible enclosing type names.
* `TypeSystem` got an extension `resolve()` which allows to obtain a `Field` instance for a field of a message type specified by `FieldPath`.