### PR TITLE
Override `context` and `typeSystem` properties for `RenderAction`

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -73,7 +73,7 @@ protected constructor(
      *
      * @see registerWith
      */
-    protected val context: CodegenContext?
+    protected open val context: CodegenContext?
         get() = if (this::_context.isInitialized) {
             _context
         } else {
@@ -87,7 +87,7 @@ protected constructor(
      *
      * This property is guaranteed to be non-`null` after [registerWith].
      */
-    protected val typeSystem: TypeSystem?
+    protected open val typeSystem: TypeSystem?
         get() = context?.typeSystem
 
     /**

--- a/api/src/main/kotlin/io/spine/protodata/render/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/render/RenderAction.kt
@@ -64,7 +64,7 @@ public abstract class RenderAction<L : Language, D : ProtoDeclaration, P : Messa
     protected val subject: D,
     protected val file: SourceFile<L>,
     protected val parameter: P,
-    final override val context: CodegenContext
+    protected final override val context: CodegenContext
 ) : Member<L>(language) {
 
     init {
@@ -74,7 +74,7 @@ public abstract class RenderAction<L : Language, D : ProtoDeclaration, P : Messa
     /**
      * A type system with the Protobuf types defined in the current code generation pipeline.
      */
-    final override val typeSystem: TypeSystem = context.typeSystem
+    protected final override val typeSystem: TypeSystem by lazy { context.typeSystem }
 
     /**
      * Renders the code in the given source file.

--- a/api/src/main/kotlin/io/spine/protodata/render/RenderAction.kt
+++ b/api/src/main/kotlin/io/spine/protodata/render/RenderAction.kt
@@ -34,6 +34,7 @@ import io.spine.protodata.ast.Service
 import io.spine.protodata.ast.TypeDeclaration
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.context.Member
+import io.spine.protodata.type.TypeSystem
 import io.spine.tools.code.Language
 
 /**
@@ -54,7 +55,7 @@ import io.spine.tools.code.Language
  * @property subject The Protobuf declaration served by this action.
  * @property file The source code file to be modified by this action.
  * @property parameter The parameter passed to the action.
- * @param context The code generation context in which this action operates.
+ * @property context The code generation context in which this action operates.
  *
  * @see Renderer
  */
@@ -63,12 +64,17 @@ public abstract class RenderAction<L : Language, D : ProtoDeclaration, P : Messa
     protected val subject: D,
     protected val file: SourceFile<L>,
     protected val parameter: P,
-    context: CodegenContext
+    final override val context: CodegenContext
 ) : Member<L>(language) {
 
     init {
         registerWith(context)
     }
+
+    /**
+     * A type system with the Protobuf types defined in the current code generation pipeline.
+     */
+    final override val typeSystem: TypeSystem = context.typeSystem
 
     /**
      * Renders the code in the given source file.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:25 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Thu Oct 10 15:41:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:29 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:30 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Thu Oct 10 15:41:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:32 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:33 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:34 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Thu Oct 10 15:41:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:50 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:53 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:54 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:55 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Thu Oct 10 15:41:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 15:41:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 10:57:58 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ClassName.kt
@@ -150,3 +150,16 @@ public class ClassName(
         }
     }
 }
+
+/**
+ * Returns the [Class] instance for this [ClassName], if any.
+ *
+ * The function returns a non-`null` result if a Java class denoted by this
+ * [ClassName] is present on the classpath.
+ */
+public fun ClassName.javaClass(): Class<*>? =
+    try {
+        Class.forName(canonical)
+    } catch (ignored: ClassNotFoundException) {
+        null
+    }

--- a/java/src/main/kotlin/io/spine/protodata/java/MessageTypeExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MessageTypeExts.kt
@@ -62,3 +62,31 @@ public fun MessageType.javaClassName(typeSystem: TypeSystem): ClassName {
     val className = javaClassName(header)
     return className
 }
+
+/**
+ * Obtains the [Class] instance for this [MessageType], if any.
+ *
+ * The function returns a non-`null` result if a Java class denoted by this
+ * [MessageType] is present on the classpath.
+ *
+ * @param accordingTo The proto file header, according to which the Java class
+ *  name is determined.
+ */
+public fun MessageType.javaClass(accordingTo: ProtoFileHeader): Class<*>? {
+    val name = javaClassName(accordingTo)
+    return name.javaClass()
+}
+
+/**
+ * Obtains the [Class] instance for this [MessageType], if any.
+ *
+ * The function returns a non-`null` result if a class denoted by this
+ * [MessageType] is present on the classpath.
+ *
+ * @param typeSystem The type system to be used for obtaining the header for the proto
+ *  file in which this message type is declared.
+ */
+public fun MessageType.javaClass(typeSystem: TypeSystem): Class<*>? {
+    val name = javaClassName(typeSystem)
+    return name.javaClass()
+}

--- a/java/src/main/kotlin/io/spine/protodata/java/render/MessageAction.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/render/MessageAction.kt
@@ -67,7 +67,7 @@ public abstract class MessageAction<P : Message>(
      * The name of the message class for which this action runs.
      */
     protected val messageClass: ClassName by lazy {
-        type.javaClassName(typeSystem!!)
+        type.javaClassName(typeSystem)
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -127,12 +127,6 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.177</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
     <version>2.0.0-SNAPSHOT.226</version>
     <scope>compile</scope>
@@ -189,6 +183,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.226</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-testutil-server</artifactId>
+    <version>2.0.0-SNAPSHOT.177</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.6")
+val protoDataVersion: String by extra("0.61.7")


### PR DESCRIPTION
This PR makes `context` and `typeSystem` properties non-nullable for `RenderAction` and its inheritors. The action registers within the context during the initialization, making the mentioned properties available.

Also, it moves `MessageType.javaClass()` extension, which emerged in `mc-java`.