### PR TITLE
Make `Policy` access `TypeSystem`

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -196,7 +196,7 @@ public fun Member<*>.findEnumTypes(): Set<EnumInFile> =
  * Services that are dependencies of the compilation process are not included.
  *
  * @see ProtobufSourceFile
- * @see ProtobufDependency
+ * @see io.spine.protodata.ast.ProtobufDependency
  */
 public fun Member<*>.findServices(): Set<ServiceInFile> =
     findAllFiles()

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -30,6 +30,7 @@ import io.spine.annotation.Internal
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.render.Renderer
 import io.spine.protodata.render.SourceFileSet
+import io.spine.protodata.type.TypeSystem
 import io.spine.server.BoundedContextBuilder
 import io.spine.server.entity.Entity
 import kotlin.reflect.KClass
@@ -92,8 +93,7 @@ public interface Plugin {
      * [reacts][io.spine.server.event.React] on `FileEntered` and `FileExited` events
      * to perform actions on the whole content of a proto file.
      *
-     * @param context
-     *         the `BoundedContextBuilder` to extend.
+     * @param context The `BoundedContextBuilder` to extend.
      */
     public fun extend(context: BoundedContextBuilder) {}
 }
@@ -123,6 +123,21 @@ public fun Plugin.applyTo(context: BoundedContextBuilder) {
         context.addEventDispatcher(it)
     }
     extend(context)
+}
+
+/**
+ * The callback which allows the plugin to propagate the given [TypeSystem] instance
+ * to its parts.
+ *
+ * This method is internal and called by [io.spine.protodata.backend.Pipeline.invoke] before
+ * [CodeGeneratorRequest][com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest] is
+ * parsed for emitting events.
+ */
+@Internal
+public fun Plugin.use(typeSystem: TypeSystem) {
+    policies().forEach {
+        it.use(typeSystem)
+    }
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Plugin.kt
@@ -113,7 +113,7 @@ public interface Plugin {
  * calls [Plugin.extend] method to allow the plugin to add additional components to the context.
  */
 @Internal
-public fun Plugin.applyTo(context: BoundedContextBuilder) {
+public fun Plugin.applyTo(context: BoundedContextBuilder, typeSystem: TypeSystem) {
     val repos = viewRepositories().toMutableList()
     val defaultRepos = views().map { ViewRepository.default(it) }
     repos.addAll(defaultRepos)
@@ -121,23 +121,9 @@ public fun Plugin.applyTo(context: BoundedContextBuilder) {
     repos.forEach(context::add)
     policies().forEach {
         context.addEventDispatcher(it)
-    }
-    extend(context)
-}
-
-/**
- * The callback which allows the plugin to propagate the given [TypeSystem] instance
- * to its parts.
- *
- * This method is internal and called by [io.spine.protodata.backend.Pipeline.invoke] before
- * [CodeGeneratorRequest][com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest] is
- * parsed for emitting events.
- */
-@Internal
-public fun Plugin.use(typeSystem: TypeSystem) {
-    policies().forEach {
         it.use(typeSystem)
     }
+    extend(context)
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.plugin
 import io.spine.base.EntityState
 import io.spine.base.EventMessage
 import io.spine.protodata.settings.LoadsSettings
+import io.spine.protodata.type.TypeSystem
 import io.spine.server.event.Policy
 import io.spine.server.query.QueryingClient
 
@@ -82,6 +83,31 @@ import io.spine.server.query.QueryingClient
  * information in the code generation domain. Thus, we directly convert between events.
  */
 public abstract class Policy<E : EventMessage> : Policy<E>(), LoadsSettings {
+
+    /**
+     * The backing field for the [typeSystem] property.
+     */
+    private lateinit var _typeSystem: TypeSystem
+
+    /**
+     * The type system for resolving type information for generating events.
+     *
+     * The property is available after [Plugin.use] is called.
+     * Accessing the property before it will result in a run-time error.
+     */
+    protected open val typeSystem: TypeSystem?
+        get() = if (this::_typeSystem.isInitialized) {
+            _typeSystem
+        } else {
+            null
+        }
+
+    /**
+     * Assigns the type system to the policy.
+     */
+    internal fun use(typeSystem: TypeSystem) {
+        _typeSystem = typeSystem
+    }
 
     final override fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> {
         return QueryingClient(context, type, javaClass.name)

--- a/api/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/Policy.kt
@@ -92,8 +92,8 @@ public abstract class Policy<E : EventMessage> : Policy<E>(), LoadsSettings {
     /**
      * The type system for resolving type information for generating events.
      *
-     * The property is available after [Plugin.use] is called.
-     * Accessing the property before it will result in a run-time error.
+     * A non-null value is available in
+     * a [rendering pipeline][io.spine.protodata.backend.Pipeline.invoke].
      */
     protected open val typeSystem: TypeSystem?
         get() = if (this::_typeSystem.isInitialized) {

--- a/api/src/main/kotlin/io/spine/protodata/plugin/View.kt
+++ b/api/src/main/kotlin/io/spine/protodata/plugin/View.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -96,9 +96,9 @@ import kotlin.reflect.KClass
  * Views have repositories which are responsible for storing states and for delivering correct
  * events to the correct views. See [ViewRepository] for more.
  *
- * @param I the type of the view ID; can be a Protobuf message, a String, an int, or a long.
- * @param M the type of the view's state; must be a Protobuf message implementing [EntityState].
- * @param B the type of the view's state builder; must match `<M>`.
+ * @param I The type of the view ID; can be a Protobuf message, a String, an int, or a long.
+ * @param M The type of the view's state; must be a Protobuf message implementing [EntityState].
+ * @param B The type of the view's state builder; must match `<M>`.
  */
 public open class View<I : Any, M : EntityState<I>, B : ValidatingBuilder<M>> :
     Projection<I, M, B>()

--- a/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
+++ b/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
@@ -36,7 +36,6 @@ import io.spine.protodata.ast.MessageType
 import io.spine.protodata.ast.ProtoDeclaration
 import io.spine.protodata.ast.ProtoDeclarationName
 import io.spine.protodata.ast.ProtoFileHeader
-import io.spine.protodata.ast.ProtobufDependency
 import io.spine.protodata.ast.ProtobufSourceFile
 import io.spine.protodata.ast.Service
 import io.spine.protodata.ast.ServiceName
@@ -47,8 +46,6 @@ import io.spine.protodata.ast.isEnum
 import io.spine.protodata.ast.isMessage
 import io.spine.protodata.ast.qualifiedName
 import io.spine.protodata.ast.typeName
-import io.spine.server.query.Querying
-import io.spine.server.query.select
 import io.spine.type.shortDebugString
 
 /**
@@ -57,21 +54,6 @@ import io.spine.type.shortDebugString
 public class TypeSystem(
     private val files: Set<ProtobufSourceFile>
 ) {
-
-    public companion object {
-
-        /**
-         * Builds a new `TypeSystem` by finding definitions via
-         * the given [client][Querying] instance.
-         */
-        @JvmStatic
-        public fun serving(client: Querying): TypeSystem {
-            val files = client.select<ProtobufSourceFile>().all()
-            val deps = client.select<ProtobufDependency>().all().map { it.source }
-            return TypeSystem(files + deps)
-        }
-    }
-
     /**
      * Looks up a message type by its name.
      */

--- a/api/src/test/kotlin/io/spine/protodata/plugin/PolicySpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/plugin/PolicySpec.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.plugin
+
+import com.google.common.annotations.VisibleForTesting
+import io.kotest.matchers.shouldBe
+import io.spine.core.External
+import io.spine.protodata.ast.event.TypeDiscovered
+import io.spine.protodata.type.TypeSystem
+import io.spine.server.event.Just
+import io.spine.server.event.NoReaction
+import io.spine.server.event.React
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Policy` should")
+internal class PolicySpec {
+
+    @Test
+    fun `obtain 'TypeSystem' after injected`() {
+        val policy = StubPolicy()
+
+        policy.typeSystem() shouldBe null
+
+        val typeSystem = TypeSystem(emptySet())
+        policy.use(typeSystem)
+
+        policy.typeSystem() shouldBe typeSystem
+    }
+}
+
+/**
+ * A stub policy for testing access to the [typeSystem] property.
+ */
+private class StubPolicy : Policy<TypeDiscovered>() {
+
+    @React
+    override fun whenever(@External event: TypeDiscovered): Just<NoReaction> = Just.noReaction
+
+    /**
+     * Opens access to the protected [typeSystem] property.
+     */
+    @VisibleForTesting
+    fun typeSystem(): TypeSystem? = typeSystem
+}

--- a/api/src/test/kotlin/io/spine/protodata/render/RendererSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/render/RendererSpec.kt
@@ -27,13 +27,9 @@
 package io.spine.protodata.render
 
 import io.kotest.matchers.shouldBe
-import io.spine.base.EntityState
 import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.type.TypeSystem
-import io.spine.server.BoundedContext
-import io.spine.server.query.Querying
-import io.spine.server.query.QueryingClient
 import io.spine.tools.code.AnyLanguage
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -46,8 +42,7 @@ import org.junit.jupiter.api.assertThrows
 internal class RendererSpec {
 
     /**
-     * An instance of `"Code Generation"` context to be used for
-     * [creating][createTypeSystem] a [typeSystem].
+     * A stub instance of `"Code Generation"` context to be used when needed in parameters.
      *
      * We do not pass any custom entity classes or repositories to the context builder,
      * as we do not need them in tests.
@@ -90,17 +85,6 @@ internal class RendererSpec {
                 renderer.registerWith(it)
             }
         }
-    }
-
-    companion object {
-
-        /**
-         * Creates an instance of [TypeSystem] for testing.
-         */
-        fun createTypeSystem(context: BoundedContext) = TypeSystem.serving(object : Querying {
-            override fun <P : EntityState<*>> select(type: Class<P>): QueryingClient<P> =
-                QueryingClient(context, type, this::javaClass.name)
-        })
     }
 }
 

--- a/backend/src/main/kotlin/io/spine/protodata/backend/Contexts.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/Contexts.kt
@@ -58,11 +58,21 @@ public class CodeGenerationContext(
      */
     private val pipelineId: String,
 
+    override val typeSystem: TypeSystem,
+
     /**
      * An optional setup function for the context.
      */
     setup: BoundedContextBuilder.() -> Unit = { }
 ) : CodegenContext {
+
+    /**
+     * Creates a stub instance of the context with empty [TypeSystem].
+     *
+     * This is a test-only constructor for the cases when resolving of types is unnecessary.
+     */
+    @VisibleForTesting
+    public constructor(pipelineId: String) : this(pipelineId, TypeSystem(emptySet()))
 
     /**
      * The underlying instance of the `Code Generation` bounded context.
@@ -78,10 +88,6 @@ public class CodeGenerationContext(
         }
         builder.setup()
         context = builder.build()
-    }
-
-    override val typeSystem: TypeSystem by lazy {
-        TypeSystem.serving(this)
     }
 
     /**
@@ -124,8 +130,7 @@ public class CodeGenerationContext(
         @VisibleForTesting
         public fun newInstance(
             pipelineId: String = Pipeline.generateId()
-        ): CodeGenerationContext =
-            CodeGenerationContext(pipelineId)
+        ): CodeGenerationContext = CodeGenerationContext(pipelineId)
     }
 }
 

--- a/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
@@ -36,7 +36,6 @@ import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.applyTo
 import io.spine.protodata.plugin.render
-import io.spine.protodata.plugin.use
 import io.spine.protodata.protobuf.toPbSourceFile
 import io.spine.protodata.render.Renderer
 import io.spine.protodata.render.SourceFile
@@ -133,17 +132,7 @@ public class Pipeline(
         // Clear the cache of previously parsed files to avoid repeated code generation
         // when running from tests.
         SourceFile.clearCache()
-        injectTypeSystem()
         emitEventsAndRenderSources()
-    }
-
-    /**
-     * Makes the [plugins] use the [typeSystem].
-     */
-    private fun injectTypeSystem() {
-        plugins.forEach { plugin ->
-            plugin.use(typeSystem)
-        }
     }
 
     private fun emitEventsAndRenderSources() {
@@ -163,7 +152,7 @@ public class Pipeline(
     private fun assembleCodegenContext(): CodegenContext =
         CodeGenerationContext(id, typeSystem) {
             plugins.forEach {
-                it.applyTo(this)
+                it.applyTo(this, typeSystem)
             }
         }
 

--- a/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
@@ -29,21 +29,24 @@ package io.spine.protodata.backend
 import com.google.common.annotations.VisibleForTesting
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.annotation.Internal
+import io.spine.code.proto.FileSet
 import io.spine.environment.DefaultMode
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.applyTo
 import io.spine.protodata.plugin.render
+import io.spine.protodata.plugin.use
+import io.spine.protodata.protobuf.toPbSourceFile
 import io.spine.protodata.render.Renderer
 import io.spine.protodata.render.SourceFile
 import io.spine.protodata.render.SourceFileSet
 import io.spine.protodata.settings.SettingsDirectory
+import io.spine.protodata.type.TypeSystem
 import io.spine.server.delivery.Delivery
 import io.spine.server.storage.memory.InMemoryStorageFactory
 import io.spine.server.transport.memory.InMemoryTransportFactory
 import io.spine.server.under
-
 
 /**
  * A pipeline which processes the Protobuf files.
@@ -61,12 +64,12 @@ import io.spine.server.under
  *
  * Lastly, the source set is stored back onto the file system.
  *
- * @property id the ID of the pipeline to be used for distinguishing contexts when
+ * @property id The ID of the pipeline to be used for distinguishing contexts when
  *   two or more pipelines are executed in the same JVM. If not specified, the ID will be generated.
- * @property plugins the code generation plugins to be applied to the pipeline.
- * @property sources the source sets to be processed by the pipeline.
- * @property request the Protobuf compiler request.
- * @property settings the directory to which setting files for the [plugins] should be stored.
+ * @property plugins The code generation plugins to be applied to the pipeline.
+ * @property sources The source sets to be processed by the pipeline.
+ * @property request The Protobuf compiler request.
+ * @property settings The directory to which setting files for the [plugins] should be stored.
  */
 @Internal
 public class Pipeline(
@@ -76,6 +79,13 @@ public class Pipeline(
     public val request: CodeGeneratorRequest,
     public val settings: SettingsDirectory
 ) {
+
+    /**
+     * The type system passed to the plugins at the start of the pipeline.
+     */
+    private val typeSystem: TypeSystem by lazy {
+        request.toTypeSystem()
+    }
 
     /**
      * Obtains code generation context used by this pipeline.
@@ -123,7 +133,20 @@ public class Pipeline(
         // Clear the cache of previously parsed files to avoid repeated code generation
         // when running from tests.
         SourceFile.clearCache()
+        injectTypeSystem()
+        emitEventsAndRenderSources()
+    }
 
+    /**
+     * Makes the [plugins] use the [typeSystem].
+     */
+    private fun injectTypeSystem() {
+        plugins.forEach { plugin ->
+            plugin.use(typeSystem)
+        }
+    }
+
+    private fun emitEventsAndRenderSources() {
         codegenContext.use {
             ConfigurationContext(id).use { configuration ->
                 ProtobufCompilerContext(id).use { compiler ->
@@ -138,7 +161,7 @@ public class Pipeline(
      * Assembles the `Code Generation` context by applying given [plugins].
      */
     private fun assembleCodegenContext(): CodegenContext =
-        CodeGenerationContext(id) {
+        CodeGenerationContext(id, typeSystem) {
             plugins.forEach {
                 it.applyTo(this)
             }
@@ -170,4 +193,13 @@ public class Pipeline(
         @JvmStatic
         public fun generateId(): String = SecureRandomString.generate()
     }
+}
+
+/**
+ * Converts this code generation request into [TypeSystem] taking all the proto files.
+ */
+private fun CodeGeneratorRequest.toTypeSystem(): TypeSystem {
+    val fileDescriptors = FileSet.of(protoFileList).files()
+    val protoFiles = fileDescriptors.map { it.toPbSourceFile() }
+    return TypeSystem(protoFiles.toSet())
 }

--- a/backend/src/test/java/io/spine/protodata/type/TypeSystemJavaSpec.java
+++ b/backend/src/test/java/io/spine/protodata/type/TypeSystemJavaSpec.java
@@ -39,7 +39,7 @@ class TypeSystemJavaSpec {
     @DisplayName("create an instance with a static method")
     void createStatic() {
         try (var context = CodeGenerationContext.newInstance()) {
-            var ts = TypeSystem.serving(new FakeQuerying(context));
+            var ts = context.getTypeSystem();
             assertThat(ts).isNotNull();
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.7"
+    private const val fallbackVersion = "0.61.8"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.7"
+    private const val fallbackDfVersion = "0.61.8"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:14:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-api:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.62.0`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-backend:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Wed Oct 16 18:07:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-cli:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Wed Oct 16 18:07:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-java:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:34 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.62.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Wed Oct 16 18:07:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10099,12 +10099,12 @@ This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.61.8`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.62.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11213,4 +11213,4 @@ This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 18:07:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 18:48:35 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:45 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Thu Oct 17 19:14:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Thu Oct 17 19:14:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11213,4 +11213,4 @@ This report was generated on **Thu Oct 17 19:14:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 17 19:14:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 17 19:37:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.61.8</version>
+<version>0.62.0</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.internal.dependency.Spine].
  */
-val protoDataVersion: String by extra("0.61.8")
+val protoDataVersion: String by extra("0.62.0")


### PR DESCRIPTION
This PR makes it possible to pass `TypeSystem` to ProtoData plugins at the very start of a `Pipeline`. 

The primary purpose is to allow `Policy` instances to use a `TypeSystem`. But if we have other pre-rendering parts of a plugin to be in need of type resolution it would be easily addressed.

## The challenge
Using a `TypeSystem` from a `Policy` was not possible because `TypeSystem` was created as a result of querying all instances of `ProtobufSourceFile` and `ProtobufDependency` that are assembled by corresponding views in response to events produced as the incoming `CodeGeneratorRequest` is parsed. Policies act in the middle of this process.

## The solution
Now a `TypeSystem` is created at the start of a `Pipeline` as the result of transforming all the proto files from the incoming request. Then the type system is passed as the new second parameter to `Plugin.apply()` extension method. The plugin, in turn, calls `Policy.use()` for all its policies.

## Other notable changes
 * `TypeSystem.service()` factory method was removed. It is no longer needed because `TypeSystem` construction no longer needs querying.
 * `CodeGenerationContext` got a test-only constructor which creates an instance with empty `TypeSystem`.
