### PR TITLE
`doc` and `span` properties for options

### DIFF
--- a/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
+++ b/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
@@ -1,0 +1,73 @@
+#
+# Periodically removes obsolete artifacts from GitHub Packages.
+#
+# Only non-release artifacts—those containing "SNAPSHOT" in their version name—are eligible
+# for removal. The latest non-release artifacts will be retained, with the exact number determined
+# by the `VERSION_COUNT_TO_KEEP` environment variable.
+#
+# Please note the following details:
+#
+# 1. An artifact cannot be deleted if it is public and has been downloaded more than 5,000 times.
+#   In this scenario, contact GitHub support for further assistance.
+#
+# 2. This workflow only applies to artifacts published from this repository.
+#
+# 3. A maximum of 100 artifacts can be removed per run from each package;
+#   if there are more than 100 obsolete artifacts, either manually restart the workflow
+#   or wait for the next scheduled removal.
+#
+# 4. When artifacts with version `x.x.x-SNAPSHOT` are published, GitHub automatically appends
+#   the current timestamp, resulting in versions like `x.x.x-SNAPSHOT.20241024.173759`.
+#   All such artifacts are grouped into one package and treated as a single package
+#   in GitHub Packages with the version `x.x.x-SNAPSHOT`. Consequently, it is not possible
+#   to remove obsolete versions within a package; only the entire package can be deleted.
+#
+
+name: Remove obsolete Maven artifacts from GitHub Packages
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight.
+
+env:
+  VERSION_COUNT_TO_KEEP: 5  # Number of most recent SNAPSHOT versions to retain.
+
+jobs:
+  retrieve-package-names:
+    name: Retrieve the package names published from this repository
+    runs-on: ubuntu-latest
+    outputs:
+      package-names: ${{ steps.request-package-names.outputs.package-names }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Retrieve the names of packages
+        id: request-package-names
+        shell: bash
+        run: |
+          repoName=$(echo ${{ github.repository }} | cut -d '/' -f2)
+          chmod +x ./config/scripts/request-package-names.sh
+          ./config/scripts/request-package-names.sh ${{ github.token }} \
+                $repoName ${{ github.repository_owner }} ./package-names.json
+          echo "package-names=$(<./package-names.json)" >> $GITHUB_OUTPUT
+
+  delete-obsolete-artifacts:
+    name: Remove obsolete artifacts published from this repository to GitHub Packages
+    needs: retrieve-package-names
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package-name: ${{ fromJson(needs.retrieve-package-names.outputs.package-names) }}
+    steps:
+      - name: Remove obsolete artifacts from '${{ matrix.package-name }}' package
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: ${{ matrix.package-name }}
+          package-type: 'maven'
+          token: ${{ github.token }}
+          min-versions-to-keep: ${{ env.VERSION_COUNT_TO_KEEP }}
+          # Ignores artifacts that do not contain the word "SNAPSHOT".
+          ignore-versions: '^(?!.+SNAPSHOT).*$'

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -146,11 +146,13 @@
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
     <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
@@ -192,6 +194,7 @@
       <option name="ignoreLocalVariables" value="false" />
       <option name="ignorePrivateMethodsAndFields" value="false" />
     </inspection_tool>
+    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -575,6 +578,7 @@
     </inspection_tool>
     <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -619,9 +623,6 @@
     </inspection_tool>
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="TYPO" enabled_by_default="true">
-      <scope name="Production" level="WARNING" enabled="true" />
-    </inspection_tool>
     <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInconvertibleTypes" value="true" />
     </inspection_tool>
@@ -689,6 +690,7 @@
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
+    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -709,6 +711,7 @@
     <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
@@ -747,10 +750,13 @@
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -784,6 +790,7 @@
     <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="3" />
     </inspection_tool>
@@ -804,6 +811,7 @@
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Problems" level="INFO" enabled="true">

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -101,6 +101,13 @@ public class Coordinates private constructor(file: FileDescriptorProto) : Locati
         return spanAt(path)
     }
 
+    /**
+     * Obtains the span of the option declared in the given context.
+     *
+     * @param option The descriptor of the option.
+     * @param context The descriptor of the scope in which the option is declared, such as
+     *   a message type, an enumeration, a service, etc.
+     */
     public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Span {
         val path = LocationPath.of(option, context)
         return spanAt(path)

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -102,7 +102,7 @@ public class Coordinates private constructor(file: FileDescriptorProto) : Locati
     }
 
     public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Span {
-        val path = LocationPath.option(option, context)
+        val path = LocationPath.of(option, context)
         return spanAt(path)
     }
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -101,6 +101,11 @@ public class Coordinates private constructor(file: FileDescriptorProto) : Locati
         return spanAt(path)
     }
 
+    public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Span {
+        val path = LocationPath.option(option, context)
+        return spanAt(path)
+    }
+
     private fun spanAt(path: LocationPath): Span {
         val location = locationAt(path)
         return location.toSpan()

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -101,6 +101,11 @@ public class Documentation private constructor(file: FileDescriptorProto) : Loca
         return commentsAt(path)
     }
 
+    public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Doc {
+        val path = LocationPath.option(option, context)
+        return commentsAt(path)
+    }
+
     private fun commentsAt(path: LocationPath): Doc {
         val location = locationAt(path)
         return doc {

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -102,10 +102,11 @@ public class Documentation private constructor(file: FileDescriptorProto) : Loca
     }
 
     /**
-     * Obtains documentation for the given option method.
+     * Obtains documentation for the given option.
      *
      * @param option The descriptor of the option.
-     * @param context The scope in which the option is declared.
+     * @param context The descriptor of the scope in which the option is declared, such as
+     *   a message type, an enumeration, a service, etc.
      */
     public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Doc {
         val path = LocationPath.of(option, context)

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -101,6 +101,12 @@ public class Documentation private constructor(file: FileDescriptorProto) : Loca
         return commentsAt(path)
     }
 
+    /**
+     * Obtains documentation for the given option method.
+     *
+     * @param option The descriptor of the option.
+     * @param context The scope in which the option is declared.
+     */
     public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Doc {
         val path = LocationPath.of(option, context)
         return commentsAt(path)

--- a/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Documentation.kt
@@ -102,7 +102,7 @@ public class Documentation private constructor(file: FileDescriptorProto) : Loca
     }
 
     public fun forOption(option: FieldDescriptor, context: GenericDescriptor): Doc {
-        val path = LocationPath.option(option, context)
+        val path = LocationPath.of(option, context)
         return commentsAt(path)
     }
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
@@ -30,16 +30,24 @@ import com.google.protobuf.DescriptorProtos.DescriptorProto
 import com.google.protobuf.DescriptorProtos.DescriptorProto.FIELD_FIELD_NUMBER
 import com.google.protobuf.DescriptorProtos.DescriptorProto.NESTED_TYPE_FIELD_NUMBER
 import com.google.protobuf.DescriptorProtos.DescriptorProto.ONEOF_DECL_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.EnumDescriptorProto
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto.VALUE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto.SERVICE_FIELD_NUMBER
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
+import com.google.protobuf.DescriptorProtos.OneofDescriptorProto
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER
 import com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
+import com.google.protobuf.Descriptors.FileDescriptor
+import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
@@ -52,6 +60,7 @@ import io.spine.util.interlaced
  *
  * See `google.protobuf.SourceCodeInfo.Location.path` for the explanation of the protocol.
  */
+@Suppress("TooManyFunctions")
 @JvmInline
 internal value class LocationPath
 private constructor(private val value: List<Int>) {
@@ -117,6 +126,54 @@ private constructor(private val value: List<Int>) {
             return rootPath.interlaced(NESTED_TYPE_FIELD_NUMBER)
                 .toList()
                 .reversed()
+        }
+
+        fun option(option: FieldDescriptor, context: GenericDescriptor): LocationPath {
+            val path = when (context) {
+                is FileDescriptor -> ofFileOption(option)
+                is Descriptor -> ofMessageOption(option)
+                is EnumDescriptor -> ofEnumOption(option)
+                is ServiceDescriptor -> ofServiceOption(option)
+                is FieldDescriptor -> ofFieldOption(option)
+                is OneofDescriptor -> ofOneofOption(option)
+                is EnumValueDescriptor -> ofEnumValueOption(option)
+                is MethodDescriptor -> ofMethodOption(option)
+                // Return the non-existing path so that the default `Location` is returned.
+                else -> LocationPath(listOf(-1, -1))
+            }
+            return path
+        }
+
+        private fun ofFileOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(FileDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofMessageOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(DescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofEnumOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(EnumDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofServiceOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(ServiceDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofFieldOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(FieldDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofOneofOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(OneofDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofEnumValueOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(EnumValueDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
+        }
+
+        private fun ofMethodOption(option: FieldDescriptor): LocationPath {
+            return LocationPath(listOf(MethodDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
         }
     }
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
@@ -128,53 +128,30 @@ private constructor(private val value: List<Int>) {
                 .reversed()
         }
 
-        fun option(option: FieldDescriptor, context: GenericDescriptor): LocationPath {
+        fun of(option: FieldDescriptor, context: GenericDescriptor): LocationPath {
             val path = when (context) {
-                is FileDescriptor -> ofFileOption(option)
-                is Descriptor -> ofMessageOption(option)
-                is EnumDescriptor -> ofEnumOption(option)
-                is ServiceDescriptor -> ofServiceOption(option)
-                is FieldDescriptor -> ofFieldOption(option)
-                is OneofDescriptor -> ofOneofOption(option)
-                is EnumValueDescriptor -> ofEnumValueOption(option)
-                is MethodDescriptor -> ofMethodOption(option)
+                is FileDescriptor -> optionAt(FileDescriptorProto.OPTIONS_FIELD_NUMBER, option)
+                is Descriptor -> optionAt(DescriptorProto.OPTIONS_FIELD_NUMBER, option)
+                is EnumDescriptor -> optionAt(EnumDescriptorProto.OPTIONS_FIELD_NUMBER, option)
+                is ServiceDescriptor -> optionAt(
+                    ServiceDescriptorProto.OPTIONS_FIELD_NUMBER,
+                    option
+                )
+                is FieldDescriptor -> optionAt(FieldDescriptorProto.OPTIONS_FIELD_NUMBER, option)
+                is OneofDescriptor -> optionAt(OneofDescriptorProto.OPTIONS_FIELD_NUMBER, option)
+                is EnumValueDescriptor -> optionAt(
+                    EnumValueDescriptorProto.OPTIONS_FIELD_NUMBER,
+                    option
+                )
+                is MethodDescriptor -> optionAt(MethodDescriptorProto.OPTIONS_FIELD_NUMBER, option)
                 // Return the non-existing path so that the default `Location` is returned.
                 else -> LocationPath(listOf(-1, -1))
             }
             return path
         }
 
-        private fun ofFileOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(FileDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofMessageOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(DescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofEnumOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(EnumDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofServiceOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(ServiceDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofFieldOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(FieldDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofOneofOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(OneofDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofEnumValueOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(EnumValueDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
-
-        private fun ofMethodOption(option: FieldDescriptor): LocationPath {
-            return LocationPath(listOf(MethodDescriptorProto.OPTIONS_FIELD_NUMBER, option.index))
-        }
+        private fun optionAt(optionsFieldNumber: Int, option: FieldDescriptor): LocationPath =
+            LocationPath(listOf(optionsFieldNumber, option.toProto().number))
     }
 
     /**
@@ -222,4 +199,3 @@ private val Descriptor.isTopLevel: Boolean
 
 private val EnumDescriptor.isTopLevel: Boolean
     get() = containingType == null
-

--- a/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/LocationPath.kt
@@ -135,6 +135,13 @@ internal constructor(private val value: List<Int>) {
         internal operator fun LocationPath.plus(another: LocationPath): LocationPath =
             LocationPath(value + another.value)
 
+        /**
+         * Obtains a location path of the option declaration.
+         *
+         * @param option The descriptor of the option.
+         * @param context The descriptor of the scope in which the option is declared, such as
+         *   a message type, an enumeration, a service, etc.
+         */
         fun of(option: FieldDescriptor, context: GenericDescriptor): LocationPath {
             val path = when (context) {
                 is FileDescriptor -> optionAt(FileDescriptorProto.OPTIONS_FIELD_NUMBER, option)
@@ -145,7 +152,8 @@ internal constructor(private val value: List<Int>) {
                 is OneofDescriptor -> context.pathOf(option)
                 is EnumValueDescriptor -> context.pathOf(option)
                 is MethodDescriptor -> context.pathOf(option)
-                // Return the non-existing path so that the default `Location` is returned.
+                // Return the non-existing path.
+                // This would make the `Locations` class return the default `Location` instance.
                 else -> LocationPath(listOf(-1, -1))
             }
             return path

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -28,10 +28,16 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.Type.ENUM
+import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.Descriptors.GenericDescriptor
+import com.google.protobuf.Descriptors.MethodDescriptor
+import com.google.protobuf.Descriptors.OneofDescriptor
+import com.google.protobuf.Descriptors.ServiceDescriptor
 import com.google.protobuf.GeneratedMessageV3.ExtendableMessage
 import com.google.protobuf.Message
 import io.spine.base.EventMessage
@@ -99,9 +105,49 @@ public suspend fun SequenceScope<EventMessage>.produceOptionEvents(
 }
 
 /**
+ * Obtains options declared in this file.
+ */
+public fun FileDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this message.
+ */
+public fun Descriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this enumeration.
+ */
+public fun EnumDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this service.
+ */
+public fun ServiceDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this field.
+ */
+public fun FieldDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this oneof.
+ */
+public fun OneofDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this enum item.
+ */
+public fun EnumValueDescriptor.options(): List<Option> = options.toList(this)
+
+/**
+ * Obtains options declared in this `rpc` method.
+ */
+public fun MethodDescriptor.options(): List<Option> = options.toList(this)
+
+/**
  * Parses this `options` message into a list of [Option]s.
  */
-public fun ExtendableMessage<*>.toList(context: GenericDescriptor): List<Option> =
+private fun ExtendableMessage<*>.toList(context: GenericDescriptor): List<Option> =
     parseOptions(context).toList()
 
 private fun ExtendableMessage<*>.parseOptions(context: GenericDescriptor): Sequence<Option> =

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -71,7 +71,7 @@ public fun Descriptor.toMessageType(): MessageType =
         name = name()
         file = getFile().file()
         val self = this@toMessageType
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
         if (containingType != null) {
             declaredIn = containingType.name()
         }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -36,7 +36,7 @@ import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.messageType
-import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.options
 import io.spine.protodata.ast.type
 import io.spine.string.camelCase
 
@@ -71,7 +71,7 @@ public fun Descriptor.toMessageType(): MessageType =
         name = name()
         file = getFile().file()
         val self = this@toMessageType
-        option.addAll(options.toList(self))
+        option.addAll(options())
         if (containingType != null) {
             declaredIn = containingType.name()
         }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -36,10 +36,10 @@ import io.spine.protodata.ast.TypeName
 import io.spine.protodata.ast.constantName
 import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.copy
+import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.enumConstant
 import io.spine.protodata.ast.enumType
-import io.spine.protodata.ast.documentation
-import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.options
 import io.spine.protodata.ast.type
 
 /**
@@ -57,7 +57,7 @@ public fun EnumDescriptor.toEnumType(): EnumType =
         val self = this@toEnumType
         val typeName = name()
         name = typeName
-        option.addAll(options.toList(self))
+        option.addAll(options())
         file = getFile().file()
         constant.addAll(values.map { it.toEnumConstant(typeName) })
         if (containingType != null) {
@@ -85,7 +85,7 @@ public fun EnumValueDescriptor.toEnumConstant(declaringType: TypeName): EnumCons
     val self = this
     val constant = buildConstant(self, declaringType)
     return constant.copy {
-        option.addAll(options.toList(self))
+        option.addAll(options())
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/EnumDescriptorExts.kt
@@ -54,16 +54,17 @@ public fun EnumDescriptor.name(): TypeName = buildTypeName(name, file, containin
  */
 public fun EnumDescriptor.toEnumType(): EnumType =
     enumType {
+        val self = this@toEnumType
         val typeName = name()
         name = typeName
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
         file = getFile().file()
         constant.addAll(values.map { it.toEnumConstant(typeName) })
         if (containingType != null) {
             declaredIn = containingType.name()
         }
-        doc = documentation().forEnum(this@toEnumType)
-        span = coordinates().forEnum(this@toEnumType)
+        doc = documentation().forEnum(self)
+        span = coordinates().forEnum(self)
     }
 
 /**
@@ -81,9 +82,10 @@ public fun EnumDescriptor.toType(): Type = type {
  * @see buildConstant
  */
 public fun EnumValueDescriptor.toEnumConstant(declaringType: TypeName): EnumConstant {
-    val constant = buildConstant(this, declaringType)
+    val self = this
+    val constant = buildConstant(self, declaringType)
     return constant.copy {
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -74,7 +74,7 @@ import io.spine.protodata.ast.field
 import io.spine.protodata.ast.fieldName
 import io.spine.protodata.ast.fieldType
 import io.spine.protodata.ast.mapEntryType
-import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.options
 import io.spine.protodata.ast.toType
 import io.spine.protodata.ast.type
 import kotlin.reflect.KClass
@@ -97,7 +97,7 @@ public fun FieldDescriptor.toField(): Field {
         // the `option.addAll()` call below. Sadly, these duplicates
         // could not be refactored into a common function because
         // they have no common compile-time type.
-        option.addAll(options.toList(self))
+        option.addAll(options())
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FieldDescriptorExts.kt
@@ -90,13 +90,14 @@ public fun FieldDescriptor.name(): FieldName = fieldName { value = name }
  * @see buildField
  */
 public fun FieldDescriptor.toField(): Field {
-    val field = buildField(this)
+    val self = this
+    val field = buildField(self)
     return field.copy {
         // There are several similar expressions in this file, like
         // the `option.addAll()` call below. Sadly, these duplicates
         // could not be refactored into a common function because
         // they have no common compile-time type.
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
@@ -133,8 +133,7 @@ private fun <T : ProtoDeclaration> Sequence<T>.associateByUrl() =
 /**
  * A factory of Protobuf definitions of a single `.proto` file.
  *
- * @property file
- *            the descriptor of the Protobuf file.
+ * @property file The descriptor of the Protobuf file.
  */
 private class DefinitionFactory(private val file: FileDescriptor) {
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
@@ -100,7 +100,7 @@ public fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
     file = file()
     packageName = `package`
     syntax = syntaxVersion()
-    option.addAll(options.toList())
+    option.addAll(options.toList(this@toHeader))
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/FileDescriptorExts.kt
@@ -40,9 +40,9 @@ import io.spine.protodata.ast.ProtoFileHeader.SyntaxVersion.PROTO3
 import io.spine.protodata.ast.ProtobufSourceFile
 import io.spine.protodata.ast.Service
 import io.spine.protodata.ast.file
+import io.spine.protodata.ast.options
 import io.spine.protodata.ast.protoFileHeader
 import io.spine.protodata.ast.protobufSourceFile
-import io.spine.protodata.ast.toList
 
 /**
  * Obtains the syntax version of the given [FileDescriptor].
@@ -100,7 +100,7 @@ public fun FileDescriptor.toHeader(): ProtoFileHeader = protoFileHeader {
     file = file()
     packageName = `package`
     syntax = syntaxVersion()
-    option.addAll(options.toList(this@toHeader))
+    option.addAll(options())
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/GenericDescriptorExts.kt
@@ -28,6 +28,7 @@ package io.spine.protodata.protobuf
 
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.EnumDescriptor
+import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
 import io.spine.type.KnownTypes
@@ -42,8 +43,16 @@ import io.spine.type.TypeUrl
  * @see io.spine.type.KnownTypes
  */
 internal fun GenericDescriptor.withSourceLines(): GenericDescriptor {
-    require(this is Descriptor || this is EnumDescriptor || this is ServiceDescriptor) {
-        "Expecting message, enum, or service descriptor. Got: `$this`."
+    require(
+        this is FileDescriptor
+                || this is Descriptor
+                || this is EnumDescriptor
+                || this is ServiceDescriptor
+    ) {
+        "Expecting file, message, enum, or service descriptor. Got: `$this`."
+    }
+    if (this is FileDescriptor) {
+        return withLines()
     }
     val typeUrl = TypeUrl.ofTypeOrService(this)
     return if (KnownTypes.instance().contains(typeUrl)) {
@@ -52,4 +61,28 @@ internal fun GenericDescriptor.withSourceLines(): GenericDescriptor {
     } else {
         this
     }
+}
+
+/**
+ * Obtains a file descriptor with source line info via one of the types or services
+ * declared in this file.
+ *
+ * This is a trick we need because [KnownTypes] does not provide API for obtaining loaded
+ * descriptor set files.
+ */
+@Suppress("ReturnCount")
+private fun FileDescriptor.withLines(): FileDescriptor {
+    fun List<GenericDescriptor>.fileOfFirst(): FileDescriptor =
+        first().withSourceLines().file
+    if (messageTypes.isNotEmpty()) {
+        return messageTypes.fileOfFirst()
+    }
+    if (enumTypes.isNotEmpty()) {
+        return enumTypes.fileOfFirst()
+    }
+    if (services.isNotEmpty()) {
+        return services.fileOfFirst()
+    }
+    // This is an unlikely case of a proto file without types or services.
+    return this
 }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
@@ -55,7 +55,7 @@ public fun MethodDescriptor.name(): RpcName = rpcName { value = name }
 public fun MethodDescriptor.toRpc(declaringService: ServiceName): Rpc {
     val rpc = buildRpc(this, declaringService)
     return rpc.copy {
-        option.addAll(options.toList())
+        option.addAll(options.toList(this@toRpc))
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MethodDescriptorExts.kt
@@ -38,9 +38,9 @@ import io.spine.protodata.ast.ServiceName
 import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.copy
 import io.spine.protodata.ast.documentation
+import io.spine.protodata.ast.options
 import io.spine.protodata.ast.rpc
 import io.spine.protodata.ast.rpcName
-import io.spine.protodata.ast.toList
 
 /**
  * Obtains the name of this RPC method as an [RpcName].
@@ -55,7 +55,7 @@ public fun MethodDescriptor.name(): RpcName = rpcName { value = name }
 public fun MethodDescriptor.toRpc(declaringService: ServiceName): Rpc {
     val rpc = buildRpc(this, declaringService)
     return rpc.copy {
-        option.addAll(options.toList(this@toRpc))
+        option.addAll(options())
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -45,11 +45,12 @@ public fun OneofDescriptor.name(): OneofName = oneofName { value = name }
  */
 public fun OneofDescriptor.toOneOfGroup(): OneofGroup =
     oneofGroup {
+        val self = this@toOneOfGroup
         val groupName = name()
         name = groupName
         field.addAll(fields.mapped())
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
         val messageType = containingType
-        doc = messageType.documentation().forOneof(this@toOneOfGroup)
-        span = messageType.coordinates().forOneof(this@toOneOfGroup)
+        doc = messageType.documentation().forOneof(self)
+        span = messageType.coordinates().forOneof(self)
     }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -33,7 +33,7 @@ import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.oneofName
-import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.options
 
 /**
  * Obtains the name of this `oneof` as a [OneofName].
@@ -49,7 +49,7 @@ public fun OneofDescriptor.toOneOfGroup(): OneofGroup =
         val groupName = name()
         name = groupName
         field.addAll(fields.mapped())
-        option.addAll(options.toList(self))
+        option.addAll(options())
         val messageType = containingType
         doc = messageType.documentation().forOneof(self)
         span = messageType.coordinates().forOneof(self)

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
@@ -33,7 +33,7 @@ import io.spine.protodata.ast.coordinates
 import io.spine.protodata.ast.documentation
 import io.spine.protodata.ast.service
 import io.spine.protodata.ast.serviceName
-import io.spine.protodata.ast.toList
+import io.spine.protodata.ast.options
 
 /**
  * Obtains the name of this service as a [ServiceName].
@@ -53,7 +53,7 @@ public fun ServiceDescriptor.toService(): Service =
         val serviceName = name()
         name = serviceName
         file = getFile().file()
-        option.addAll(options.toList(self))
+        option.addAll(options())
         rpc.addAll(methods.map { it.toRpc(serviceName) })
         doc = documentation().forService(self)
         span = coordinates().forService(self)

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/ServiceDescriptorExts.kt
@@ -49,11 +49,12 @@ public fun ServiceDescriptor.name(): ServiceName = serviceName {
  */
 public fun ServiceDescriptor.toService(): Service =
     service {
+        val self = this@toService
         val serviceName = name()
         name = serviceName
         file = getFile().file()
-        option.addAll(options.toList())
+        option.addAll(options.toList(self))
         rpc.addAll(methods.map { it.toRpc(serviceName) })
-        doc = documentation().forService(this@toService)
-        span = coordinates().forService(this@toService)
+        doc = documentation().forService(self)
+        span = coordinates().forService(self)
     }

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -123,7 +123,7 @@ message MessageType {
     //
     repeated TypeName nested_enums = 8 [(distinct) = true];
 
-    // Documentation of this type.
+    // The documentation of this type.
     Doc doc = 9;
 
     // Coordinates of the declaration.
@@ -155,7 +155,7 @@ message EnumType {
     //
     TypeName declared_in = 5;
 
-    // Documentation of this type.
+    // The documentation of this type.
     Doc doc = 6;
 
     // Coordinates of the declaration.
@@ -193,7 +193,7 @@ message EnumConstant {
     // Options associated with this constant.
     repeated Option option = 6;
 
-    // Documentation of this constant.
+    // The documentation of this constant.
     Doc doc = 7;
 
     // Coordinates of the declaration.
@@ -343,7 +343,7 @@ message Field {
     // Field-level options.
     repeated Option option = 7 [(distinct) = true];
 
-    // Documentation of this field.
+    // The documentation of this field.
     Doc doc = 8;
 
     // Coordinates of the declaration.
@@ -371,7 +371,7 @@ message OneofGroup {
     // Oneof-level options.
     repeated Option option = 3 [(distinct) = true];
 
-    // Documentation of this group.
+    // The documentation of this group.
     Doc doc = 4;
 
     // Coordinates of the declaration.
@@ -416,7 +416,7 @@ message Service {
     //
     repeated Rpc rpc = 4 [(distinct) = true];
 
-    // Documentation of this service.
+    // The documentation of this service.
     Doc doc = 5;
 
     // Coordinates of the declaration.
@@ -453,7 +453,7 @@ message Rpc {
     // `rpc`-level options.
     repeated Option option = 6 [(distinct) = true];
 
-    // Documentation of this `rpc`.
+    // The documentation of this `rpc`.
     Doc doc = 7;
 
     // The coordinates of the declaration.
@@ -513,6 +513,12 @@ message Option {
 
     // The packed value of the option.
     google.protobuf.Any value = 4 [(required) = true];
+
+    // The documentation of the option.
+    Doc doc = 5;
+
+    // The coordinates of the declaration.
+    Span span = 8;
 }
 
 // Documentation associated with a certain Protobuf declaration.

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -518,7 +518,7 @@ message Option {
     Doc doc = 5;
 
     // The coordinates of the declaration.
-    Span span = 8;
+    Span span = 6;
 }
 
 // Documentation associated with a certain Protobuf declaration.

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.ast
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
+import io.spine.protobuf.field
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
 import org.junit.jupiter.api.DisplayName
@@ -89,6 +90,22 @@ internal class OptionExtsSpec {
                 startColumn shouldBe 5
                 endLine shouldBe 58
                 endColumn shouldBe 7
+            }
+        }
+    }
+
+    @Test
+    fun `obtain options for a field`() {
+        val field = Selector.getDescriptor().field("position")!!
+        val options = field.options()
+
+        options.named("required").run {
+            doc.leadingComment.shouldBeEmpty()
+            span .run {
+                startLine shouldBe 63
+                startColumn shouldBe 9
+                endLine shouldBe 63
+                endColumn shouldBe 26
             }
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.ast
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.spine.protodata.ast.given.OptionExtsSpecProto
+import io.spine.protodata.ast.given.Selector
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -57,6 +58,36 @@ internal class OptionExtsSpec {
                 startColumn shouldBe 1
                 endLine shouldBe 37
                 endColumn shouldBe 54
+            }
+        }
+    }
+
+    @Test
+    fun `obtain options for a message`() {
+        val msg = Selector.getDescriptor()
+        val options = msg.options.toList(msg)
+
+        options.named("deprecated").run {
+            doc.leadingComment shouldContain "This is a standard message option."
+            doc.trailingComment shouldContain "A trailing comment for the option."
+
+            span.run {
+                startLine shouldBe 51
+                startColumn shouldBe 5
+                endLine shouldBe 51
+                endColumn shouldBe 31
+            }
+        }
+
+        options.named("entity").run {
+            doc.leadingComment shouldContain "This is a custom Spine option."
+            doc.trailingComment shouldContain "Another trailing comment."
+
+            span.run {
+                startLine shouldBe 55
+                startColumn shouldBe 5
+                endLine shouldBe 58
+                endColumn shouldBe 7
             }
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -33,112 +33,117 @@ import io.spine.protobuf.field
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("Extensions for `Option` should")
 internal class OptionExtsSpec {
 
-    @Test
-    fun  `obtain options for a file`() {
-        val file = OptionExtsSpecProto.getDescriptor()
-        val options = file.options()
+    @Nested inner class
+    `obtain options for`{
 
-        options.named("type_url_prefix").run {
-            doc.leadingComment shouldContain "We use type URL prefix"
-            span.run {
-                startLine shouldBe 34
-                startColumn shouldBe 1
-                endLine shouldBe 34
-                endColumn shouldBe 44
+        @Test
+        fun  `a file`() {
+            val file = OptionExtsSpecProto.getDescriptor()
+            val options = file.options()
+
+            options.named("type_url_prefix").run {
+                doc.leadingComment shouldContain "We use type URL prefix"
+                span.run {
+                    startLine shouldBe 34
+                    startColumn shouldBe 1
+                    endLine shouldBe 34
+                    endColumn shouldBe 44
+                }
+            }
+
+            options.named("java_package").run {
+                doc.leadingComment shouldContain "The preferred package"
+                span.run {
+                    startLine shouldBe 37
+                    startColumn shouldBe 1
+                    endLine shouldBe 37
+                    endColumn shouldBe 54
+                }
             }
         }
 
-        options.named("java_package").run {
-            doc.leadingComment shouldContain "The preferred package"
-            span.run {
-                startLine shouldBe 37
-                startColumn shouldBe 1
-                endLine shouldBe 37
-                endColumn shouldBe 54
+        @Test
+        fun `a message`() {
+            val msg = Selector.getDescriptor()
+            val options = msg.options()
+
+            options.named("deprecated").run {
+                doc.leadingComment shouldContain "This is a standard message option."
+                doc.trailingComment shouldContain "A trailing comment for the option."
+
+                span.run {
+                    startLine shouldBe 55
+                    startColumn shouldBe 5
+                    endLine shouldBe 55
+                    endColumn shouldBe 31
+                }
+            }
+
+            options.named("entity").run {
+                doc.leadingComment shouldContain "This is a custom Spine option."
+                doc.trailingComment shouldContain "Another trailing comment."
+
+                span.run {
+                    startLine shouldBe 59
+                    startColumn shouldBe 5
+                    endLine shouldBe 62
+                    endColumn shouldBe 7
+                }
             }
         }
-    }
 
-    @Test
-    fun `obtain options for a message`() {
-        val msg = Selector.getDescriptor()
-        val options = msg.options()
+        @Test
+        fun `a field`() {
+            val field = Selector.getDescriptor().field("position")!!
+            val options = field.options()
 
-        options.named("deprecated").run {
-            doc.leadingComment shouldContain "This is a standard message option."
-            doc.trailingComment shouldContain "A trailing comment for the option."
-
-            span.run {
-                startLine shouldBe 51
-                startColumn shouldBe 5
-                endLine shouldBe 51
-                endColumn shouldBe 31
+            options.named("required").run {
+                doc.leadingComment.shouldBeEmpty()
+                span .run {
+                    startLine shouldBe 67
+                    startColumn shouldBe 9
+                    endLine shouldBe 67
+                    endColumn shouldBe 26
+                }
             }
         }
 
-        options.named("entity").run {
-            doc.leadingComment shouldContain "This is a custom Spine option."
-            doc.trailingComment shouldContain "Another trailing comment."
+        @Test
+        fun `an enum`() {
+            val enum = Selector.Position.getDescriptor()
+            val options = enum.options()
 
-            span.run {
-                startLine shouldBe 55
-                startColumn shouldBe 5
-                endLine shouldBe 58
-                endColumn shouldBe 7
+            options.named("deprecated").run {
+                doc.leadingComment shouldContain "A standard enum option."
+                span.run {
+                    startLine shouldBe 74
+                    endLine shouldBe 74
+                    startColumn shouldBe 9
+                    endColumn shouldBe 35
+                }
             }
         }
-    }
 
-    @Test
-    fun `obtain options for a field`() {
-        val field = Selector.getDescriptor().field("position")!!
-        val options = field.options()
+        @Test
+        fun `an enum item`() {
+            val item = Selector.Position.POSITION_LEFT.valueDescriptor
+            val options = item.options()
 
-        options.named("required").run {
-            doc.leadingComment.shouldBeEmpty()
-            span .run {
-                startLine shouldBe 63
-                startColumn shouldBe 9
-                endLine shouldBe 63
-                endColumn shouldBe 26
-            }
-        }
-    }
-
-    @Test
-    fun `obtain options for an enum`() {
-        val enum = Selector.Position.getDescriptor()
-        val options = enum.options()
-
-        options.named("deprecated").run {
-            doc.leadingComment shouldContain "A standard enum option."
-            span.run {
-                startLine shouldBe 70
-                endLine shouldBe 70
-                startColumn shouldBe 9
-                endColumn shouldBe 35
-            }
-        }
-    }
-
-    @Test
-    fun `obtain options for an enum item`() {
-        val item = Selector.Position.POSITION_LEFT.valueDescriptor
-        val options = item.options()
-
-        options.named("deprecated").run {
-            // Enum item docs are not available from descriptors.
-            doc.leadingComment.shouldBeEmpty()
-            span.run {
-                startLine shouldBe 77
-                endLine shouldBe 77
-                startColumn shouldBe 13
-                endColumn shouldBe 31
+            options.named("deprecated").run {
+                // Enum item docs are not available from descriptors.
+                doc.leadingComment.shouldBeEmpty()
+                span.run {
+                    startLine shouldBe 81
+                    endLine shouldBe 81
+                    startColumn shouldBe 13
+                    endColumn shouldBe 31
+                }
             }
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -27,6 +27,7 @@
 package io.spine.protodata.ast
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
@@ -104,6 +105,23 @@ internal class OptionExtsSpec {
                 endLine shouldBe 70
                 startColumn shouldBe 9
                 endColumn shouldBe 35
+            }
+        }
+    }
+
+    @Test
+    fun `obtain options for an enum item`() {
+        val item = Selector.Position.POSITION_LEFT.valueDescriptor
+        val options = item.options()
+
+        options.named("deprecated").run {
+            // Enum item docs are not available from descriptors.
+            doc.leadingComment.shouldBeEmpty()
+            span.run {
+                startLine shouldBe 77
+                endLine shouldBe 77
+                startColumn shouldBe 13
+                endColumn shouldBe 31
             }
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -39,7 +39,7 @@ internal class OptionExtsSpec {
     @Test
     fun  `obtain options for a file`() {
         val file = OptionExtsSpecProto.getDescriptor()
-        val options = file.options.toList(file)
+        val options = file.options()
 
         options.named("type_url_prefix").run {
             doc.leadingComment shouldContain "We use type URL prefix"
@@ -65,7 +65,7 @@ internal class OptionExtsSpec {
     @Test
     fun `obtain options for a message`() {
         val msg = Selector.getDescriptor()
-        val options = msg.options.toList(msg)
+        val options = msg.options()
 
         options.named("deprecated").run {
             doc.leadingComment shouldContain "This is a standard message option."
@@ -88,6 +88,22 @@ internal class OptionExtsSpec {
                 startColumn shouldBe 5
                 endLine shouldBe 58
                 endColumn shouldBe 7
+            }
+        }
+    }
+
+    @Test
+    fun `obtain options for an enum`() {
+        val enum = Selector.Position.getDescriptor()
+        val options = enum.options()
+
+        options.named("deprecated").run {
+            doc.leadingComment shouldContain "A standard enum option."
+            span.run {
+                startLine shouldBe 70
+                endLine shouldBe 70
+                startColumn shouldBe 9
+                endColumn shouldBe 35
             }
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.protodata.ast.given.OptionExtsSpecProto
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Extensions for `Option` should")
+internal class OptionExtsSpec {
+
+    @Test
+    fun  `obtain options for a file`() {
+        val file = OptionExtsSpecProto.getDescriptor()
+        val options = file.options.toList(file)
+
+        options.named("type_url_prefix").run {
+            doc.leadingComment shouldContain "We use type URL prefix"
+            span.run {
+                startLine shouldBe 34
+                startColumn shouldBe 1
+                endLine shouldBe 34
+                endColumn shouldBe 44
+            }
+        }
+
+        options.named("java_package").run {
+            doc.leadingComment shouldContain "The preferred package"
+            span.run {
+                startLine shouldBe 37
+                startColumn shouldBe 1
+                endLine shouldBe 37
+                endColumn shouldBe 54
+            }
+        }
+    }
+}
+
+private fun List<Option>.named(name: String): Option = find { it.name == name }!!

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -30,6 +30,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
 import io.spine.protobuf.field
+import io.spine.protodata.ast.given.NotificationRequest
+import io.spine.protodata.ast.given.NotificationService
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
 import org.junit.jupiter.api.DisplayName
@@ -115,6 +117,24 @@ internal class OptionExtsSpec {
         }
 
         @Test
+        fun `a field group under oneof`() {
+            val oneof = NotificationRequest.getDescriptor().oneofs.find { it.name == "channel" }!!
+            val options = oneof.options()
+
+            options.named("is_required").run {
+                doc.leadingComment shouldContain "A channel must be selected."
+                doc.trailingComment shouldContain "The trailing comment for the `oneof` option."
+
+                span.run {
+                    startLine shouldBe 104
+                    startColumn shouldBe 9
+                    endLine shouldBe 104
+                    endColumn shouldBe 37
+                }
+            }
+        }
+
+        @Test
         fun `an enum`() {
             val enum = Selector.Position.getDescriptor()
             val options = enum.options()
@@ -143,6 +163,44 @@ internal class OptionExtsSpec {
                     endLine shouldBe 81
                     startColumn shouldBe 13
                     endColumn shouldBe 31
+                }
+            }
+        }
+
+        @Test
+        fun `a service`() {
+            val service = NotificationService.getDescriptor()
+            val options = service.options()
+
+            options.named("deprecated").run {
+                doc.leadingComment shouldContain "A standard service option."
+                doc.trailingComment shouldContain "Trailing comment for the standard option."
+
+                span.run {
+                    startLine shouldBe 122
+                    startColumn shouldBe 5
+                    endLine shouldBe 122
+                    endColumn shouldBe 31
+                }
+            }
+        }
+
+        @Test
+        fun `a service method`() {
+            val method = NotificationService.getDescriptor().methods.find {
+                it.name == "SendNotification"
+            }!!
+            val options = method.options()
+
+            options.named("idempotency_level").run {
+                doc.leadingComment shouldContain "Ensure retry-safe behavior."
+                doc.trailingComment shouldContain "Trailing comment for the standard method option."
+
+                span.run {
+                    startLine shouldBe 132
+                    startColumn shouldBe 9
+                    endLine shouldBe 132
+                    endColumn shouldBe 47
                 }
             }
         }

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -73,7 +73,7 @@ message Selector {
 
         // Left.
         POSITION_LEFT = 1 [
-            // A standard enum value option.
+            // Comments of enum item options are not included into descriptors.
             deprecated = false
         ];
 

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -65,10 +65,17 @@ message Selector {
 
     // Enumerates the positions of the selector.
     enum Position {
+
+        // A standard enum option.
+        option deprecated = false;
+
         POSITION_UNDEFINED = 0;
 
         // Left.
-        POSITION_LEFT = 1;
+        POSITION_LEFT = 1 [
+            // A standard enum value option.
+            deprecated = false
+        ];
 
         // Right.
         POSITION_RIGHT = 2;
@@ -82,3 +89,8 @@ message Selector {
 
     google.protobuf.Timestamp when_changed = 2;
 }
+
+
+
+// Turn generic services on so that the code and descriptors are generated.
+option java_generic_services = true;

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -42,6 +42,10 @@ option java_outer_classname = "OptionExtsSpecProto";
 // Use multiple files so that each declaration is a top-level Java class.
 option java_multiple_files = true;
 
+// Turn generic services on so that the code and descriptors are generated.
+option java_generic_services = true;
+
+import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 // This is a stub message with documentation.
@@ -90,7 +94,3 @@ message Selector {
     google.protobuf.Timestamp when_changed = 2;
 }
 
-
-
-// Turn generic services on so that the code and descriptors are generated.
-option java_generic_services = true;

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package spine.protodata.ast;
+
+import "spine/options.proto";
+
+// We use type URL prefix for stub types too.
+option (type_url_prefix) = "type.spine.io";
+
+// The preferred package name is "given" to separate stub types from production or test code.
+option java_package = "io.spine.protodata.ast.given";
+
+// Explicitly set the outer class name.
+option java_outer_classname = "OptionExtsSpecProto";
+
+// Use multiple files so that each declaration is a top-level Java class.
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+
+// This is a stub message with documentation.
+message Selector {
+
+    // The current position of the selector.
+    Position position = 1 [
+        // A selector cannot be in an undefined position.
+        (required) = true
+    ];
+
+    // Enumerates the positions of the selector.
+    enum Position {
+        POSITION_UNDEFINED = 0;
+
+        // Left.
+        POSITION_LEFT = 1;
+
+        // Right.
+        POSITION_RIGHT = 2;
+
+        // Top.
+        POSITION_TOP = 3;
+
+        // Bottom.
+        POSITION_BOTTOM = 4;
+    }
+
+    google.protobuf.Timestamp when_changed = 2;
+}

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -59,7 +59,7 @@ message Selector {
 
     // The current position of the selector.
     Position position = 1 [
-        // A selector cannot be in an undefined position.
+        // This comment is not included into the location info.
         (required) = true
     ];
 

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -47,6 +47,16 @@ import "google/protobuf/timestamp.proto";
 // This is a stub message with documentation.
 message Selector {
 
+    // This is a standard message option.
+    option deprecated = false;
+    // A trailing comment for the option.
+
+    // This is a custom Spine option.
+    option (entity) = {
+        kind: ENTITY,
+        visibility: FULL
+    }; // Another trailing comment.
+
     // The current position of the selector.
     Position position = 1 [
         // A selector cannot be in an undefined position.

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -94,3 +94,62 @@ message Selector {
     google.protobuf.Timestamp when_changed = 2;
 }
 
+// Message for sending a notification
+message NotificationRequest {
+    string user_id = 1 [(required) = true];
+
+    // A method of notification.
+    oneof channel {
+        // A channel must be selected.
+        option (is_required) = true;
+        // The trailing comment for the `oneof` option.
+
+        EmailNotification email = 2;
+        SmsNotification sms = 3;
+        PushNotification push = 4;
+    }
+}
+
+// Response message
+message NotificationResponse {
+    bool success = 1;
+    string message = 2;
+}
+
+// The service to send notifications.
+service NotificationService {
+    // A standard service option.
+    option deprecated = false;
+    // Trailing comment for the standard option.
+
+    // A custom service option.
+    option (SPI_service) = true;
+    // Trailing comment for the custom option.
+
+    // The method for sending notifications.
+    rpc SendNotification (NotificationRequest) returns (NotificationResponse) {
+        // Ensure retry-safe behavior.
+        option idempotency_level = IDEMPOTENT;
+        // Trailing comment for the standard method option.
+    }
+}
+
+// Email notification type
+message EmailNotification {
+    string email_address = 1;
+    string subject = 2;
+    string body = 3;
+}
+
+// SMS notification type
+message SmsNotification {
+    string phone_number = 1;
+    string body = 2;
+}
+
+// Push notification type
+message PushNotification {
+    string device_token = 1;
+    string title = 2;
+    string body = 3;
+}

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -26,6 +26,8 @@
 
 package io.spine.protodata.backend.event
 
+import com.google.common.collect.ImmutableSet
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import io.spine.base.EventMessage
@@ -52,10 +54,10 @@ public object CompilerEvents {
      * The resulting sequence is always finite, it's limited by the type set.
      */
     public fun parse(request: CodeGeneratorRequest): Sequence<EventMessage> {
+        val allFiles = request.protoFileList.toDescriptors()
         val filesToGenerate = request.fileToGenerateList.toSet()
-        val files = FileSet.of(request.protoFileList)
         return sequence {
-            val (ownFiles, dependencies) = files.files().partition {
+            val (ownFiles, dependencies) = allFiles.partition {
                 it.name in filesToGenerate
             }
             yieldAll(dependencies.map { it.toDependencyEvent() })
@@ -115,6 +117,16 @@ private class ProtoFileEvents(
             }
         )
     }
+}
+
+/**
+ * Convert this collection of [FileDescriptorProto] to a set of corresponding
+ * instances of [FileDescriptor].
+ */
+private fun Collection<FileDescriptorProto>.toDescriptors(): ImmutableSet<FileDescriptor> {
+    val files = FileSet.of(this)
+    val fileDescriptors = files.files()
+    return fileDescriptors
 }
 
 /**

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -93,7 +93,7 @@ private class ProtoFileEvents(
                 header = hdr
             }
         )
-        produceOptionEvents(file.options) {
+        produceOptionEvents(file.options, file) {
             fileOptionDiscovered {
                 file = header.file
                 option = it

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumCompilerEvents.kt
@@ -76,7 +76,7 @@ internal class EnumCompilerEvents(
                 type = typeName
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             enumOptionDiscovered {
                 file = path
                 this.type = typeName
@@ -118,7 +118,7 @@ internal class EnumCompilerEvents(
                 constant = theConstant
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             enumConstantOptionDiscovered {
                 file = path
                 type = typeName

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageCompilerEvents.kt
@@ -88,7 +88,7 @@ internal class MessageCompilerEvents(
                 type = messageType.name
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             typeOptionDiscovered {
                 file = path
                 type = typeName
@@ -149,7 +149,7 @@ internal class MessageCompilerEvents(
                 group = oneofGroup
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             oneofOptionDiscovered {
                 file = path
                 type = typeName
@@ -192,7 +192,7 @@ internal class MessageCompilerEvents(
                 field = theField
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             fieldOptionDiscovered {
                 file = path
                 type = typeName

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceCompilerEvents.kt
@@ -77,7 +77,7 @@ internal class ServiceCompilerEvents(
                 service = serviceName
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             serviceOptionDiscovered {
                 file = path
                 service = serviceName
@@ -108,7 +108,7 @@ internal class ServiceCompilerEvents(
                 rpc = theRpc
             }
         )
-        produceOptionEvents(desc.options) {
+        produceOptionEvents(desc.options, desc) {
             rpcOptionDiscovered {
                 file = path
                 service = serviceName

--- a/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -48,7 +48,9 @@ import io.spine.protobuf.AnyPacker
 import io.spine.protodata.ast.PrimitiveType.TYPE_BOOL
 import io.spine.protodata.ast.ProtobufDependency
 import io.spine.protodata.ast.ProtobufSourceFile
+import io.spine.protodata.ast.doc
 import io.spine.protodata.ast.option
+import io.spine.protodata.ast.span
 import io.spine.protodata.ast.toType
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.context.CodegenContext
@@ -178,6 +180,9 @@ class CodeGenerationContextSpec {
                 number = BETA_TYPE_FIELD_NUMBER
                 type = TYPE_BOOL.toType()
                 value = AnyPacker.pack(BoolValue.of(true))
+                //TODO:2024-12-05:alexander.yevsyukov: Populate with data.
+                doc = doc { }
+                span = span { }
             })
             // 4 regular fields and 2 fields under `oneof`.
             journeyType.fieldList shouldHaveSize 6

--- a/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -180,9 +180,16 @@ class CodeGenerationContextSpec {
                 number = BETA_TYPE_FIELD_NUMBER
                 type = TYPE_BOOL.toType()
                 value = AnyPacker.pack(BoolValue.of(true))
-                //TODO:2024-12-05:alexander.yevsyukov: Populate with data.
-                doc = doc { }
-                span = span { }
+                doc = doc {
+                    // The option is not documented.
+                    // It's OK because we test docs of options in the tests of the `api` module.
+                }
+                span = span {
+                    startLine = 34
+                    startColumn = 5
+                    endLine = 34
+                    endColumn = 31
+                }
             })
             // 4 regular fields and 2 fields under `oneof`.
             journeyType.fieldList shouldHaveSize 6

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -46,6 +46,7 @@ import io.spine.dependency.lib.Okio
 import io.spine.dependency.lib.Plexus
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.lib.Slf4J
+import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
 import io.spine.dependency.test.Hamcrest
 import io.spine.dependency.test.JUnit
@@ -186,7 +187,7 @@ fun ModuleDependency.excludeSpineBase() {
 fun Project.forceSpineBase() {
     configurations.all {
         resolutionStrategy {
-            force(Spine.base)
+            force(Base.lib)
         }
     }
 }
@@ -200,7 +201,7 @@ fun Project.forceBaseInProtoTasks() {
     configurations.configureEach {
         if (name.lowercased().contains("proto")) {
             resolutionStrategy {
-                force(Spine.baseForBuildScript)
+                force(Base.libForBuildScript)
             }
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
@@ -31,17 +31,20 @@ package io.spine.dependency.build
 object ErrorProne {
     // https://github.com/google/error-prone
     private const val version = "2.23.0"
+
+    const val group = "com.google.errorprone"
+
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 
     val annotations = listOf(
-        "com.google.errorprone:error_prone_annotations:$version",
-        "com.google.errorprone:error_prone_type_annotations:$version"
+        "$group:error_prone_annotations:$version",
+        "$group:error_prone_type_annotations:$version"
     )
-    const val core = "com.google.errorprone:error_prone_core:$version"
-    const val checkApi = "com.google.errorprone:error_prone_check_api:$version"
-    const val testHelpers = "com.google.errorprone:error_prone_test_helpers:$version"
-    const val javacPlugin  = "com.google.errorprone:javac:$javacPluginVersion"
+    const val core = "$group:error_prone_core:$version"
+    const val checkApi = "$group:error_prone_check_api:$version"
+    const val testHelpers = "$group:error_prone_test_helpers:$version"
+    const val javacPlugin  = "$group:javac:$javacPluginVersion"
 
     // https://github.com/tbroyer/gradle-errorprone-plugin/releases
     object GradlePlugin {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Asm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Asm.kt
@@ -30,13 +30,14 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Asm {
     private const val version = "9.6"
-    const val lib = "org.ow2.asm:asm:$version"
+    const val group = "org.ow2.asm"
+    const val lib = "$group:asm:$version"
 
     // We use the following artifacts only to force the versions
     // of the dependencies which are transitive for us.
     //
-    const val tree = "org.ow2.asm:asm-tree:$version"
-    const val analysis = "org.ow2.asm:asm-analysis:$version"
-    const val util = "org.ow2.asm:asm-util:$version"
-    const val commons = "org.ow2.asm:asm-commons:$version"
+    const val tree = "$group:asm-tree:$version"
+    const val analysis = "$group:asm-analysis:$version"
+    const val util = "$group:asm-util:$version"
+    const val commons = "$group:asm-commons:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
@@ -31,20 +31,21 @@ package io.spine.dependency.lib
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
     const val version        = "1.59.0"
-    const val api            = "io.grpc:grpc-api:$version"
-    const val auth           = "io.grpc:grpc-auth:$version"
-    const val core           = "io.grpc:grpc-core:$version"
-    const val context        = "io.grpc:grpc-context:$version"
-    const val inProcess      = "io.grpc:grpc-inprocess:$version"
-    const val stub           = "io.grpc:grpc-stub:$version"
-    const val okHttp         = "io.grpc:grpc-okhttp:$version"
-    const val protobuf       = "io.grpc:grpc-protobuf:$version"
-    const val protobufLite   = "io.grpc:grpc-protobuf-lite:$version"
-    const val netty          = "io.grpc:grpc-netty:$version"
-    const val nettyShaded    = "io.grpc:grpc-netty-shaded:$version"
+    const val group          = "io.grpc"
+    const val api            = "$group:grpc-api:$version"
+    const val auth           = "$group:grpc-auth:$version"
+    const val core           = "$group:grpc-core:$version"
+    const val context        = "$group:grpc-context:$version"
+    const val inProcess      = "$group:grpc-inprocess:$version"
+    const val stub           = "$group:grpc-stub:$version"
+    const val okHttp         = "$group:grpc-okhttp:$version"
+    const val protobuf       = "$group:grpc-protobuf:$version"
+    const val protobufLite   = "$group:grpc-protobuf-lite:$version"
+    const val netty          = "$group:grpc-netty:$version"
+    const val nettyShaded    = "$group:grpc-netty-shaded:$version"
 
     object ProtocPlugin {
         const val id = "grpc"
-        const val artifact = "io.grpc:protoc-gen-grpc-java:$version"
+        const val artifact = "$group:protoc-gen-grpc-java:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaPoet.kt
@@ -30,5 +30,8 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object JavaPoet {
     private const val version = "1.13.0"
-    const val lib = "com.squareup:javapoet:$version"
+    const val group = "com.squareup"
+    const val artifact = "javapoet"
+    const val module = "$group:$artifact"
+    const val lib = "$module:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
@@ -30,7 +30,8 @@ package io.spine.dependency.lib
 object JavaX {
     // This artifact, which used to be a part of J2EE, moved under the Eclipse EE4J project.
     // https://github.com/eclipse-ee4j/common-annotations-api
-    const val annotations = "javax.annotation:javax.annotation-api:1.3.2"
+    const val annotationGroup = "javax.annotation"
+    const val annotations = "$annotationGroup:javax.annotation-api:1.3.2"
 
     const val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
@@ -32,7 +32,7 @@ package io.spine.dependency.lib
     "ConstPropertyName" /* https://bit.ly/kotlin-prop-names */
 )
 object Protobuf {
-    private const val group = "com.google.protobuf"
+    const val group = "com.google.protobuf"
     const val version       = "3.25.1"
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
@@ -39,6 +39,7 @@ object Roaster {
      */
     private const val version = "2.28.0.Final"
 
-    const val api = "org.jboss.forge.roaster:roaster-api:$version"
-    const val jdt = "org.jboss.forge.roaster:roaster-jdt:$version"
+    const val group = "org.jboss.forge.roaster"
+    const val api = "$group:roaster-api:$version"
+    const val jdt = "$group:roaster-jdt:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
@@ -37,15 +37,23 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
      */
-    const val base = "2.0.0-SNAPSHOT.223"
-    const val baseForBuildScript = "2.0.0-SNAPSHOT.223"
+    @Deprecated(message = "Please use `Base.version`.", ReplaceWith("Base.version"))
+    const val base = Base.version
+
+    @Suppress("unused")
+    @Deprecated(
+        message = "Please use `Base.versionForBuildScript`.",
+        ReplaceWith("Base.versionForBuildScript")
+    )
+    const val baseForBuildScript = Base.versionForBuildScript
 
     /**
      * The version of [Spine.reflect].
      *
      * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
      */
-    const val reflect = "2.0.0-SNAPSHOT.190"
+    @Deprecated(message = "Please use `Reflect.version`.", ReplaceWith("Reflect.version"))
+    const val reflect = Reflect.version
 
     /**
      * The version of [Logging].
@@ -58,7 +66,8 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
      */
-    const val testlib = "2.0.0-SNAPSHOT.184"
+    @Deprecated(message = "Please use `TestLib.version`.", ReplaceWith("TestLib.version"))
+    const val testlib = TestLib.version
 
     /**
      * The version of `core-java`.
@@ -71,41 +80,51 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
      */
-    const val mc = "2.0.0-SNAPSHOT.133"
+    @Deprecated(
+        message = "Please use `ModelCompiler.version` instead.",
+        ReplaceWith("ModelCompiler.version")
+    )
+    const val mc = ModelCompiler.version
 
     /**
      * The version of [Spine.baseTypes].
      *
      * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
      */
-    const val baseTypes = "2.0.0-SNAPSHOT.126"
+    @Deprecated(message = "Please use `BaseTypes.version`.", ReplaceWith("BaseTypes.version"))
+    const val baseTypes = BaseTypes.version
 
     /**
      * The version of [Spine.time].
      *
      * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
      */
-    const val time = "2.0.0-SNAPSHOT.135"
+    @Deprecated(message = "Please use `Time.version`.", ReplaceWith("Time.version"))
+    const val time = Time.version
 
     /**
      * The version of [Spine.change].
      *
      * @see <a href="https://github.com/SpineEventEngine/change">spine-change</a>
      */
-    const val change = "2.0.0-SNAPSHOT.118"
+    @Deprecated(message = "Please use `Change.version`.", ReplaceWith("Change.version"))
+    const val change = Change.version
 
     /**
      * The version of [Spine.text].
      *
      * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
      */
-    const val text = "2.0.0-SNAPSHOT.6"
+    @Deprecated(message = "Please use `Text.version`.", ReplaceWith("Text.version"))
+    const val text = Text.version
 
     /**
      * The version of [Spine.toolBase].
      *
      * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
      */
+    @Suppress("unused")
+    @Deprecated(message = "Please use `ToolBase.version`.", ReplaceWith("ToolBase.version"))
     const val toolBase = ToolBase.version
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -24,21 +24,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Base module.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Base {
+    const val version = "2.0.0-SNAPSHOT.223"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.223"
+    const val group = Spine.group
+    const val artifact = "spine-base"
+    const val lib = "$group:$artifact:$version"
+    const val libForBuildScript = "$group:$artifact:$versionForBuildScript"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/BaseTypes.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/BaseTypes.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Base module.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object BaseTypes {
+    const val version = "2.0.0-SNAPSHOT.126"
+    const val group = Spine.group
+    const val artifact = "spine-base-types"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/change">spine-change</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Change {
+    const val version = "2.0.0-SNAPSHOT.118"
+    const val group = Spine.group
+    const val artifact = "spine-change"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,9 +34,15 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.183"
-    const val core = "$group:spine-core:$version"
-    const val client = "$group:spine-client:$version"
-    const val server = "$group:spine-server:$version"
+    const val version = "2.0.0-SNAPSHOT.182"
+
+    const val coreArtifact = "spine-core"
+    const val clientArtifact = "spine-client"
+    const val serverArtifact = "spine-server"
+
+    const val core = "$group:$coreArtifact:$version"
+    const val client = "$group:$clientArtifact:$version"
+    const val server = "$group:$serverArtifact:$version"
+
     const val testUtilServer = "${Spine.toolsGroup}:spine-testutil-server:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,9 +33,12 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.240"
+    const val version = "2.0.0-SNAPSHOT.242"
     const val group = Spine.group
-    const val lib = "$group:spine-logging:$version"
+
+    const val loggingArtifact = "spine-logging"
+
+    const val lib = "$group:$loggingArtifact:$version"
     const val libJvm = "$group:spine-logging-jvm:$version"
 
     const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ModelCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ModelCompiler.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Model Compiler Gradle API.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object ModelCompiler {
+    const val version = "2.0.0-SNAPSHOT.133"
+    const val group = Spine.toolsGroup
+    const val artifact = "spine-model-compiler"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.69.5"
+    private const val fallbackVersion = "0.69.6"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.69.5"
+    private const val fallbackDfVersion = "0.69.6"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -115,8 +115,10 @@ object ProtoData {
     val cliApi
         get() = "$group:protodata-cli-api:$version"
 
+    val javaModule = "$group:protodata-java"
+
     fun java(version: String): String =
-        "$group:protodata-java:$version"
+        "$javaModule:$version"
 
     val java
         get() = java(version)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Reflect.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Reflect.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Reflect {
+    const val version = "2.0.0-SNAPSHOT.191"
+    const val group = Spine.group
+    const val artifact = "spine-reflect"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Spine.kt
@@ -35,30 +35,59 @@ object Spine {
     const val group = "io.spine"
     const val toolsGroup = "io.spine.tools"
 
-    const val base = "$group:spine-base:${ArtifactVersion.base}"
-    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.baseForBuildScript}"
+    @Deprecated(message = "Please use `Base.lib`.", ReplaceWith("Base.lib"))
+    const val base = Base.lib
 
-    const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
-    const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
-    const val time = "$group:spine-time:${ArtifactVersion.time}"
-    const val change = "$group:spine-change:${ArtifactVersion.change}"
-    const val text = "$group:spine-text:${ArtifactVersion.text}"
+    @Deprecated(
+        message = "Please use `Base.libForBuildScript`.",
+        ReplaceWith("Base.libForBuildScript")
+    )
+    const val baseForBuildScript = Base.libForBuildScript
 
-    const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
-    const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
+    @Deprecated(message = "Please use `Reflect.lib`.", ReplaceWith("Reflect.lib"))
+    const val reflect = Reflect.lib
+
+    @Deprecated(message = "Please use `BaseTypes.lib`.", ReplaceWith("BaseTypes.lib"))
+    const val baseTypes = BaseTypes.lib
+
+    @Deprecated(message = "Please use `Time.lib`.", ReplaceWith("Time.lib"))
+    const val time = Time.lib
+
+    @Deprecated(message = "Please use `Time.lib`.", ReplaceWith("Time.lib"))
+    const val change = Change.lib
+
+    @Deprecated(message = "Please use `Text.lib`.", ReplaceWith("Text.lib"))
+    const val text = Text.lib
+
+    @Deprecated(message = "Please use `TestLib.lib`.", ReplaceWith("TestLib.lib"))
+    const val testlib = TestLib.lib
+
+    @Deprecated(message = "Please use `Time.testLib`.", ReplaceWith("Time.testLib"))
+    const val testUtilTime = Time.testLib
 
     @Deprecated(message = "Please use `ToolBase.psiJava` instead`.")
-    const val psiJava = "$toolsGroup:spine-psi-java:${ArtifactVersion.toolBase}"
+    const val psiJava = "$toolsGroup:spine-psi-java:${ToolBase.version}"
+
     @Deprecated(message = "Please use `ToolBase.psiJava` instead`.")
-    const val psiJavaBundle = "$toolsGroup:spine-psi-java-bundle:${ArtifactVersion.toolBase}"
+    const val psiJavaBundle = "$toolsGroup:spine-psi-java-bundle:${ToolBase.version}"
+
     @Deprecated(message = "Please use `ToolBase.lib` instead`.")
-    const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
-    @Deprecated(message = "Please use `ToolBase.pluginBase` instead`.")
-    const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
-    @Deprecated(message = "Please use `ToolBase.pluginTestlib` instead`.")
-    const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
+    const val toolBase = "$toolsGroup:spine-tool-base:${ToolBase.version}"
 
-    const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
+    @Deprecated(message = "Please use `ToolBase.pluginBase` instead`.")
+    const val pluginBase = "$toolsGroup:spine-plugin-base:${ToolBase.version}"
+
+    @Deprecated(
+        message = "Please use `ToolBase.pluginTestlib` instead`.",
+        ReplaceWith("ToolBase.pluginTestlib")
+    )
+    const val pluginTestlib = ToolBase.pluginTestlib
+
+    @Deprecated(
+        message = "Please use `ModelCompiler.lib` instead.",
+        ReplaceWith("ModelCompiler.lib")
+    )
+    const val modelCompiler = ModelCompiler.lib
 
     @Deprecated(
         message = "Please use top level `McJava` object instead.",

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine TestLib library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object TestLib {
+    const val version = "2.0.0-SNAPSHOT.184"
+    const val group = Spine.toolsGroup
+    const val artifact = "spine-testlib"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Text {
+    const val version = "2.0.0-SNAPSHOT.6"
+    const val group = Spine.group
+    const val artifact = "spine-text"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -24,21 +24,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Time library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Time {
+    const val version = "2.0.0-SNAPSHOT.135"
+    const val group = Spine.group
+    const val artifact = "spine-time"
+    const val lib = "$group:$artifact:$version"
+
+    //TODO:2024-11-29:alexander.yevsyukov: Change the artifact name to `spine-time-testlib`.
+    const val testLib = "${Spine.toolsGroup}:spine-testutil-time:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -31,21 +31,24 @@ package io.spine.dependency.local
  *
  * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
  */
-@Suppress("unused", "ConstPropertyName")
+@Suppress("ConstPropertyName")
 object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.177"
+    const val version = "2.0.0-SNAPSHOT.178"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"
 
-    const val runtime = "$group:$prefix-java-runtime:$version"
+    const val runtimeModule = "$group:$prefix-java-runtime"
+    const val runtime = "$runtimeModule:$version"
     const val java = "$group:$prefix-java:$version"
 
+    const val javaBundleModule = "$group:$prefix-java-bundle"
+
     /** Obtains the artifact for the `java-bundle` artifact of the given version. */
-    fun javaBundle(version: String) = "$group:$prefix-java-bundle:$version"
+    fun javaBundle(version: String) = "$javaBundleModule:$version"
 
     val javaBundle = javaBundle(version)
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
@@ -35,7 +35,7 @@ package io.spine.dependency.test
  */
 @Suppress("unused", "ConstPropertyName")
 object Kotest {
-    const val version = "5.9.1"
+    const val version = "5.8.0"
     const val group = "io.kotest"
     const val assertions = "$group:kotest-assertions-core:$version"
     const val runnerJUnit5 = "$group:kotest-runner-junit5:$version"

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -32,7 +32,8 @@ import io.spine.dependency.lib.Guava
 import io.spine.dependency.lib.JavaX
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Logging
-import io.spine.dependency.local.Spine
+import io.spine.dependency.local.Reflect
+import io.spine.dependency.local.TestLib
 import io.spine.dependency.test.JUnit
 import io.spine.dependency.test.Jacoco
 import io.spine.dependency.test.Kotest
@@ -144,7 +145,7 @@ fun Module.addDependencies() = dependencies {
     testImplementation(JUnit.pioneer)
     JUnit.api.forEach { testImplementation(it) }
 
-    testImplementation(Spine.testlib)
+    testImplementation(TestLib.lib)
     testImplementation(Kotest.frameworkEngine)
     testImplementation(Kotest.datatest)
     testImplementation(Kotest.runnerJUnit5Jvm)
@@ -161,7 +162,7 @@ fun Module.forceConfigurations() {
                     JUnit.bom,
                     JUnit.runner,
                     Dokka.BasePlugin.lib,
-                    Spine.reflect
+                    Reflect.lib,
                 )
             }
         }

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -26,12 +26,12 @@
 
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
-import io.spine.dependency.test.JUnit
 import io.spine.dependency.lib.Protobuf
-import io.spine.dependency.test.Truth
+import io.spine.dependency.local.Base
 import io.spine.dependency.local.CoreJava
-import io.spine.dependency.local.Spine
 import io.spine.dependency.local.ToolBase
+import io.spine.dependency.test.JUnit
+import io.spine.dependency.test.Truth
 import io.spine.gradle.javac.configureErrorProne
 import io.spine.gradle.javac.configureJavac
 import io.spine.gradle.kotlin.applyJvmToolchain
@@ -102,7 +102,7 @@ fun Module.forceConfigurations() {
         resolutionStrategy {
             force(
                 Protobuf.compiler,
-                Spine.base,
+                Base.lib,
                 ToolBase.lib,
             )
         }

--- a/buildSrc/src/main/kotlin/test-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/test-module.gradle.kts
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.dependency.local.Spine
+import io.spine.dependency.local.Base
 import io.spine.dependency.local.Validation
 
 plugins {
@@ -34,7 +34,7 @@ plugins {
 
 dependencies {
     arrayOf(
-        Spine.base,
+        Base.lib,
         Validation.runtime
     ).forEach {
         testFixturesImplementation(it)?.because(

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:49:20 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-api:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1017,12 +1017,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.69.7`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1858,12 +1858,12 @@ This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-backend:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2884,12 +2884,12 @@ This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-cli:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3933,12 +3933,12 @@ This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4941,12 +4941,12 @@ This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5953,12 +5953,12 @@ This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7142,12 +7142,12 @@ This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-java:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8168,12 +8168,12 @@ This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.69.7`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9006,12 +9006,12 @@ This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10047,12 +10047,12 @@ This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.69.6`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.69.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11158,4 +11158,4 @@ This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 19:08:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Sat Dec 07 17:49:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Sat Dec 07 17:49:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Sat Dec 07 17:49:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Sat Dec 07 17:49:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 07 17:49:20 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 18:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Tue Dec 03 16:48:30 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Tue Dec 03 16:48:31 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Tue Dec 03 16:48:32 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Tue Dec 03 16:48:33 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 16:48:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 04 18:33:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1017,7 +1017,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1858,7 +1858,7 @@ This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2884,7 +2884,7 @@ This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3933,7 +3933,7 @@ This report was generated on **Wed Dec 04 19:08:35 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4941,7 +4941,7 @@ This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5953,7 +5953,7 @@ This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7142,7 +7142,7 @@ This report was generated on **Wed Dec 04 19:08:36 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8168,7 +8168,7 @@ This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9006,7 +9006,7 @@ This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10047,7 +10047,7 @@ This report was generated on **Wed Dec 04 19:08:37 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11158,4 +11158,4 @@ This report was generated on **Wed Dec 04 19:08:38 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 04 19:08:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 07 17:19:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -92,25 +92,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.242</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-jvm</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.242</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-reflect</artifactId>
-    <version>2.0.0-SNAPSHOT.190</version>
+    <version>2.0.0-SNAPSHOT.191</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.183</version>
+    <version>2.0.0-SNAPSHOT.182</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.177</version>
+    <version>2.0.0-SNAPSHOT.178</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -194,7 +194,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.183</version>
+    <version>2.0.0-SNAPSHOT.182</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.69.6</version>
+<version>0.69.7</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.69.6")
+val protoDataVersion: String by extra("0.69.7")


### PR DESCRIPTION
This PR adds `doc` and `span` properties for the `Option` type, and extends parsing of Protobuf descriptors for populating these properties.

## Changes in details
 * Extension functions called `options()` was added to the descriptor types. The functions return the options declared in the corresponding scope. 
 * The `ExtendableMessage.toList()` extension was hidden because the `options()` extensions now do the job.
 * `config` was also updated.
