### PR TITLE
Make message expressions covariant

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-api:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:37 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:32:59 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.68.1`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Tue Nov 19 12:19:37 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:05 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-backend:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:06 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-cli:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:07 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4957,12 +4957,12 @@ This report was generated on **Tue Nov 19 12:19:38 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:08 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5977,12 +5977,12 @@ This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:09 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7174,12 +7174,12 @@ This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:19 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-java:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8200,12 +8200,12 @@ This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:20 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.68.1`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9046,12 +9046,12 @@ This report was generated on **Tue Nov 19 12:19:39 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:40 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:22 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10095,12 +10095,12 @@ This report was generated on **Tue Nov 19 12:19:40 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:40 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:22 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.68.0`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.68.1`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11214,4 +11214,4 @@ This report was generated on **Tue Nov 19 12:19:40 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 19 12:19:40 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 21 18:33:25 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/FieldAccess.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/FieldAccess.kt
@@ -39,7 +39,7 @@ import io.spine.protodata.ast.fieldName
  */
 public class FieldAccess
 internal constructor(
-    public val message: Expression<Message>,
+    public val message: Expression<out Message>,
     name: FieldName,
     kind: Cardinality,
 ) : FieldConventions(name, kind) {
@@ -48,7 +48,7 @@ internal constructor(
      * Constructs field access for the given [message] and [name].
      */
     internal constructor(
-        message: Expression<Message>,
+        message: Expression<out Message>,
         name: String,
         kind: Cardinality = CARDINALITY_SINGLE
     ) : this(message, fieldName { value = name }, kind)

--- a/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
@@ -47,6 +47,20 @@ public fun <T> ClassName.call(
 ): MethodCall<T> = MethodCall(this, name, arguments, generics)
 
 /**
+ * Constructs a call to a static method of this class.
+ *
+ * @param name The name of the method.
+ * @param argument The method argument.
+ * @param generics The method type parameters.
+ */
+@JvmOverloads
+public fun <T> ClassName.call(
+    name: String,
+    argument: Expression<*>,
+    generics: List<ClassName> = listOf()
+): MethodCall<T> = MethodCall(this, name, argument, generics)
+
+/**
  * Constructs an expression which creates a new builder for this class.
  *
  * Example: `ClassName("com.acme.Bird").newBuilder()` yields

--- a/java/src/main/kotlin/io/spine/protodata/java/ProtobufExpressions.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ProtobufExpressions.kt
@@ -58,11 +58,11 @@ public fun Expression<*>.packToAny(): Expression<ProtoAny> {
 /**
  * Obtains a [FieldAccess] to the [field] of this message.
  */
-public fun Expression<Message>.field(field: Field): FieldAccess =
+public fun Expression<out Message>.field(field: Field): FieldAccess =
     FieldAccess(this, field.name, field.type.cardinality)
 
 /**
  * Obtains a [FieldAccess] to the field of this message with the given [name].
  */
-public fun Expression<Message>.field(name: String, cardinality: Cardinality): FieldAccess =
+public fun Expression<out Message>.field(name: String, cardinality: Cardinality): FieldAccess =
     FieldAccess(this, name, cardinality)

--- a/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
@@ -30,6 +30,9 @@ package io.spine.protodata.java
 
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.qualifiedName
+import io.spine.protodata.type.TypeSystem
+import io.spine.string.simply
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -63,6 +66,19 @@ public fun TypeName.javaClassName(accordingTo: ProtoFileHeader): ClassName =
     }, { packageName, list ->
         ClassName(packageName, list)
     })
+
+/**
+ * Obtains a fully qualified Java class name, generated for the Protobuf type with this name.
+ *
+ * @param typeSystem The type system to be used for obtaining the header for the proto
+ *   file in which this message type is declared.
+ */
+public fun TypeName.javaClassName(typeSystem: TypeSystem): ClassName {
+    val header = typeSystem.findMessage(this)?.second
+        ?: error("Cannot find Java `${simply<ClassName>()}` for the Protobuf `${qualifiedName}`.")
+    val className = javaClassName(header)
+    return className
+}
 
 /**
  * Obtains a fully qualified Java enum type name, generated for the Protobuf enum with this name.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.68.0</version>
+<version>0.68.1</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.68.999")
+val protoDataVersion: String by extra("0.68.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.68.0")
+val protoDataVersion: String by extra("0.68.999")


### PR DESCRIPTION
This PR introduces several small changes required to apply the updated Expressions API in Validation.

The changes are the following:

1. Make message-related expression extensions covariant, so that they could be used upon any children of `Message`.
2. Add `TypeName.javaClassName()` overload, which accept the type system.
3. Add `ClassName.call()` overload, which accepts a single argument only. There is a similar constructor of `MessageCall`.