### PR TITLE
Errors and warnings

### DIFF
--- a/api-tests/build.gradle.kts
+++ b/api-tests/build.gradle.kts
@@ -27,6 +27,7 @@
 import io.spine.dependency.lib.Protobuf
 
 plugins {
+    protobuf
     prototap
     `test-module`
 }

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -59,7 +59,7 @@ public object Compilation {
      * The method returns the string printed to the console so that it could be also
      * put into logging output.
      *
-     * @param file The file in which causes the warning.
+     * @param file The file which causes the warning.
      * @param line The one-based number of the line with the questionable code.
      * @param column The one-based number of the column with the questionable code.
      * @param message The description of the warning.

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata
+
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * Provides functions to report compilation errors and warnings.
+ */
+public object Compilation {
+
+    /**
+     * The exit code for a compilation error.
+     */
+    public const val ERROR_EXIT_CODE: Int = -1
+
+    /**
+     * Prints the error diagnostics to [System.err] and exits the process with [ERROR_EXIT_CODE].
+     *
+     * @param file The file in which the error occurred.
+     * @param line The one-based number of the line with the error.
+     * @param column The one-based number of the column with the error.
+     * @param message The description of what went wrong.
+     */
+    public fun error(file: File, line: Int, column: Int, message: String) {
+        val output = "e: $file:$line:$column: $message"
+        System.err.println(output)
+        exitProcess(ERROR_EXIT_CODE)
+    }
+
+    /**
+     * Prints the warning diagnostics to [System.out].
+     *
+     * The method returns the string printed to the console so that it could be also
+     * put into logging output.
+     *
+     * @param file The file in which causes the warning.
+     * @param line The one-based number of the line with the questionable code.
+     * @param column The one-based number of the column with the questionable code.
+     * @param message The description of the warning.
+     * @return the string printed to the console.
+     */
+    public fun warning(file: File, line: Int, column: Int, message: String): String {
+        val output = "w: $file:$line:$column: $message"
+        println(output)
+        return output
+    }
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -37,6 +37,7 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.spine.protodata.protobuf.fromResources
 import io.spine.protodata.util.Cache
 
 /**
@@ -150,4 +151,7 @@ private fun Location.toSpan(): Span {
 /**
  * Obtains coordinates for the file this [GenericDescriptor].
  */
-internal fun GenericDescriptor.coordinates(): Coordinates = Coordinates.of(file)
+internal fun GenericDescriptor.coordinates(): Coordinates {
+    val fromResources = fromResources()
+    return Coordinates.of(fromResources.file)
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -37,7 +37,7 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
-import io.spine.protodata.protobuf.fromResources
+import io.spine.protodata.protobuf.withSourceLines
 import io.spine.protodata.util.Cache
 
 /**
@@ -152,6 +152,6 @@ private fun Location.toSpan(): Span {
  * Obtains coordinates for the file this [GenericDescriptor].
  */
 internal fun GenericDescriptor.coordinates(): Coordinates {
-    val fromResources = fromResources()
+    val fromResources = withSourceLines()
     return Coordinates.of(fromResources.file)
 }

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata.ast
 
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
@@ -36,90 +37,106 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
-import io.spine.string.trimWhitespace
 
 /**
- * Documentation contained in a Protobuf file.
+ * Provides line and column numbers for declarations in a Protobuf file.
  */
-public class Documentation(file: FileDescriptorProto) : Locations(file) {
+public class Coordinates(file: FileDescriptorProto) : Locations(file) {
 
     /**
-     * Creates an instance of `Documentation` with all the docs from the given file.
+     * Creates an instance with coordinates of declarations in the given file.
      */
     public constructor(file: FileDescriptor) : this(file.toProto())
 
     /**
-     * Obtains documentation for the given message.
+     * Obtains declaration coordinates the given message.
      */
-    public fun forMessage(d: Descriptor): Doc {
+    public fun forMessage(d: Descriptor): Span {
         val path = LocationPath.fromMessage(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given message field.
+     * Obtains declaration coordinates the given message.
      */
-    public fun forField(d: FieldDescriptor): Doc {
+    public fun forField(d: FieldDescriptor): Span {
         val path = LocationPath.fromMessage(d.containingType).field(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given `oneof` group.
+     * Obtains declaration coordinates for the given `oneof` group.
      */
-    public fun forOneof(d: OneofDescriptor): Doc {
+    public fun forOneof(d: OneofDescriptor): Span {
         val path = LocationPath.fromMessage(d.containingType).oneof(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given enum type.
+     * Obtains declaration coordinates for the given enum type.
      */
-    public fun forEnum(d: EnumDescriptor): Doc {
+    public fun forEnum(d: EnumDescriptor): Span {
         val path = LocationPath.fromEnum(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given enum constant.
+     * Obtains declaration coordinates for the given enum constant.
      */
-    public fun forEnumConstant(d: EnumValueDescriptor): Doc {
+    public fun forEnumConstant(d: EnumValueDescriptor): Span {
         val path = LocationPath.fromEnum(d.type).constant(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given service.
+     * Obtains declaration coordinates for the given service.
      */
-    public fun forService(d: ServiceDescriptor): Doc {
+    public fun forService(d: ServiceDescriptor): Span {
         val path = LocationPath.fromService(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
     /**
-     * Obtains documentation for the given RPC method.
+     * Obtains declaration coordinates for the given RPC method.
      */
-    public fun forRpc(d: MethodDescriptor): Doc {
+    public fun forRpc(d: MethodDescriptor): Span {
         val path = LocationPath.fromService(d.service).rpc(d)
-        return commentsAt(path)
+        return spanAt(path)
     }
 
-    private fun commentsAt(path: LocationPath): Doc {
+    private fun spanAt(path: LocationPath): Span {
         val location = locationAt(path)
-        return doc {
-            leadingComment = location.leadingComments.trimWhitespace()
-            trailingComment = location.trailingComments.trimWhitespace()
-            detachedComment.addAll(location.leadingDetachedCommentsList.trimWhitespace())
-        }
+        return location.toSpan()
     }
 }
 
-private fun Iterable<String>.trimWhitespace(): List<String> =
-    map { it.trimWhitespace() }
+/**
+ * Converts the [Location.span][Location.getSpanList] field into [Span].
+ *
+ * See the documentation of the `Location.span` field for details.
+ */
+private fun Location.toSpan(): Span {
+    if (this == Location.getDefaultInstance()) {
+        return Span.getDefaultInstance()
+    }
+    // Convert the value of the `span` field into four-elements array.
+    val slots =
+        if (spanCount == 3)
+            arrayOf(getSpan(0), getSpan(1), getSpan(0), getSpan(2))
+        else
+            arrayOf(getSpan(0), getSpan(1), getSpan(2), getSpan(3))
+    // Add 1 to make the coordinates 1-based.
+    return span {
+        startLine = slots[0] + 1
+        startColumn = slots[1] + 1
+        endLine = slots[2] + 1
+        endColumn = slots[3] + 1
+    }
+}
 
 /**
- * Obtains documentation for the file of this [GenericDescriptor].
+ * Obtains coordinates for the file this [GenericDescriptor].
  */
-internal fun GenericDescriptor.documentation(): Documentation = Documentation(file)
+internal fun GenericDescriptor.coordinates(): Coordinates = Coordinates(file)
 
-//TODO:2024-11-30:alexander.yevsyukov: Cache the above construction.
+//TODO:2024-11-30:alexander.yevsyukov: Cache this.

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -37,16 +37,12 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.spine.protodata.util.Cache
 
 /**
  * Provides line and column numbers for declarations in a Protobuf file.
  */
-public class Coordinates(file: FileDescriptorProto) : Locations(file) {
-
-    /**
-     * Creates an instance with coordinates of declarations in the given file.
-     */
-    public constructor(file: FileDescriptor) : this(file.toProto())
+public class Coordinates private constructor(file: FileDescriptorProto) : Locations(file) {
 
     /**
      * Obtains declaration coordinates the given message.
@@ -108,6 +104,23 @@ public class Coordinates(file: FileDescriptorProto) : Locations(file) {
         val location = locationAt(path)
         return location.toSpan()
     }
+
+    public companion object : Cache<FileDescriptorProto, Coordinates>() {
+
+        override fun create(key: FileDescriptorProto, param: Any?): Coordinates = Coordinates(key)
+
+        /**
+         * Obtains coordinates for the given file.
+         */
+        @JvmStatic
+        public fun of(file: FileDescriptor): Coordinates = get(file.toProto(), null)
+
+        /**
+         * Obtains coordinates for the given file.
+         */
+        @JvmStatic
+        public fun of(file: FileDescriptorProto): Coordinates = get(file, null)
+    }
 }
 
 /**
@@ -137,6 +150,4 @@ private fun Location.toSpan(): Span {
 /**
  * Obtains coordinates for the file this [GenericDescriptor].
  */
-internal fun GenericDescriptor.coordinates(): Coordinates = Coordinates(file)
-
-//TODO:2024-11-30:alexander.yevsyukov: Cache this.
+internal fun GenericDescriptor.coordinates(): Coordinates = Coordinates.of(file)

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -36,7 +36,7 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
-import io.spine.protodata.protobuf.fromResources
+import io.spine.protodata.protobuf.withSourceLines
 import io.spine.protodata.util.Cache
 import io.spine.string.trimWhitespace
 
@@ -136,6 +136,6 @@ private fun Iterable<String>.trimWhitespace(): List<String> =
  * Obtains documentation for the file of this [GenericDescriptor].
  */
 internal fun GenericDescriptor.documentation(): Documentation {
-    val fromResources = fromResources()
+    val fromResources = withSourceLines()
     return Documentation.of(fromResources.file)
 }

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -36,17 +36,13 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.spine.protodata.util.Cache
 import io.spine.string.trimWhitespace
 
 /**
  * Documentation contained in a Protobuf file.
  */
-public class Documentation(file: FileDescriptorProto) : Locations(file) {
-
-    /**
-     * Creates an instance of `Documentation` with all the docs from the given file.
-     */
-    public constructor(file: FileDescriptor) : this(file.toProto())
+public class Documentation private constructor(file: FileDescriptorProto) : Locations(file) {
 
     /**
      * Obtains documentation for the given message.
@@ -112,6 +108,24 @@ public class Documentation(file: FileDescriptorProto) : Locations(file) {
             detachedComment.addAll(location.leadingDetachedCommentsList.trimWhitespace())
         }
     }
+
+    public companion object : Cache<FileDescriptorProto, Documentation>() {
+
+        override fun create(key: FileDescriptorProto, param: Any?): Documentation =
+            Documentation(key)
+
+        /**
+         * Obtains documentation for the given file.
+         */
+        @JvmStatic
+        public fun of(file: FileDescriptor): Documentation = get(file.toProto())
+
+        /**
+         * Obtains documentation for the given file.
+         */
+        @JvmStatic
+        public fun of(file: FileDescriptorProto): Documentation = get(file)
+    }
 }
 
 private fun Iterable<String>.trimWhitespace(): List<String> =
@@ -120,6 +134,4 @@ private fun Iterable<String>.trimWhitespace(): List<String> =
 /**
  * Obtains documentation for the file of this [GenericDescriptor].
  */
-internal fun GenericDescriptor.documentation(): Documentation = Documentation(file)
-
-//TODO:2024-11-30:alexander.yevsyukov: Cache the above construction.
+internal fun GenericDescriptor.documentation(): Documentation = Documentation.of(file)

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -36,6 +36,7 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.spine.protodata.protobuf.fromResources
 import io.spine.protodata.util.Cache
 import io.spine.string.trimWhitespace
 
@@ -134,4 +135,7 @@ private fun Iterable<String>.trimWhitespace(): List<String> =
 /**
  * Obtains documentation for the file of this [GenericDescriptor].
  */
-internal fun GenericDescriptor.documentation(): Documentation = Documentation.of(file)
+internal fun GenericDescriptor.documentation(): Documentation {
+    val fromResources = fromResources()
+    return Documentation.of(fromResources.file)
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.DescriptorProto.FIELD_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.DescriptorProto.NESTED_TYPE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.DescriptorProto.ONEOF_DECL_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.EnumDescriptorProto.VALUE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto.SERVICE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.EnumDescriptor
+import com.google.protobuf.Descriptors.EnumValueDescriptor
+import com.google.protobuf.Descriptors.FieldDescriptor
+import com.google.protobuf.Descriptors.MethodDescriptor
+import com.google.protobuf.Descriptors.OneofDescriptor
+import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.spine.util.interlaced
+
+/**
+ * A numerical path to a location is source code.
+ *
+ * Used by the Protobuf compiler as a coordinate system for arbitrary Protobuf declarations.
+ *
+ * See `google.protobuf.SourceCodeInfo.Location.path` for the explanation of the protocol.
+ */
+@JvmInline
+internal value class LocationPath
+private constructor(private val value: List<Int>) {
+
+    companion object {
+
+        /**
+         * Obtains the `LocationPath` from the Protobuf's `Location`.
+         */
+        fun from(location: Location): LocationPath {
+            return LocationPath(location.pathList)
+        }
+
+        /**
+         * Obtains the `LocationPath` from the given message.
+         */
+        fun fromMessage(descriptor: Descriptor): LocationPath {
+            val numbers = mutableListOf<Int>()
+            numbers.add(MESSAGE_TYPE_FIELD_NUMBER)
+            if (!descriptor.isTopLevel) {
+                numbers.addAll(upToTop(descriptor.containingType))
+                numbers.add(NESTED_TYPE_FIELD_NUMBER)
+            }
+            numbers.add(descriptor.index)
+            return LocationPath(numbers)
+        }
+
+        /**
+         * Obtains the `LocationPath` from the given enum.
+         */
+        fun fromEnum(descriptor: EnumDescriptor): LocationPath {
+            val numbers = mutableListOf<Int>()
+            if (descriptor.isTopLevel) {
+                numbers.add(FileDescriptorProto.ENUM_TYPE_FIELD_NUMBER)
+            } else {
+                numbers.add(MESSAGE_TYPE_FIELD_NUMBER)
+                numbers.addAll(upToTop(descriptor.containingType))
+                numbers.add(DescriptorProto.ENUM_TYPE_FIELD_NUMBER)
+            }
+            numbers.add(descriptor.index)
+            return LocationPath(numbers)
+        }
+
+        /**
+         * Obtains the `LocationPath` from the given service.
+         */
+        fun fromService(descriptor: ServiceDescriptor): LocationPath {
+            return LocationPath(
+                listOf(
+                    SERVICE_FIELD_NUMBER,
+                    descriptor.index
+                )
+            )
+        }
+
+        private fun upToTop(parent: Descriptor): List<Int> {
+            val rootPath = mutableListOf<Int>()
+            var containingType: Descriptor? = parent
+            while (containingType != null) {
+                rootPath.add(containingType.index)
+                containingType = containingType.containingType
+            }
+            return rootPath.interlaced(NESTED_TYPE_FIELD_NUMBER)
+                .toList()
+                .reversed()
+        }
+    }
+
+    /**
+     * Obtains the `LocationPath` to the given field.
+     *
+     * It's expected that the field belongs to the message located at this location path.
+     */
+    fun field(field: FieldDescriptor): LocationPath =
+        subDeclaration(FIELD_FIELD_NUMBER, field.index)
+
+    /**
+     * Obtains the `LocationPath` to the given `oneof` group.
+     *
+     * It's expected that the group is declared in the message located at this location path.
+     */
+    fun oneof(group: OneofDescriptor): LocationPath =
+        subDeclaration(ONEOF_DECL_FIELD_NUMBER, group.index)
+
+    /**
+     * Obtains the `LocationPath` to the given enum constant.
+     *
+     * It's expected that the constant belongs to the enum located at this location path.
+     */
+    fun constant(constant: EnumValueDescriptor): LocationPath =
+        subDeclaration(VALUE_FIELD_NUMBER, constant.index)
+
+    /**
+     * Obtains the `LocationPath` to the given RPC.
+     *
+     * It's expected that the RPC belongs to the service located at this location path.
+     */
+    fun rpc(rpc: MethodDescriptor): LocationPath =
+        subDeclaration(METHOD_FIELD_NUMBER, rpc.index)
+
+    override fun toString(): String {
+        return "LocationPath(${value.joinToString()})"
+    }
+
+    private fun subDeclaration(descriptorFieldNumber: Int, index: Int): LocationPath =
+        LocationPath(value + arrayOf(descriptorFieldNumber, index))
+}
+
+private val Descriptor.isTopLevel: Boolean
+    get() = containingType == null
+
+private val EnumDescriptor.isTopLevel: Boolean
+    get() = containingType == null
+

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -65,7 +65,7 @@ public fun Descriptor.toMessageType(): MessageType =
     }
 
 /**
- * Converts the `Descriptor` into [Type] instance with the [message][Type.getMessage]
+ * Converts the `Descriptor` into [Type] instance with the [message][Type.message]
  * property initialized.
  */
 public fun Descriptor.toType(): Type = type {

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -52,14 +52,14 @@ public fun Descriptor.name(): TypeName = buildTypeName(name, file, containingTyp
  * The method filters synthetic descriptors created for map fields.
  * A descriptor of a map field entry is named after the name of the field
  * with the `"Entry"` suffix.
- * We use this convention for filtering [nestedTypes] returned by Protobuf API.
+ * We use this convention for filtering [Descriptor.nestedTypes] returned by Protobuf API.
  *
  * @see <a href="https://protobuf.dev/programming-guides/proto3/#maps-features">
  *     Protobuf documentation</a>
  */
-public fun Descriptor.nestedTypes(): List<Descriptor> {
-    val mapEntryTypes =
-        fields.filter { it.isMapField }.map { it.name.camelCase() + "Entry" }.toList()
+public fun Descriptor.realNestedTypes(): List<Descriptor> {
+    val mapEntryTypes = fields.filter { it.isMapField }
+        .map { it.name.camelCase() + "Entry" }.toList()
     return nestedTypes.filter { !mapEntryTypes.contains(it.name) }
 }
 
@@ -77,7 +77,7 @@ public fun Descriptor.toMessageType(): MessageType =
         }
         oneofGroup.addAll(realOneofs.map { it.toOneOfGroup() })
         field.addAll(fields.mapped())
-        nestedMessages.addAll(nestedTypes().map { it.name() })
+        nestedMessages.addAll(realNestedTypes().map { it.name() })
         nestedEnums.addAll(enumTypes.map { it.name() })
         doc = documentation().forMessage(self)
         span = coordinates().forMessage(self)
@@ -153,7 +153,7 @@ internal fun <T> walkMessage(
         while (queue.isNotEmpty()) {
             val msg = queue.removeFirst()
             yieldAll(extractorFun(msg))
-            queue.addAll(msg.nestedTypes())
+            queue.addAll(msg.realNestedTypes())
         }
     }
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -29,21 +29,15 @@ package io.spine.protodata.protobuf
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FileDescriptor
-import com.google.protobuf.Descriptors.GenericDescriptor
-import io.spine.protodata.ast.Documentation
 import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.MessageType
 import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.documentation
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.messageType
 import io.spine.protodata.ast.toList
 import io.spine.protodata.ast.type
-
-/**
- * Obtains documentation of this [GenericDescriptor].
- */
-internal val GenericDescriptor.fileDoc: Documentation
-    get() = Documentation(file)
 
 /**
  * Obtains the name of this message type as a [TypeName].
@@ -57,7 +51,9 @@ public fun Descriptor.toMessageType(): MessageType =
     messageType {
         name = name()
         file = getFile().file()
-        doc = fileDoc.forMessage(this@toMessageType)
+        val self = this@toMessageType
+        doc = documentation().forMessage(self)
+        span = coordinates().forMessage(self)
         option.addAll(options.toList())
         if (containingType != null) {
             declaredIn = containingType.name()

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -52,8 +52,6 @@ public fun Descriptor.toMessageType(): MessageType =
         name = name()
         file = getFile().file()
         val self = this@toMessageType
-        doc = documentation().forMessage(self)
-        span = coordinates().forMessage(self)
         option.addAll(options.toList())
         if (containingType != null) {
             declaredIn = containingType.name()
@@ -62,6 +60,8 @@ public fun Descriptor.toMessageType(): MessageType =
         field.addAll(fields.mapped())
         nestedMessages.addAll(nestedTypes.map { it.name() })
         nestedEnums.addAll(enumTypes.map { it.name() })
+        doc = documentation().forMessage(self)
+        span = coordinates().forMessage(self)
     }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -100,6 +100,7 @@ public fun buildConstant(desc: EnumValueDescriptor, declaringType: TypeName): En
         declaredIn = declaringType
         number = desc.number
         orderOfDeclaration = desc.index
-        doc = desc.documentation().forEnumConstant(desc)
-        span = desc.coordinates().forEnumConstant(desc)
+        val enumType = desc.type
+        doc = enumType.documentation().forEnumConstant(desc)
+        span = enumType.coordinates().forEnumConstant(desc)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -34,6 +34,7 @@ import io.spine.protodata.ast.EnumType
 import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.constantName
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.enumConstant
 import io.spine.protodata.ast.enumType
@@ -62,6 +63,7 @@ public fun EnumDescriptor.toEnumType(): EnumType =
             declaredIn = containingType.name()
         }
         doc = documentation().forEnum(this@toEnumType)
+        span = coordinates().forEnum(this@toEnumType)
     }
 
 /**
@@ -99,4 +101,5 @@ public fun buildConstant(desc: EnumValueDescriptor, declaringType: TypeName): En
         number = desc.number
         orderOfDeclaration = desc.index
         doc = desc.documentation().forEnumConstant(desc)
+        span = desc.coordinates().forEnumConstant(desc)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -37,6 +37,7 @@ import io.spine.protodata.ast.constantName
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.enumConstant
 import io.spine.protodata.ast.enumType
+import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.toList
 import io.spine.protodata.ast.type
 
@@ -52,7 +53,6 @@ public fun EnumDescriptor.name(): TypeName = buildTypeName(name, file, containin
  */
 public fun EnumDescriptor.toEnumType(): EnumType =
     enumType {
-        val docs = fileDoc
         val typeName = name()
         name = typeName
         option.addAll(options.toList())
@@ -61,7 +61,7 @@ public fun EnumDescriptor.toEnumType(): EnumType =
         if (containingType != null) {
             declaredIn = containingType.name()
         }
-        doc = docs.forEnum(this@toEnumType)
+        doc = documentation().forEnum(this@toEnumType)
     }
 
 /**
@@ -98,5 +98,5 @@ public fun buildConstant(desc: EnumValueDescriptor, declaringType: TypeName): En
         declaredIn = declaringType
         number = desc.number
         orderOfDeclaration = desc.index
-        doc = desc.fileDoc.forEnumConstant(desc)
+        doc = desc.documentation().forEnumConstant(desc)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -67,6 +67,7 @@ import io.spine.protodata.ast.PrimitiveType.TYPE_UINT32
 import io.spine.protodata.ast.PrimitiveType.TYPE_UINT64
 import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.field
@@ -110,16 +111,16 @@ public fun buildField(desc: FieldDescriptor): Field =
     field {
         val declaredIn = desc.containingType.name()
         name = desc.name()
-        orderOfDeclaration = desc.index
-        doc = desc.documentation().forField(desc)
-        number = desc.number
-        declaringType = declaredIn
-
         // New `FieldType` and `group_name` API.
         type = desc.toFieldType()
+        declaringType = declaredIn
+        number = desc.number
+        orderOfDeclaration = desc.index
         desc.realContainingOneof?.let {
             enclosingOneof = it.name()
         }
+        doc = desc.documentation().forField(desc)
+        span = desc.coordinates().forField(desc)
     }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -109,7 +109,8 @@ public fun FieldDescriptor.toField(): Field {
  */
 public fun buildField(desc: FieldDescriptor): Field =
     field {
-        val declaredIn = desc.containingType.name()
+        val messageType = desc.containingType
+        val declaredIn = messageType.name()
         name = desc.name()
         // New `FieldType` and `group_name` API.
         type = desc.toFieldType()
@@ -119,8 +120,8 @@ public fun buildField(desc: FieldDescriptor): Field =
         desc.realContainingOneof?.let {
             enclosingOneof = it.name()
         }
-        doc = desc.documentation().forField(desc)
-        span = desc.coordinates().forField(desc)
+        doc = messageType.documentation().forField(desc)
+        span = messageType.coordinates().forField(desc)
     }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -68,6 +68,7 @@ import io.spine.protodata.ast.PrimitiveType.TYPE_UINT64
 import io.spine.protodata.ast.Type
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.copy
+import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.field
 import io.spine.protodata.ast.fieldName
 import io.spine.protodata.ast.fieldType
@@ -110,7 +111,7 @@ public fun buildField(desc: FieldDescriptor): Field =
         val declaredIn = desc.containingType.name()
         name = desc.name()
         orderOfDeclaration = desc.index
-        doc = desc.fileDoc.forField(desc)
+        doc = desc.documentation().forField(desc)
         number = desc.number
         declaringType = declaredIn
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
@@ -146,7 +146,7 @@ private class DefinitionFactory(private val file: FileDescriptor) {
     fun messageTypes(): Sequence<MessageType> {
         var messages = file.messageTypes.asSequence()
         for (msg in file.messageTypes) {
-            messages += walkMessage(msg) { it.nestedTypes() }
+            messages += walkMessage(msg) { it.realNestedTypes() }
         }
         return messages.map { it.toMessageType() }
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
@@ -146,7 +146,7 @@ private class DefinitionFactory(private val file: FileDescriptor) {
     fun messageTypes(): Sequence<MessageType> {
         var messages = file.messageTypes.asSequence()
         for (msg in file.messageTypes) {
-            messages += walkMessage(msg) { it.nestedTypes }
+            messages += walkMessage(msg) { it.nestedTypes() }
         }
         return messages.map { it.toMessageType() }
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
@@ -27,16 +27,23 @@
 package io.spine.protodata.protobuf
 
 import com.google.protobuf.Descriptors.GenericDescriptor
+import io.spine.type.KnownTypes
 import io.spine.type.TypeUrl
 
 /**
  * Obtains the version of this descriptor with source line information loaded from
  * the descriptor set files stored in resources.
  *
+ * If resources do not have the version of this descriptor, returns [this].
+ *
  * @see io.spine.type.KnownTypes
  */
-internal fun GenericDescriptor.fromResources(): GenericDescriptor {
+internal fun GenericDescriptor.withSourceLines(): GenericDescriptor {
     val typeUrl = TypeUrl.of(this)
-    val typeName = typeUrl.toTypeName()
-    return typeName.genericDescriptor()
+    return if (KnownTypes.instance().contains(typeUrl)) {
+        val typeName = typeUrl.toTypeName()
+        typeName.genericDescriptor()
+    } else {
+        this
+    }
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
@@ -26,7 +26,10 @@
 
 package io.spine.protodata.protobuf
 
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.GenericDescriptor
+import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.type.KnownTypes
 import io.spine.type.TypeUrl
 
@@ -39,6 +42,9 @@ import io.spine.type.TypeUrl
  * @see io.spine.type.KnownTypes
  */
 internal fun GenericDescriptor.withSourceLines(): GenericDescriptor {
+    require(this is Descriptor || this is EnumDescriptor || this is ServiceDescriptor) {
+        "Expecting message, enum, or service descriptor. Got: `$this`."
+    }
     val typeUrl = TypeUrl.ofTypeOrService(this)
     return if (KnownTypes.instance().contains(typeUrl)) {
         val typeName = typeUrl.typeName()

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.protobuf
+
+import com.google.protobuf.Descriptors.GenericDescriptor
+import io.spine.type.TypeUrl
+
+/**
+ * Obtains the version of this descriptor with source line information loaded from
+ * the descriptor set files stored in resources.
+ *
+ * @see io.spine.type.KnownTypes
+ */
+internal fun GenericDescriptor.fromResources(): GenericDescriptor {
+    val typeUrl = TypeUrl.of(this)
+    val typeName = typeUrl.toTypeName()
+    return typeName.genericDescriptor()
+}

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
@@ -39,9 +39,9 @@ import io.spine.type.TypeUrl
  * @see io.spine.type.KnownTypes
  */
 internal fun GenericDescriptor.withSourceLines(): GenericDescriptor {
-    val typeUrl = TypeUrl.of(this)
+    val typeUrl = TypeUrl.ofTypeOrService(this)
     return if (KnownTypes.instance().contains(typeUrl)) {
-        val typeName = typeUrl.toTypeName()
+        val typeName = typeUrl.typeName()
         typeName.genericDescriptor()
     } else {
         this

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
@@ -36,6 +36,7 @@ import io.spine.protodata.ast.Rpc
 import io.spine.protodata.ast.RpcName
 import io.spine.protodata.ast.ServiceName
 import io.spine.protodata.ast.copy
+import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.rpc
 import io.spine.protodata.ast.rpcName
 import io.spine.protodata.ast.toList
@@ -86,6 +87,6 @@ public fun buildRpc(
     cardinality = desc.cardinality
     requestType = desc.inputType.name()
     responseType = desc.outputType.name()
-    doc = desc.fileDoc.forRpc(desc)
+    doc = desc.documentation().forRpc(desc)
     service = declaringService
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
@@ -89,6 +89,7 @@ public fun buildRpc(
     requestType = desc.inputType.name()
     responseType = desc.outputType.name()
     service = declaringService
-    doc = desc.documentation().forRpc(desc)
-    span = desc.coordinates().forRpc(desc)
+    val serviceDescr = desc.service
+    doc = serviceDescr.documentation().forRpc(desc)
+    span = serviceDescr.coordinates().forRpc(desc)
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
@@ -35,6 +35,7 @@ import io.spine.protodata.ast.CallCardinality.UNARY
 import io.spine.protodata.ast.Rpc
 import io.spine.protodata.ast.RpcName
 import io.spine.protodata.ast.ServiceName
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.rpc
@@ -87,6 +88,7 @@ public fun buildRpc(
     cardinality = desc.cardinality
     requestType = desc.inputType.name()
     responseType = desc.outputType.name()
-    doc = desc.documentation().forRpc(desc)
     service = declaringService
+    doc = desc.documentation().forRpc(desc)
+    span = desc.coordinates().forRpc(desc)
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -49,6 +49,7 @@ public fun OneofDescriptor.toOneOfGroup(): OneofGroup =
         name = groupName
         field.addAll(fields.mapped())
         option.addAll(options.toList())
-        doc = documentation().forOneof(this@toOneOfGroup)
-        span = coordinates().forOneof(this@toOneOfGroup)
+        val messageType = containingType
+        doc = messageType.documentation().forOneof(this@toOneOfGroup)
+        span = messageType.coordinates().forOneof(this@toOneOfGroup)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.protobuf
 import com.google.protobuf.Descriptors.OneofDescriptor
 import io.spine.protodata.ast.OneofGroup
 import io.spine.protodata.ast.OneofName
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.oneofName
@@ -49,4 +50,5 @@ public fun OneofDescriptor.toOneOfGroup(): OneofGroup =
         field.addAll(fields.mapped())
         option.addAll(options.toList())
         doc = documentation().forOneof(this@toOneOfGroup)
+        span = coordinates().forOneof(this@toOneOfGroup)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.protobuf
 import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.protodata.ast.Service
 import io.spine.protodata.ast.ServiceName
+import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.service
 import io.spine.protodata.ast.serviceName
@@ -54,4 +55,5 @@ public fun ServiceDescriptor.toService(): Service =
         rpc.addAll(methods.map { it.toRpc(serviceName) })
         option.addAll(options.toList())
         doc = documentation().forService(this@toService)
+        span = coordinates().forService(this@toService)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
@@ -52,8 +52,8 @@ public fun ServiceDescriptor.toService(): Service =
         val serviceName = name()
         name = serviceName
         file = getFile().file()
-        rpc.addAll(methods.map { it.toRpc(serviceName) })
         option.addAll(options.toList())
+        rpc.addAll(methods.map { it.toRpc(serviceName) })
         doc = documentation().forService(this@toService)
         span = coordinates().forService(this@toService)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.protobuf
 import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.protodata.ast.Service
 import io.spine.protodata.ast.ServiceName
+import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.service
 import io.spine.protodata.ast.serviceName
 import io.spine.protodata.ast.toList
@@ -47,11 +48,10 @@ public fun ServiceDescriptor.name(): ServiceName = serviceName {
  */
 public fun ServiceDescriptor.toService(): Service =
     service {
-        val docs = fileDoc
         val serviceName = name()
         name = serviceName
         file = getFile().file()
         rpc.addAll(methods.map { it.toRpc(serviceName) })
         option.addAll(options.toList())
-        doc = docs.forService(this@toService)
+        doc = documentation().forService(this@toService)
     }

--- a/api/src/main/kotlin/io/spine/protodata/util/Cache.kt
+++ b/api/src/main/kotlin/io/spine/protodata/util/Cache.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.util
+
+import com.sksamuel.aedile.core.cacheBuilder
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Abstract base for classes caching instances of [V] created for keys of the type [K].
+ *
+ * @param K The type in response to which cached values are created.
+ * @param V The type of values stored in the cache.
+ *
+ * @param initialCapacity The initial capacity of the cache.
+ */
+public abstract class Cache<K: Any, V: Any>(private val initialCapacity: Int = 100) {
+
+    @Suppress("MemberNameEqualsClassName")
+    private val cache = cacheBuilder<K, V> {
+        initialCapacity = this@Cache.initialCapacity
+    }.build()
+
+    /**
+     * Creates an instance of the cached value for the given key.
+     *
+     * @param key The key for creating the value.
+     * @param param Additional parameter for creating the value.
+     * @see get
+     */
+    protected abstract fun create(key: K, param: Any?): V
+
+    /**
+     * Obtains or creates an instance for the given file.
+     *
+     * @param key The key for obtaining the value.
+     * @param param Additional parameter for creating the value.
+     * @see create
+     */
+    protected fun get(key: K, param: Any? = null): V {
+        return synchronized(this) {
+            runBlocking {
+                cache.get(key) {
+                    create(key, param)
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears the cache.
+     *
+     * Clearing the cache may be useful in between tests to avoid stale instances.
+     */
+    public fun clearCache() {
+        synchronized(this) {
+            cache.invalidateAll()
+        }
+    }
+}

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -125,6 +125,9 @@ message MessageType {
 
     // Documentation of this type.
     Doc doc = 9;
+
+    // Coordinates of the declaration.
+    Span span = 10;
 }
 
 // A Protobuf enum type.
@@ -154,6 +157,9 @@ message EnumType {
 
     // Documentation of this type.
     Doc doc = 6;
+
+    // Coordinates of the declaration.
+    Span span = 7;
 }
 
 // A name of an enum constant.
@@ -189,6 +195,9 @@ message EnumConstant {
 
     // Documentation of this constant.
     Doc doc = 7;
+
+    // Coordinates of the declaration.
+    Span span = 8;
 }
 
 // A primitive Protobuf type.
@@ -336,6 +345,9 @@ message Field {
 
     // Documentation of this field.
     Doc doc = 8;
+
+    // Coordinates of the declaration.
+    Span span = 9;
 }
 
 // Name of a group of fields.
@@ -503,7 +515,7 @@ message Doc {
     //
     string leading_comment = 1;
 
-    // The comment placed beneath above the declaration without any empty lines.
+    // The comment placed beneath the declaration without any empty lines.
     string trailing_comment = 2;
 
     // Comments placed above the declaration separated by at least
@@ -513,4 +525,27 @@ message Doc {
     // but rather to its context.
     //
     repeated string detached_comment = 3;
+}
+
+// The location span of a Protobuf declaration.
+//
+// Values of the fields are 1-based.
+// Zero values mean that the location is unknown.
+//
+message Span {
+
+    // The line where the declaration is started.
+    int32 start_line = 1;
+
+    // The column where the declaration is started.
+    int32 start_column = 2;
+
+    // The line where the declaration ends.
+    //
+    // Contains the same value as `start_line` for one line declarations.
+    //
+    int32 end_line = 3;
+
+    // The column where the declaration ends.
+    int32 end_column = 4;
 }

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -84,13 +84,13 @@ message MessageType {
     TypeName name = 1 [(required) = true];
 
     // Path to the file which declares this type.
-    File file = 5 [(required) = true];
+    File file = 2 [(required) = true];
 
     // Name of the message type which hosts the declaration of this type.
     //
     // This field is empty for the top level message type.
     //
-    TypeName declared_in = 6;
+    TypeName declared_in = 3;
 
     // Message-level options.
     repeated Option option = 4 [(distinct) = true];
@@ -101,13 +101,13 @@ message MessageType {
     //
     // The fields are ordered by their order of declaration in the message.
     //
-    repeated Field field = 2;
+    repeated Field field = 5;
 
     // The field groups defined in this type.
     //
     // The `oneof`s are ordered by their order of declaration in the message.
     //
-    repeated OneofGroup oneof_group = 3 [(distinct) = true];
+    repeated OneofGroup oneof_group = 6 [(distinct) = true];
 
     // Message type declarations nested inside this type.
     //
@@ -407,14 +407,14 @@ message Service {
     // Path to the file which declares this service.
     File file = 2;
 
+    // Service-level options.
+    repeated Option option = 3 [(distinct) = true];
+
     // The remote procedure call methods exposed by this service.
     //
     // The methods are ordered by their order of declaration in the service.
     //
-    repeated Rpc rpc = 3 [(distinct) = true];
-
-    // Service-level options.
-    repeated Option option = 4 [(distinct) = true];
+    repeated Rpc rpc = 4 [(distinct) = true];
 
     // Documentation of this service.
     Doc doc = 5;

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -83,6 +83,18 @@ message MessageType {
 
     TypeName name = 1 [(required) = true];
 
+    // Path to the file which declares this type.
+    File file = 5 [(required) = true];
+
+    // Name of the message type which hosts the declaration of this type.
+    //
+    // This field is empty for the top level message type.
+    //
+    TypeName declared_in = 6;
+
+    // Message-level options.
+    repeated Option option = 4 [(distinct) = true];
+
     // The fields of this type.
     //
     // Does not include the fields belonging to a field group.
@@ -96,18 +108,6 @@ message MessageType {
     // The `oneof`s are ordered by their order of declaration in the message.
     //
     repeated OneofGroup oneof_group = 3 [(distinct) = true];
-
-    // Message-level options.
-    repeated Option option = 4 [(distinct) = true];
-
-    // Path to the file which declares this type.
-    File file = 5 [(required) = true];
-
-    // Name of the message type which hosts the declaration of this type.
-    //
-    // This field is empty for the top level message type.
-    //
-    TypeName declared_in = 6;
 
     // Message type declarations nested inside this type.
     //
@@ -373,6 +373,9 @@ message OneofGroup {
 
     // Documentation of this group.
     Doc doc = 4;
+
+    // Coordinates of the declaration.
+    Span span = 5;
 }
 
 // A name of a Protobuf service type.
@@ -401,20 +404,23 @@ message Service {
 
     ServiceName name = 1 [(required) = true];
 
+    // Path to the file which declares this service.
+    File file = 2;
+
     // The remote procedure call methods exposed by this service.
     //
     // The methods are ordered by their order of declaration in the service.
     //
-    repeated Rpc rpc = 2 [(distinct) = true];
+    repeated Rpc rpc = 3 [(distinct) = true];
 
     // Service-level options.
-    repeated Option option = 3 [(distinct) = true];
+    repeated Option option = 4 [(distinct) = true];
 
     // Documentation of this service.
-    Doc doc = 4;
+    Doc doc = 5;
 
-    // Path to the file which declares this service.
-    File file = 5;
+    // Coordinates of the declaration.
+    Span span = 6;
 }
 
 // A name of an RPC method.
@@ -428,27 +434,30 @@ message Rpc {
 
     RpcName name = 1 [(required) = true];
 
+    // The service declaring this remote procedure.
+    ServiceName service = 2 [(required) = true];
+
     // The kind of call.
     //
     // A call may accept one request or a stream of requests and produce
     // one response or a stream of responses.
     //
-    CallCardinality cardinality = 2 [(required) = true];
+    CallCardinality cardinality = 3 [(required) = true];
 
     // The type of the request messages.
-    TypeName request_type = 3 [(required) = true];
+    TypeName request_type = 4 [(required) = true];
 
     // The type of the response messages.
-    TypeName response_type = 4 [(required) = true];
+    TypeName response_type = 5 [(required) = true];
 
     // `rpc`-level options.
-    repeated Option option = 5 [(distinct) = true];
+    repeated Option option = 6 [(distinct) = true];
 
     // Documentation of this `rpc`.
-    Doc doc = 6;
+    Doc doc = 7;
 
-    // The service declaring this method.
-    ServiceName service = 7 [(required) = true];
+    // The coordinates of the declaration.
+    Span span = 8;
 }
 
 // The kind of exchange between a client and a server in a single `rpc` call.

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
@@ -27,7 +27,14 @@
 package io.spine.protodata.ast
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
+import io.spine.protodata.ast.given.Driver
+import io.spine.protodata.ast.given.Tractor
+import io.spine.protodata.protobuf.toMessageType
+import io.spine.type.KnownTypes
+import io.spine.type.TypeUrl
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -74,6 +81,33 @@ internal class FieldExtsSpec {
                 .buildPartial()
 
             field.isRepeated shouldBe false
+        }
+    }
+
+    @Test
+    fun `add field documentation`() {
+        val typeUrl = TypeUrl.of(Tractor::class.java)
+        val mt = typeUrl.toTypeName().messageDescriptor()
+        val field = mt.toMessageType().field("driver")
+        val doc = field.doc
+        doc.run {
+            leadingComment shouldContain "This is the leading comment"
+            trailingComment shouldContain "This is the trailing comment"
+            detachedCommentList.find { it.contains("detached comment") } shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `add field coordinates`() {
+        val typeUrl = TypeUrl.of(Driver::class.java)
+        val mt = typeUrl.toTypeName().messageDescriptor()
+        val field = mt.toMessageType().field("license_number")
+        val span = field.span
+        span.run {
+            startLine shouldBe 69
+            startColumn shouldBe 5
+            endLine shouldBe 69
+            endColumn shouldBe 51
         }
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
@@ -33,8 +33,6 @@ import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
 import io.spine.protodata.ast.given.Driver
 import io.spine.protodata.ast.given.Tractor
 import io.spine.protodata.protobuf.toMessageType
-import io.spine.type.KnownTypes
-import io.spine.type.TypeUrl
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -86,9 +84,7 @@ internal class FieldExtsSpec {
 
     @Test
     fun `add field documentation`() {
-        val typeUrl = TypeUrl.of(Tractor::class.java)
-        val mt = typeUrl.toTypeName().messageDescriptor()
-        val field = mt.toMessageType().field("driver")
+        val field = Tractor.getDescriptor().toMessageType().field("driver")
         val doc = field.doc
         doc.run {
             leadingComment shouldContain "This is the leading comment"
@@ -99,9 +95,7 @@ internal class FieldExtsSpec {
 
     @Test
     fun `add field coordinates`() {
-        val typeUrl = TypeUrl.of(Driver::class.java)
-        val mt = typeUrl.toTypeName().messageDescriptor()
-        val field = mt.toMessageType().field("license_number")
+        val field = Driver.getDescriptor().toMessageType().field("license_number")
         val span = field.span
         span.run {
             startLine shouldBe 69

--- a/api/src/test/proto/protodata/ast/field_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/field_exts_spec.proto
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package spine.protodata.ast;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.ast.given";
+option java_outer_classname = "FieldExtsSpecProto";
+option java_multiple_files = true;
+
+// A simple message with a message-level option and fields with options.
+message Tractor {
+
+    // An example of docs for a message level option.
+    // The option is multi-line.
+    option (entity) = {
+        kind: ENTITY
+        visibility: FULL
+    };
+
+    // The driver of the tractor. This is the leading comment.
+    Driver driver = 1 [
+        // A tractor may not have a driver, but if it has, it must be valid.
+        // This is an example of an option comment.
+        (validate) = true
+    ];
+    // This is the trailing comment for the `driver` field.
+
+    // A detached comment above the `plow` field.
+
+    // This is the leading comment for the field.
+    Plow plow = 2 [ /* A one-line option comment. */ (validate) = true];
+}
+
+message Plow {
+    string description = 1 [(required) = true];
+}
+
+message Driver {
+    string name = 1 [(required) = true];
+    string license_number = 2 [(required) = true];
+}

--- a/api/src/test/proto/protodata/ast/field_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/field_exts_spec.proto
@@ -45,6 +45,8 @@ message Tractor {
         visibility: FULL
     };
 
+    // A detached comment above the `driver` field.
+
     // The driver of the tractor. This is the leading comment.
     Driver driver = 1 [
         // A tractor may not have a driver, but if it has, it must be valid.
@@ -53,7 +55,6 @@ message Tractor {
     ];
     // This is the trailing comment for the `driver` field.
 
-    // A detached comment above the `plow` field.
 
     // This is the leading comment for the field.
     Plow plow = 2 [ /* A one-line option comment. */ (validate) = true];

--- a/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
@@ -31,6 +31,8 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.annotation.Internal
 import io.spine.code.proto.FileSet
 import io.spine.environment.DefaultMode
+import io.spine.protodata.ast.Coordinates
+import io.spine.protodata.ast.Documentation
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.plugin.Plugin
@@ -129,10 +131,21 @@ public class Pipeline(
      * should be single-threaded.
      */
     public operator fun invoke() {
-        // Clear the cache of previously parsed files to avoid repeated code generation
-        // when running from tests.
-        SourceFile.clearCache()
+        clearCaches()
         emitEventsAndRenderSources()
+    }
+
+    /**
+     * Clears the static caches that could have been created by previous runs, e.g., when
+     * running from tests.
+     *
+     * Clears the caches of previously parsed files to avoid repeated code generation.
+     * Also, clears the caches of [Documentation] and [Coordinates] classes.
+     */
+    private fun clearCaches() {
+        SourceFile.clearCache()
+        Documentation.clearCache()
+        Coordinates.clearCache()
     }
 
     private fun emitEventsAndRenderSources() {

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -76,13 +76,15 @@ private class ProtoFileEvents(
     private val fileDescriptor: FileDescriptor
 ) {
     private val header = fileDescriptor.toHeader()
-    private val documentation = Documentation(fileDescriptor)
+    private val documentation = Documentation.of(fileDescriptor)
 
     /**
      * Yields compiler events for the given file.
      *
-     * Opens with an [FileEntered] event. Then go the events regarding the file metadata. Then go
-     * the events regarding the file contents. At last, closes with an [FileExited] event.
+     * Opens with an [FileEntered] event.
+     * Then go the events regarding the file metadata.
+     * Then go the events regarding the file contents.
+     * At last, closes with an [FileExited] event.
      */
     suspend fun SequenceScope<EventMessage>.produceFileEvents() {
         yield(

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -30,9 +30,6 @@ import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.base.EventMessage
 import io.spine.code.proto.FileSet
-import io.spine.protodata.ast.Documentation
-import io.spine.protodata.ast.event.FileEntered
-import io.spine.protodata.ast.event.FileExited
 import io.spine.protodata.ast.event.dependencyDiscovered
 import io.spine.protodata.ast.event.fileEntered
 import io.spine.protodata.ast.event.fileExited
@@ -64,7 +61,7 @@ public object CompilerEvents {
             yieldAll(dependencies.map { it.toDependencyEvent() })
             ownFiles
                 .map(::ProtoFileEvents)
-                .forEach { it.apply { produceFileEvents() } }
+                .forEach { it.apply { produceEvents() } }
         }
     }
 }
@@ -73,20 +70,19 @@ public object CompilerEvents {
  * Produces events from the associated file.
  */
 private class ProtoFileEvents(
-    private val fileDescriptor: FileDescriptor
+    private val file: FileDescriptor
 ) {
-    private val header = fileDescriptor.toHeader()
-    private val documentation = Documentation.of(fileDescriptor)
+    private val header = file.toHeader()
 
     /**
      * Yields compiler events for the given file.
      *
-     * Opens with an [FileEntered] event.
+     * Opens with an [FileEntered][io.spine.protodata.ast.event.FileEntered] event.
      * Then go the events regarding the file metadata.
      * Then go the events regarding the file contents.
-     * At last, closes with an [FileExited] event.
+     * At last, closes with an [FileExited][io.spine.protodata.ast.event.FileExited] event.
      */
-    suspend fun SequenceScope<EventMessage>.produceFileEvents() {
+    suspend fun SequenceScope<EventMessage>.produceEvents() {
         yield(
             fileEntered {
                 // Avoid the name clash with the class property.
@@ -95,25 +91,23 @@ private class ProtoFileEvents(
                 header = hdr
             }
         )
-        produceOptionEvents(fileDescriptor.options) {
+        produceOptionEvents(file.options) {
             fileOptionDiscovered {
                 file = header.file
                 option = it
             }
         }
-        val messageEvents = MessageCompilerEvents(header, documentation)
-        fileDescriptor.messageTypes.forEach {
-            messageEvents.apply { produceMessageEvents(it) }
+        val messageEvents = MessageCompilerEvents(header)
+        file.messageTypes.forEach {
+            messageEvents.apply { produceEvents(it) }
         }
-        //TODO:2024-11-30:alexander.yevsyukov: Where's documentation?
         val enumEvents = EnumCompilerEvents(header)
-        fileDescriptor.enumTypes.forEach {
-            enumEvents.apply { produceEnumEvents(it) }
+        file.enumTypes.forEach {
+            enumEvents.apply { produceEvents(it) }
         }
-        //TODO:2024-11-30:alexander.yevsyukov: Where's documentation?
         val serviceEvents = ServiceCompilerEvents(header)
-        fileDescriptor.services.forEach {
-            serviceEvents.apply { produceServiceEvents(it) }
+        file.services.forEach {
+            serviceEvents.apply { produceEvents(it) }
         }
         yield(
             fileExited {

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -103,10 +103,12 @@ private class ProtoFileEvents(
         fileDescriptor.messageTypes.forEach {
             messageEvents.apply { produceMessageEvents(it) }
         }
+        //TODO:2024-11-30:alexander.yevsyukov: Where's documentation?
         val enumEvents = EnumCompilerEvents(header)
         fileDescriptor.enumTypes.forEach {
             enumEvents.apply { produceEnumEvents(it) }
         }
+        //TODO:2024-11-30:alexander.yevsyukov: Where's documentation?
         val serviceEvents = ServiceCompilerEvents(header)
         fileDescriptor.services.forEach {
             serviceEvents.apply { produceServiceEvents(it) }

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
@@ -31,10 +31,6 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor
 import io.spine.base.EventMessage
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.constantName
-import io.spine.protodata.ast.event.EnumConstantEntered
-import io.spine.protodata.ast.event.EnumConstantExited
-import io.spine.protodata.ast.event.EnumEntered
-import io.spine.protodata.ast.event.EnumExited
 import io.spine.protodata.ast.event.enumConstantEntered
 import io.spine.protodata.ast.event.enumConstantExited
 import io.spine.protodata.ast.event.enumConstantOptionDiscovered
@@ -57,12 +53,12 @@ internal class EnumCompilerEvents(
     /**
      * Yields compiler events for the given enum type.
      *
-     * Opens with an [EnumEntered] event.
+     * Opens with an [EnumEntered][io.spine.protodata.ast.event.EnumEntered] event.
      * Then the events regarding the type metadata go.
      * Then go the events regarding the enum constants.
-     * At last, closes with an [EnumExited] event.
+     * At last, closes with an [EnumExited][io.spine.protodata.ast.event.EnumExited] event.
      */
-    internal suspend fun SequenceScope<EventMessage>.produceEnumEvents(
+    internal suspend fun SequenceScope<EventMessage>.produceEvents(
         desc: EnumDescriptor
     ) {
         val enumType = desc.toEnumType()
@@ -101,9 +97,10 @@ internal class EnumCompilerEvents(
     /**
      * Yields compiler events for the given enum constant.
      *
-     * Opens with an [EnumConstantEntered] event.
+     * Opens with an [EnumConstantEntered][io.spine.protodata.ast.event.EnumConstantEntered] event.
      * Then go the events regarding the constant options.
-     * At last, closes with an [EnumConstantExited] event.
+     * At last, closes with an
+     * [EnumConstantExited][io.spine.protodata.ast.event.EnumConstantExited] event.
      */
     private suspend fun SequenceScope<EventMessage>.produceConstantEvents(
         desc: EnumValueDescriptor

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -30,7 +30,6 @@ import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import io.spine.base.EventMessage
-import io.spine.protodata.ast.Coordinates
 import io.spine.protodata.ast.Documentation
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.event.FieldEntered

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -36,8 +36,6 @@ import io.spine.protodata.ast.event.FieldEntered
 import io.spine.protodata.ast.event.FieldExited
 import io.spine.protodata.ast.event.OneofGroupEntered
 import io.spine.protodata.ast.event.OneofGroupExited
-import io.spine.protodata.ast.event.TypeEntered
-import io.spine.protodata.ast.event.TypeExited
 import io.spine.protodata.ast.event.fieldEntered
 import io.spine.protodata.ast.event.fieldExited
 import io.spine.protodata.ast.event.fieldOptionDiscovered
@@ -58,21 +56,20 @@ import io.spine.protodata.protobuf.toMessageType
  * Produces events for a message.
  */
 internal class MessageCompilerEvents(
-    private val header: ProtoFileHeader,
-    private val documentation: Documentation
+    private val header: ProtoFileHeader
 ) {
     /**
      * Yields compiler events for the given message type.
      *
-     * Starts with an [TypeEntered] event.
+     * Starts with [TypeDiscovered][io.spine.protodata.ast.event.TypeDiscovered] and
+     * [io.spine.protodata.ast.event.TypeEntered] events.
      * Then the events regarding the type metadata come.
      * Then go the events regarding the fields.
-     * At last, closes with an [TypeExited] event.
+     * At last, closes with an [TypeExited][io.spine.protodata.ast.event.TypeExited] event.
      *
-     * @param desc
-     *         the descriptor of a Protobuf [Message] type.
+     * @param desc The descriptor of the message type.
      */
-    internal suspend fun SequenceScope<EventMessage>.produceMessageEvents(
+    internal suspend fun SequenceScope<EventMessage>.produceEvents(
         desc: Descriptor
     ) {
         val typeName = desc.name()
@@ -107,13 +104,13 @@ internal class MessageCompilerEvents(
             .forEach { produceFieldEvents(it) }
 
         desc.nestedTypes.forEach {
-            produceMessageEvents(desc = it)
+            produceEvents(desc = it)
         }
 
         val enums = EnumCompilerEvents(header)
         desc.enumTypes.forEach {
             enums.apply {
-                produceEnumEvents(desc = it)
+                produceEvents(desc = it)
             }
         }
 
@@ -137,6 +134,7 @@ internal class MessageCompilerEvents(
         desc: OneofDescriptor
     ) {
         val typeName = desc.containingType.name()
+        val documentation = Documentation.of(desc.containingType.file)
         val oneofName = desc.name()
         val oneofGroup = oneofGroup {
             name = oneofName

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -30,6 +30,7 @@ import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import io.spine.base.EventMessage
+import io.spine.protodata.ast.Coordinates
 import io.spine.protodata.ast.Documentation
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.event.FieldEntered

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -50,7 +50,7 @@ import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.produceOptionEvents
 import io.spine.protodata.protobuf.buildField
 import io.spine.protodata.protobuf.name
-import io.spine.protodata.protobuf.nestedTypes
+import io.spine.protodata.protobuf.realNestedTypes
 import io.spine.protodata.protobuf.toMessageType
 
 /**
@@ -104,7 +104,7 @@ internal class MessageCompilerEvents(
             .filter { it.realContainingOneof == null }
             .forEach { produceFieldEvents(it) }
 
-        desc.nestedTypes().forEach {
+        desc.realNestedTypes().forEach {
             produceEvents(desc = it)
         }
 

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -50,6 +50,7 @@ import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.produceOptionEvents
 import io.spine.protodata.protobuf.buildField
 import io.spine.protodata.protobuf.name
+import io.spine.protodata.protobuf.nestedTypes
 import io.spine.protodata.protobuf.toMessageType
 
 /**
@@ -103,7 +104,7 @@ internal class MessageCompilerEvents(
             .filter { it.realContainingOneof == null }
             .forEach { produceFieldEvents(it) }
 
-        desc.nestedTypes.forEach {
+        desc.nestedTypes().forEach {
             produceEvents(desc = it)
         }
 

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
@@ -54,10 +54,12 @@ internal class ServiceCompilerEvents(
     /**
      * Yields compiler events for the given service.
      *
-     * Opens with an [ServiceEntered] event. Then go the events regarding the service metadata.
-     * Then go the events regarding the RPC methods. At last, closes with an [ServiceExited] event.
+     * Opens with an [ServiceEntered] event.
+     * Then go the events regarding the service metadata.
+     * Then go the events regarding the RPC methods.
+     * At last, closes with an [ServiceExited] event.
      */
-    internal suspend fun SequenceScope<EventMessage>.produceServiceEvents(
+    internal suspend fun SequenceScope<EventMessage>.produceEvents(
         desc: ServiceDescriptor
     ) {
         val path = header.file

--- a/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-proto-model.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
 
 configurations.all {
     if(name.endsWith("ProtoPath")) {
-        System.err.println(" --- Configuring `$name` with `${Spine.baseForBuildScript}`. ---")
         resolutionStrategy.force(
             Spine.baseForBuildScript
         )

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
@@ -37,8 +37,8 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
      */
-    const val base = "2.0.0-SNAPSHOT.220"
-    const val baseForBuildScript = "2.0.0-SNAPSHOT.220"
+    const val base = "2.0.0-SNAPSHOT.221"
+    const val baseForBuildScript = "2.0.0-SNAPSHOT.221"
 
     /**
      * The version of [Spine.reflect].

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
@@ -37,8 +37,8 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
      */
-    const val base = "2.0.0-SNAPSHOT.221"
-    const val baseForBuildScript = "2.0.0-SNAPSHOT.221"
+    const val base = "2.0.0-SNAPSHOT.223"
+    const val baseForBuildScript = "2.0.0-SNAPSHOT.223"
 
     /**
      * The version of [Spine.reflect].

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.258"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.259"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.258"
+    const val version = "2.0.0-SNAPSHOT.259"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.69.4"
+    private const val fallbackVersion = "0.69.5"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.69.4"
+    private const val fallbackDfVersion = "0.69.5"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.176"
+    const val version = "2.0.0-SNAPSHOT.177"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -55,7 +55,6 @@ plugins {
 
 apply {
     plugin(Dokka.GradlePlugin.id)
-    plugin(Protobuf.GradlePlugin.id)
 }
 
 apply<IncrementGuard>()

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:20 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Thu Nov 28 20:14:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Thu Nov 28 20:14:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Thu Nov 28 20:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Thu Nov 28 20:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:11 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Thu Nov 28 20:14:11 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 28 20:14:11 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 19:38:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Mon Dec 02 18:01:13 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 16:48:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sat Nov 30 20:45:57 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 20:46:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 01 19:11:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-api:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:20 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:57 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.69.6`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1858,12 +1858,12 @@ This report was generated on **Sat Nov 30 19:38:20 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-backend:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2884,12 +2884,12 @@ This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-cli:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3933,12 +3933,12 @@ This report was generated on **Sat Nov 30 19:38:21 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:58 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4941,12 +4941,12 @@ This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5953,12 +5953,12 @@ This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:45:59 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7142,12 +7142,12 @@ This report was generated on **Sat Nov 30 19:38:22 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-java:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8168,12 +8168,12 @@ This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.69.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9006,12 +9006,12 @@ This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10047,12 +10047,12 @@ This report was generated on **Sat Nov 30 19:38:23 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:46:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.69.5`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.69.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11158,4 +11158,4 @@ This report was generated on **Sat Nov 30 19:38:24 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 30 19:38:24 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 30 20:46:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sun Dec 01 19:11:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Sun Dec 01 19:11:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Sun Dec 01 19:11:34 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Sun Dec 01 19:11:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Sun Dec 01 19:11:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 01 19:11:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:13 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Mon Dec 02 17:36:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:14 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Mon Dec 02 17:36:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Mon Dec 02 17:36:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 17:36:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:01:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.69.5</version>
+<version>0.69.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.176</version>
+    <version>2.0.0-SNAPSHOT.177</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -267,12 +267,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.69.2</version>
+    <version>0.69.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.69.2</version>
+    <version>0.69.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -282,13 +282,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.258</version>
+    <version>2.0.0-SNAPSHOT.259</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.258</version>
+    <version>2.0.0-SNAPSHOT.259</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -303,7 +303,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.175</version>
+    <version>2.0.0-SNAPSHOT.177</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.221</version>
+    <version>2.0.0-SNAPSHOT.223</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.220</version>
+    <version>2.0.0-SNAPSHOT.221</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.69.5")
+val protoDataVersion: String by extra("0.69.6")


### PR DESCRIPTION
This PR provides initial API for dealing with compilation errors and warnings.

## Line number information
The PR introduces the `Span` type which provides coordinates for Protobuf declarations. Corresponding AST types were extended with the `span` fields.

Also, the helper class called `Coordinates` was introduced. It is similar to the `Documentation` class which helps with creation of `Doc` instances. 

Now both `Documentation` and `Coordinates` classes have the common `Locations` base. 
Instances of `Documentation` and `Coordinates` are created after `FileDescriptorProto` and are cached using the new `Cache` utility class.

The extension `GenericDescriptor.withSourceLines()` extension which tries to load a version of `GenericDescriptor` from a descriptor set file stored in resources. `Documentation` and `Coordinates` use this extension.

## Other notable changes
 * The caching of `SourceFile` instances was updated to use the new `Cache` class.
 * Added `Descriptor.nestedTypes()` extension function which filters the output of `getNestedTypes()` removing synthetic descriptors created for entry types of map fields.

