### PR TITLE
Add `FieldType` extensions adopted in Validation

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldTypeExts.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:JvmName("FieldTypes")
+
 package io.spine.protodata.ast
 
 import io.spine.protodata.ast.Cardinality.CARDINALITY_LIST

--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldTypeExts.kt
@@ -181,7 +181,7 @@ private fun Type.maybePrimitiveType(): PrimitiveType? =
     if (isPrimitive) primitive else null
 
 /**
- * Extracts direct or element type information from this field type.
+ * Extracts the information about the direct type or the type of elements from this field type.
  *
  * @see extractTypeName
  * @see extractMessageType
@@ -192,7 +192,7 @@ public fun FieldType.extractType(): Type = when {
     isPrimitive -> toType()
     isMap -> map.valueType
     isList -> list
-    else -> error("Cannot get type info from the field type ${this.shortly()}.")
+    else -> error("Cannot get type info from the field type `${this.shortly()}`.")
 }
 
 /**

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
@@ -54,32 +54,32 @@ import org.junit.jupiter.api.assertThrows
 internal class FieldTypeSpec {
 
     @Nested inner class
-    `provide a name of a` : TypeTest() {
+    `provide type name for diagnostics` : TypeTest() {
 
         /** Obtains a type name of the field with the given name. */
         private fun nameOf(fieldName: String) = typeOf(fieldName).name
 
         @Test
-        fun `primitive field`() = nameOf("count") shouldBe "int32"
+        fun `when primitive`() = nameOf("count") shouldBe "int32"
 
         @Test
-        fun `message field`() = nameOf("email") shouldBe "given.type.Email"
+        fun `when message`() = nameOf("email") shouldBe "given.type.Email"
 
         @Test
-        fun `enum field`() = nameOf("assumed") shouldBe "given.type.Priority"
+        fun `when enum`() = nameOf("assumed") shouldBe "given.type.Priority"
 
         @Test
-        fun `repeated primitive field`() = nameOf("counts") shouldBe "repeated uint64"
+        fun `when repeated primitive`() = nameOf("counts") shouldBe "repeated uint64"
 
         @Test
-        fun `repeated message field`() = nameOf("emails") shouldBe "repeated given.type.Email"
+        fun `when repeated message`() = nameOf("emails") shouldBe "repeated given.type.Email"
 
         @Test
-        fun `map with values of a primitive type`() =
+        fun `when map with primitive values`() =
             nameOf("histogram") shouldBe "map<string, sint64>"
 
         @Test
-        fun `map with values of a message type`() =
+        fun `when map with message values`() =
             nameOf("sorted") shouldBe "map<int32, given.type.Email>"
 
         @Test

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.shouldBe
 import io.spine.protodata.ast.Cardinality.CARDINALITY_LIST
 import io.spine.protodata.ast.Cardinality.CARDINALITY_MAP
 import io.spine.protodata.ast.Cardinality.CARDINALITY_SINGLE
+import io.spine.protodata.ast.FieldType.KindCase
 import io.spine.protodata.ast.PrimitiveType.TYPE_INT32
 import io.spine.protodata.ast.PrimitiveType.TYPE_SINT64
 import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
@@ -80,6 +81,11 @@ internal class FieldTypeSpec {
         @Test
         fun `map with values of a message type`() =
             nameOf("sorted") shouldBe "map<int32, given.type.Email>"
+
+        @Test
+        fun `returning the name of 'kindCase' otherwise`() {
+            FieldType.getDefaultInstance().name shouldBe KindCase.KIND_NOT_SET.name
+        }
     }
 
     @Test
@@ -116,6 +122,8 @@ internal class FieldTypeSpec {
         isSingular("names") shouldBe false
         isSingular("priorities") shouldBe false
         isSingular("histogram") shouldBe false
+
+        FieldType.getDefaultInstance().isSingular shouldBe false
     }
 
     @Nested inner class
@@ -131,6 +139,13 @@ internal class FieldTypeSpec {
 
         @Test
         fun `map fields`() = cardinalityOf("histogram") shouldBe CARDINALITY_MAP
+
+        @Test
+        fun `throwing when no type information available`() {
+            assertThrows<IllegalStateException> {
+                FieldType.getDefaultInstance().cardinality
+            }
+        }
     }
 
     @Nested inner class
@@ -220,6 +235,7 @@ internal class FieldTypeSpec {
         
         @Test
         fun `returning 'null' for other types`() {
+            typeNameOf("count") shouldBe null
             typeNameOf("names") shouldBe null
             typeNameOf("names") shouldBe null
             typeNameOf("histogram") shouldBe null
@@ -279,7 +295,7 @@ internal class FieldTypeSpec {
         @Test
         fun `throwing when type info is not available`() {
             assertThrows<IllegalStateException> {
-                FieldType.getDefaultInstance().toType()
+                FieldType.getDefaultInstance().extractType()
             }
         }
     }
@@ -304,8 +320,12 @@ internal class FieldTypeSpec {
 
         refersToAny("home") shouldBe true
         refersToAny("neighbourhood") shouldBe true
+        refersToAny("lottery") shouldBe true
+
         refersToAny("nobody") shouldBe false
         refersToAny("out_there") shouldBe false
+        refersToAny("void") shouldBe false
+        refersToAny("mockery") shouldBe false
     }
 }
 

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldTypeSpec.kt
@@ -30,45 +30,290 @@ import io.kotest.matchers.shouldBe
 import io.spine.protodata.ast.Cardinality.CARDINALITY_LIST
 import io.spine.protodata.ast.Cardinality.CARDINALITY_MAP
 import io.spine.protodata.ast.Cardinality.CARDINALITY_SINGLE
+import io.spine.protodata.ast.PrimitiveType.TYPE_INT32
+import io.spine.protodata.ast.PrimitiveType.TYPE_SINT64
+import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
+import io.spine.protodata.ast.PrimitiveType.TYPE_UINT64
+import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.toMessageType
-import io.spine.test.type.OopFun
+import io.spine.protodata.protobuf.toPbSourceFile
+import io.spine.protodata.protobuf.toType
+import io.spine.protodata.type.TypeSystem
+import io.spine.test.type.Anybody
+import io.spine.test.type.Email
+import io.spine.test.type.FieldSamples
+import io.spine.test.type.FieldTypeSpecProto
+import io.spine.test.type.Priority
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("`FieldType` should")
 internal class FieldTypeSpec {
 
-    private val messageType = OopFun.getDescriptor().toMessageType()
-
     @Nested inner class
-    `obtain cardinality for`  {
+    `provide a name of a` : TypeTest() {
+
+        /** Obtains a type name of the field with the given name. */
+        private fun nameOf(fieldName: String) = typeOf(fieldName).name
 
         @Test
-        fun `map fields`() {
-            cardinalityOf("gorillas") shouldBe CARDINALITY_MAP
-        }
+        fun `primitive field`() = nameOf("count") shouldBe "int32"
 
         @Test
-        fun `list fields`() {
-            cardinalityOf("tree") shouldBe CARDINALITY_LIST
-        }
+        fun `message field`() = nameOf("email") shouldBe "given.type.Email"
 
         @Test
-        fun `single fields`() {
-            cardinalityOf("jungle") shouldBe CARDINALITY_SINGLE
-        }
+        fun `enum field`() = nameOf("assumed") shouldBe "given.type.Priority"
 
-        private fun cardinalityOf(fieldName: String): Cardinality =
-            field(fieldName).type.cardinality
+        @Test
+        fun `repeated primitive field`() = nameOf("counts") shouldBe "repeated uint64"
+
+        @Test
+        fun `repeated message field`() = nameOf("emails") shouldBe "repeated given.type.Email"
+
+        @Test
+        fun `map with values of a primitive type`() =
+            nameOf("histogram") shouldBe "map<string, sint64>"
+
+        @Test
+        fun `map with values of a message type`() =
+            nameOf("sorted") shouldBe "map<int32, given.type.Email>"
+    }
+
+    @Test
+    fun `tell if it is a list`() {
+        val messageType = FieldSamples.getDescriptor().toMessageType()
+        fun isList(fieldName: String) = messageType.field(fieldName).type.isList
+
+        isList("count") shouldBe false
+        isList("counts") shouldBe true
+        isList("names") shouldBe true
+        isList("histogram") shouldBe false
+    }
+
+    @Test
+    fun `tell if it is a map`() {
+        val messageType = FieldSamples.getDescriptor().toMessageType()
+        fun isMap(fieldName: String) = messageType.field(fieldName).type.isMap
+
+        isMap("count") shouldBe false
+        isMap("counts") shouldBe false
+        isMap("names") shouldBe false
+        isMap("histogram") shouldBe true
+        isMap("sorted") shouldBe true
     }
 
     @Test
     fun `tell if it is singular`() {
-        field("gorillas").type.isSingular shouldBe false
-        field("tree").type.isSingular shouldBe false
-        field("jungle").type.isSingular shouldBe true
+        val messageType = FieldSamples.getDescriptor().toMessageType()
+        fun isSingular(fieldName: String) = messageType.field(fieldName).type.isSingular
+
+        isSingular("count") shouldBe true
+        isSingular("name") shouldBe true
+
+        isSingular("names") shouldBe false
+        isSingular("priorities") shouldBe false
+        isSingular("histogram") shouldBe false
     }
 
-    private fun field(fieldName: String) = messageType.field(fieldName)
+    @Nested inner class
+    `obtain cardinality of` : TypeTest()  {
+
+        private fun cardinalityOf(fieldName: String): Cardinality = typeOf(fieldName).cardinality
+
+        @Test
+        fun `single fields`() = cardinalityOf("count") shouldBe CARDINALITY_SINGLE
+
+        @Test
+        fun `list fields`() = cardinalityOf("counts") shouldBe CARDINALITY_LIST
+
+        @Test
+        fun `map fields`() = cardinalityOf("histogram") shouldBe CARDINALITY_MAP
+    }
+
+    @Nested inner class
+    `convert itself to 'Type'` : TypeTest() {
+
+        private fun toType(fieldName: String): Type = typeOf(fieldName).toType()
+
+        @Test
+        fun `when primitive`() {
+            toType("count") shouldBe type { primitive = TYPE_INT32 }
+            toType("name") shouldBe type { primitive = TYPE_STRING }
+        }
+
+        @Test
+        fun `when message`() =
+            toType("email") shouldBe type { message = Email.getDescriptor().name() }
+
+        @Test
+        fun `when enum`() =
+            toType("assumed") shouldBe type { enumeration = Priority.getDescriptor().name() }
+
+        @Test
+        fun `rejecting when list`() {
+            assertThrows<IllegalStateException> {
+                toType("emails")
+            }
+        }
+
+        @Test
+        fun `rejecting when map`() {
+            assertThrows<IllegalStateException> {
+                toType("sorted")
+            }
+        }
+    }
+
+    @Nested inner class
+    `extract 'MessageType'` : TypeTest() {
+
+        private val typeSystem = TypeSystem(setOf(
+            FieldTypeSpecProto.getDescriptor().toPbSourceFile()
+        ))
+
+        private fun messageTypeFrom(fieldName: String): MessageType? =
+            typeOf(fieldName).extractMessageType(typeSystem)
+
+        private val expected = Email.getDescriptor().toMessageType()
+
+        @Test
+        fun `when message`() = messageTypeFrom("email") shouldBe expected
+
+        @Test
+        fun `when list`() = messageTypeFrom("emails") shouldBe expected
+
+        @Test
+        fun `when map`() = messageTypeFrom("sorted") shouldBe expected
+
+        @Test
+        fun `returning 'null' for other types`() {
+            messageTypeFrom("count") shouldBe null
+            messageTypeFrom("names") shouldBe null
+            messageTypeFrom("priorities") shouldBe null
+            messageTypeFrom("histogram") shouldBe null
+        }
+    }
+
+    @Nested inner class
+    `extract 'TypeName'` : TypeTest() {
+
+        private fun typeNameOf(fieldName: String): TypeName? = typeOf(fieldName).extractTypeName()
+
+        private val expectedMessage = Email.getDescriptor().name()
+        private val expectedEnum = Priority.getDescriptor().name()
+
+        @Test
+        fun `when refers to a message`() {
+            typeNameOf("email") shouldBe expectedMessage
+            typeNameOf("emails") shouldBe expectedMessage
+            typeNameOf("sorted") shouldBe expectedMessage
+        }
+
+        @Test
+        fun `when refers to an enum`() {
+            typeNameOf("assumed") shouldBe expectedEnum
+            typeNameOf("priorities") shouldBe expectedEnum
+        }
+        
+        @Test
+        fun `returning 'null' for other types`() {
+            typeNameOf("names") shouldBe null
+            typeNameOf("names") shouldBe null
+            typeNameOf("histogram") shouldBe null
+        }
+    }
+
+    @Nested inner class
+    `extract 'PrimitiveType'` : TypeTest() {
+
+        private fun extractFrom(fieldName: String): PrimitiveType? =
+            typeOf(fieldName).extractPrimitiveType()
+
+        @Test
+        fun `from singular`() = extractFrom("count") shouldBe TYPE_INT32
+
+        @Test
+        fun `from list`() = extractFrom("counts") shouldBe TYPE_UINT64
+
+        @Test
+        fun `from map`() = extractFrom("histogram") shouldBe TYPE_SINT64
+
+        @Test
+        fun `returning 'null' if does not refer to a primitive type`() {
+            extractFrom("email") shouldBe null
+            extractFrom("emails") shouldBe null
+            extractFrom("assumed") shouldBe null
+            // Check we do not extract from keys.
+            extractFrom("sorted") shouldBe null
+        }
+    }
+
+    @Nested inner class
+    `extract 'Type'` : TypeTest() {
+
+        private fun extractFrom(fieldName: String): Type = typeOf(fieldName).extractType()
+
+        private val expectedMessageType = Email.getDescriptor().toType()
+
+        @Test
+        fun `when primitive`() = extractFrom("count") shouldBe TYPE_INT32.toType()
+
+        @Test
+        fun `when list of primitives`() = extractFrom("counts") shouldBe TYPE_UINT64.toType()
+
+        @Test
+        fun `when message`() = extractFrom("email") shouldBe expectedMessageType
+
+        @Test
+        fun `when message list`() = extractFrom("emails") shouldBe expectedMessageType
+
+        @Test
+        fun `when a map with messages`() = extractFrom("sorted") shouldBe expectedMessageType
+
+        @Test
+        fun `when a map with primitives`() = extractFrom("histogram") shouldBe TYPE_SINT64.toType()
+
+        @Test
+        fun `throwing when type info is not available`() {
+            assertThrows<IllegalStateException> {
+                FieldType.getDefaultInstance().toType()
+            }
+        }
+    }
+
+    @Test
+    fun `tell if refers to a message type`() {
+        val messageType = FieldSamples.getDescriptor().toMessageType()
+        fun refersToMessage(fieldName: String) = messageType.field(fieldName).type.refersToMessage()
+
+        refersToMessage("email") shouldBe true
+        refersToMessage("emails") shouldBe true
+        refersToMessage("sorted") shouldBe true
+
+        refersToMessage("assumed") shouldBe false
+        refersToMessage("count") shouldBe false
+    }
+
+    @Test
+    fun `tell if refers to 'Any'`() {
+        val messageType = Anybody.getDescriptor().toMessageType()
+        fun refersToAny(fieldName: String) = messageType.field(fieldName).type.refersToAny()
+
+        refersToAny("home") shouldBe true
+        refersToAny("neighbourhood") shouldBe true
+        refersToAny("nobody") shouldBe false
+        refersToAny("out_there") shouldBe false
+    }
+}
+
+/**
+ * Abstract base for nested test suites accessing field types of the given [messageType].
+ */
+abstract class TypeTest(
+    private val messageType: MessageType = FieldSamples.getDescriptor().toMessageType()
+) {
+    protected fun typeOf(fieldName: String): FieldType = messageType.field(fieldName).type
 }

--- a/api/src/testFixtures/proto/given/type/field_type_spec.proto
+++ b/api/src/testFixtures/proto/given/type/field_type_spec.proto
@@ -75,10 +75,13 @@ enum Priority {
     PRIORITY_LOW = 3;
 }
 
-// A collection of fields with `Any` and without.
+// A collection of fields with `Any`, and without.
 message Anybody {
     google.protobuf.Any home = 1;
     repeated google.protobuf.Any neighbourhood = 2;
     google.protobuf.Empty nobody = 3;
-    bool out_there = 4;
+    repeated google.protobuf.Empty void = 4;
+    bool out_there = 5;
+    map<string, google.protobuf.Any> lottery = 6;
+    map<string, google.protobuf.Empty> mockery = 7;
 }

--- a/api/src/testFixtures/proto/given/type/field_type_spec.proto
+++ b/api/src/testFixtures/proto/given/type/field_type_spec.proto
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package given.type;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.type";
+option java_outer_classname = "FieldTypeSpecProto";
+option java_multiple_files = true;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// Provides various types of fields.
+//
+// We deliberately violate our custom conventions for naming repeated and map fields
+// for brevity and clarity of underlying tests. Please follow the conventions in other types.
+//
+// See: https://github.com/SpineEventEngine/documentation/wiki/Protobuf-code-style#naming-repeated-and-map-fields
+//
+message FieldSamples {
+    int32 count = 1;
+    repeated uint64 counts = 2;
+
+    string name = 3;
+    repeated string names = 4;
+
+    Email email = 5;
+    repeated Email emails = 6;
+
+    Priority assumed = 7;
+    repeated Priority priorities = 8;
+
+    map<string, sint64> histogram = 9;
+    map<int32, Email> sorted = 10;
+}
+
+message Email {
+    string subject = 1;
+    string text = 2;
+}
+
+enum Priority {
+    PRIORITY_UNKNOWN = 0;
+    PRIORITY_HIGH = 1;
+    PRIORITY_NORMAL = 2;
+    PRIORITY_LOW = 3;
+}
+
+// A collection of fields with `Any` and without.
+message Anybody {
+    google.protobuf.Any home = 1;
+    repeated google.protobuf.Any neighbourhood = 2;
+    google.protobuf.Empty nobody = 3;
+    bool out_there = 4;
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.64.0"
+    private const val fallbackVersion = "0.65.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3941,7 +3941,7 @@ This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4957,7 +4957,7 @@ This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5977,7 +5977,7 @@ This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7174,7 +7174,7 @@ This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8200,7 +8200,7 @@ This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9046,7 +9046,7 @@ This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10095,7 +10095,7 @@ This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11214,4 +11214,4 @@ This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-api:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.66.0`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-backend:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Sun Nov 03 20:17:12 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-cli:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Sun Nov 03 20:17:13 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-java:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.66.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9046,12 +9046,12 @@ This report was generated on **Sun Nov 03 20:17:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10095,12 +10095,12 @@ This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.65.2`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.66.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11214,4 +11214,4 @@ This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 03 20:17:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 12:14:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.65.2`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Sat Nov 02 15:30:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-backend:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Sat Nov 02 15:30:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:52 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Sat Nov 02 15:30:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-java:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:53 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.65.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9046,12 +9046,12 @@ This report was generated on **Sat Nov 02 15:30:59 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:31:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10095,12 +10095,12 @@ This report was generated on **Sat Nov 02 15:31:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:31:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.65.1`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.65.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11214,4 +11214,4 @@ This report was generated on **Sat Nov 02 15:31:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 15:31:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 03 19:41:54 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.65.2</version>
+<version>0.66.0</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.65.1</version>
+<version>0.65.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.65.2")
+val protoDataVersion: String by extra("0.66.0")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.65.1")
+val protoDataVersion: String by extra("0.65.2")


### PR DESCRIPTION
This PR adds `FieldType` extensions there were recently [adopted in Validation](https://github.com/SpineEventEngine/validation/pull/141).

## Breaking changes
* `FieldTypeExts.kt` got `@file:JvmName("FieldTypes")` which requires updating imports in Java code.


