### PR TITLE
Extend `MethodCall` with `put` methods

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-api:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1025,12 +1025,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:28 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:53 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.80.5`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Fri Dec 20 12:07:28 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:29 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:54 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-backend:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Fri Dec 20 12:07:29 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:30 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:55 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-cli:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3941,12 +3941,12 @@ This report was generated on **Fri Dec 20 12:07:30 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:31 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:56 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli-api:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-cli-api:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4949,12 +4949,12 @@ This report was generated on **Fri Dec 20 12:07:31 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:32 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:57 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5961,12 +5961,12 @@ This report was generated on **Fri Dec 20 12:07:32 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:32 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:58 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7150,12 +7150,12 @@ This report was generated on **Fri Dec 20 12:07:32 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:33 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:58 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-java:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8176,12 +8176,12 @@ This report was generated on **Fri Dec 20 12:07:33 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:34 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:54:59 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.80.5`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9014,12 +9014,12 @@ This report was generated on **Fri Dec 20 12:07:34 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:35 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:55:00 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10055,12 +10055,12 @@ This report was generated on **Fri Dec 20 12:07:35 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:36 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:55:01 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.80.4`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.80.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11179,4 +11179,4 @@ This report was generated on **Fri Dec 20 12:07:36 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 20 12:07:36 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 24 16:55:01 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/JavaValueConverter.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/JavaValueConverter.kt
@@ -111,7 +111,7 @@ public class JavaValueConverter(typeSystem: TypeSystem) : ValueConverter<Java, E
         return if (valuesMap.isEmpty()) {
             mapExpression()
         } else {
-            mapExpression(valuesMap, keyClass!!, valueClass!!)
+            mapExpression(keyClass!!, valueClass!!, valuesMap)
         }
     }
 

--- a/java/src/main/kotlin/io/spine/protodata/java/Literal.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/Literal.kt
@@ -53,3 +53,11 @@ public open class Literal<T>(value: T) : Expression<T>("$value")
  * No extra character escaping is performed.
  */
 public class StringLiteral(value: String) : Literal<String>("\"$value\"")
+
+/**
+ * A `long` literal.
+ *
+ * Represents the same value as the given long, followed by `L` symbol.
+ * For example, for "12" it will produce the following code: "12L".
+ */
+public class LongLiteral(value: Long) : Literal<String>("${value}L")

--- a/java/src/main/kotlin/io/spine/protodata/java/MethodCall.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MethodCall.kt
@@ -104,9 +104,29 @@ public open class MethodCall<T> @JvmOverloads constructor(
 
     /**
      * Constructs an expression chaining a call of an `addAllField(...)` method.
+     *
+     * @see listExpression
      */
     public fun chainAddAll(field: String, value: Expression<*>): MethodCall<Message.Builder> =
         fieldAccess(field).addAll(value)
+
+    /**
+     * Constructs an expression chaining a call of an `putField(...)` method.
+     */
+    public fun chainPut(
+        field: String,
+        key: Expression<*>,
+        value: Expression<*>
+    ): MethodCall<Message.Builder> =
+        fieldAccess(field).put(key, value)
+
+    /**
+     * Constructs an expression chaining a call of an `putAllField(...)` method.
+     *
+     * @see mapExpression
+     */
+    public fun chainPutAll(field: String, value: Expression<*>): MethodCall<Message.Builder> =
+        fieldAccess(field).putAll(value)
 
     private fun fieldAccess(fieldName: String) = FieldAccess(Expression(toCode()), fieldName)
 }

--- a/java/src/main/kotlin/io/spine/protodata/java/MethodCall.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MethodCall.kt
@@ -111,7 +111,7 @@ public open class MethodCall<T> @JvmOverloads constructor(
         fieldAccess(field).addAll(value)
 
     /**
-     * Constructs an expression chaining a call of an `putField(...)` method.
+     * Constructs an expression chaining a call of a `putField(...)` method.
      */
     public fun chainPut(
         field: String,
@@ -121,7 +121,7 @@ public open class MethodCall<T> @JvmOverloads constructor(
         fieldAccess(field).put(key, value)
 
     /**
-     * Constructs an expression chaining a call of an `putAllField(...)` method.
+     * Constructs an expression chaining a call of a `putAllField(...)` method.
      *
      * @see mapExpression
      */

--- a/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
@@ -112,9 +112,9 @@ public fun listExpression(vararg expressions: Expression<*>): MethodCall<Immutab
  * @param valueType The type of the values in the map.
  */
 public fun mapExpression(
-    entries: Map<Expression<*>, Expression<*>>,
     keyType: ClassName,
-    valueType: ClassName
+    valueType: ClassName,
+    entries: Map<Expression<*>, Expression<*>>
 ): MethodCall<ImmutableMap<*, *>> {
     require(entries.isNotEmpty()) {
         "Can't construct an expression to yield Guava's `ImmutableMap` with empty `entries`." +

--- a/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/MethodCalls.kt
@@ -107,9 +107,9 @@ public fun listExpression(vararg expressions: Expression<*>): MethodCall<Immutab
 /**
  * Constructs an expression that yields Guava's [ImmutableMap] with the given [entries].
  *
- * @param entries The entries to fill the map with, can't be empty.
  * @param keyType The type of the keys in the map.
  * @param valueType The type of the values in the map.
+ * @param entries The entries to fill the map with, can't be empty.
  */
 public fun mapExpression(
     keyType: ClassName,

--- a/java/src/test/kotlin/io/spine/protodata/java/FieldAccessSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/FieldAccessSpec.kt
@@ -107,9 +107,9 @@ internal class FieldAccessSpec {
     fun `provide putAll() method`() {
         val access = mapField().access()
         val mapValue = mapExpression(
-            mapOf(StringLiteral("foo") to StringLiteral("bar")),
             keyType = ClassName(String::class),
-            valueType = ClassName(String::class)
+            valueType = ClassName(String::class),
+            mapOf(StringLiteral("foo") to StringLiteral("bar"))
         )
         val expression = access.putAll(mapValue)
         val type = String::class.java.canonicalName

--- a/java/src/test/kotlin/io/spine/protodata/java/MethodCallSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/MethodCallSpec.kt
@@ -26,6 +26,7 @@
 
 package io.spine.protodata.java
 
+import com.google.api.QuotaLimit
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.protobuf.Duration
@@ -117,6 +118,41 @@ internal class MethodCallSpec {
             setter.toCode() shouldBe
                     "${FieldMask::class.qualifiedName}.newBuilder()" +
                     ".addAllPaths(${ImmutableList::class.qualifiedName}.of(1, 2))"
+        }
+
+        @Test
+        fun `put() method`() {
+            val builder = ClassName(QuotaLimit::class).newBuilder()
+                .chainPut(
+                    "values",
+                    StringLiteral("Standard"),
+                    LongLiteral(160)
+                )
+            builder.toCode() shouldBe
+                    "${QuotaLimit::class.qualifiedName}.newBuilder().putValues(\"Standard\", 160L)"
+        }
+
+        @Test
+        @Suppress("MaxLineLength") // To keep the readability of code literals.
+        fun `putAll() method`() {
+            val values = mapExpression(
+                keyType = ClassName(String::class),
+                valueType = ClassName(Long::class.javaObjectType),
+                entries = mapOf(
+                    StringLiteral("Short") to LongLiteral(80),
+                    StringLiteral("Standard") to LongLiteral(160),
+                    StringLiteral("Extended") to LongLiteral(560)
+                )
+            )
+            val builder = ClassName(QuotaLimit::class).newBuilder()
+                .chainPutAll("values", values)
+            builder.toCode() shouldBe
+                    "${QuotaLimit::class.qualifiedName}.newBuilder()" +
+                    ".putAllValues(" +
+                    "com.google.common.collect.ImmutableMap.<java.lang.String, java.lang.Long>builder()" +
+                    ".put(\"Short\", 80L).put(\"Standard\", 160L).put(\"Extended\", 560L)" +
+                    ".build()" +
+                    ")"
         }
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.80.4</version>
+<version>0.80.5</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.80.4")
+val protoDataVersion: String by extra("0.80.5")


### PR DESCRIPTION
This changeset does the following:

1. Extends `MethodCall` with `chainPut()` and `chainPutAll()` methods.
2. Changes the parameters order of `mapExpression()` method. Looks like declaration of the map key and value types should go before the actual entry list. We are used to reading declaration statements in this order.
3. Introduces `LongLiteral` that appends "L" ending to produced Java code.