### PR TITLE
File URIs in compilation warning and error messages

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -155,8 +155,8 @@ private fun File.maybeUri(): String = if (isAbsolute) {
 }
 
 /**
- * The prefix used in a file URI if no
- * [host name is used](https://en.wikipedia.org/wiki/File_URI_scheme).
+ * The prefix used in a file URI if
+ * [host name is not used](https://en.wikipedia.org/wiki/File_URI_scheme).
  */
 @VisibleForTesting
 internal const val NO_HOSTNAME_PREFIX = "file:/"

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -98,12 +98,8 @@ public object Compilation {
     }
 
     @VisibleForTesting
-    internal fun errorMessage(
-        file: File,
-        line: Int,
-        column: Int,
-        message: String
-    ) = "$ERROR_PREFIX ${file.maybeUri()}:$line:$column: $message"
+    internal fun errorMessage(file: File, line: Int, column: Int, message: String) =
+        "$ERROR_PREFIX ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * Prints the warning diagnostics to [System.out].
@@ -124,12 +120,8 @@ public object Compilation {
     }
 
     @VisibleForTesting
-    internal fun warningMessage(
-        file: File,
-        line: Int,
-        column: Int,
-        message: String
-    ) = "$WARNING_PREFIX ${file.maybeUri()}:$line:$column: $message"
+    internal fun warningMessage(file: File, line: Int, column: Int, message: String) =
+        "$WARNING_PREFIX ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * The exception thrown by [Compilation.error] when the testing mode is on.

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -167,7 +167,7 @@ internal const val NO_HOSTNAME_PREFIX = "file:/"
  *
  * We use this prefix because it is recognized by the IntelliJ IDEA
  * console as a clickable URI.
- * This prefix is also used for reporting Kotlin compilation errors.
+ * Kotlin compiler also uses this prefix for reporting compilation errors.
  */
 @VisibleForTesting
 internal const val EMPTY_HOSTNAME_PREFIX = "file:///"

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -32,6 +32,7 @@ import io.spine.environment.Tests
 import java.io.File
 import kotlin.system.exitProcess
 
+
 /**
  * Provides functions to report compilation errors and warnings.
  *
@@ -58,6 +59,18 @@ public object Compilation {
      * The exit code for a compilation error.
      */
     public const val ERROR_EXIT_CODE: Int = -1
+
+    /**
+     * The prefix used for error messages.
+     */
+    @VisibleForTesting
+    internal const val ERROR_PREFIX = "e:"
+
+    /**
+     * The prefix used for warning messages.
+     */
+    @VisibleForTesting
+    internal const val WARNING_PREFIX = "w:"
 
     /**
      * Prints the error diagnostics to [System.err] and terminates the compilation.
@@ -90,7 +103,7 @@ public object Compilation {
         line: Int,
         column: Int,
         message: String
-    ) = "e: ${file.maybeUri()}:$line:$column: $message"
+    ) = "$ERROR_PREFIX ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * Prints the warning diagnostics to [System.out].
@@ -116,7 +129,7 @@ public object Compilation {
         line: Int,
         column: Int,
         message: String
-    ) = "w: ${file.maybeUri()}:$line:$column: $message"
+    ) = "$WARNING_PREFIX ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * The exception thrown by [Compilation.error] when the testing mode is on.

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -131,13 +131,38 @@ public object Compilation {
 /**
  * Converts the path of this file into a URI if the path is absolute.
  *
- * If the path is relative, it is simply returned as the result of this function.
+ * The purpose of this function is to make it easier to locate a file with
+ * an error or a warning. When a file URI is used for the console output,
+ * it could be opened in an IDE or a browser.
  *
- * The purpose of this function is to provide make the file reference actionable
- * when it is printed in the console output associated with an error or warning message.
+ * If the path is relative, it is simply returned as the result of this function.
+ * Even though file URI could be
+ * [relative](https://stackoverflow.com/questions/7857416/file-uri-scheme-and-relative-files)
+ * we do not want to use this because its full path would be resolved relatively
+ * to a user home directory or the current directory.
+ * None of these cases represent a directory with proto files.
+ * Therefore, we just print a relative file name to avoid the confusion.
  */
 private fun File.maybeUri(): String = if (isAbsolute) {
-    toURI().toString()
+    toURI().toString().replace(NO_HOSTNAME_PREFIX, EMPTY_HOSTNAME_PREFIX)
 } else {
     path
 }
+
+/**
+ * The prefix used in a file URI if no
+ * [host name is used](https://en.wikipedia.org/wiki/File_URI_scheme).
+ */
+@VisibleForTesting
+internal const val NO_HOSTNAME_PREFIX = "file:/"
+
+/**
+ * The prefix used in a file URI for an
+ * [empty host name](https://en.wikipedia.org/wiki/File_URI_scheme).
+ *
+ * We use this prefix because it is recognized by the IntelliJ IDEA
+ * console as a clickable URI.
+ * This prefix is also used for reporting Kotlin compilation errors.
+ */
+@VisibleForTesting
+internal const val EMPTY_HOSTNAME_PREFIX = "file:///"

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 
 package io.spine.protodata
 
+import com.google.common.annotations.VisibleForTesting
 import io.spine.base.Mistake
 import io.spine.environment.Tests
 import java.io.File
@@ -83,12 +84,13 @@ public object Compilation {
         }
     }
 
-    private fun errorMessage(
+    @VisibleForTesting
+    internal fun errorMessage(
         file: File,
         line: Int,
         column: Int,
         message: String
-    ) = "e: $file:$line:$column: $message"
+    ) = "e: ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * Prints the warning diagnostics to [System.out].
@@ -103,10 +105,18 @@ public object Compilation {
      * @return the string printed to the console.
      */
     public fun warning(file: File, line: Int, column: Int, message: String): String {
-        val output = "w: $file:$line:$column: $message"
+        val output = warningMessage(file, line, column, message)
         println(output)
         return output
     }
+
+    @VisibleForTesting
+    internal fun warningMessage(
+        file: File,
+        line: Int,
+        column: Int,
+        message: String
+    ) = "w: ${file.maybeUri()}:$line:$column: $message"
 
     /**
      * The exception thrown by [Compilation.error] when the testing mode is on.
@@ -116,4 +126,18 @@ public object Compilation {
             private const val serialVersionUID: Long = 0L
         }
     }
+}
+
+/**
+ * Converts the path of this file into a URI if the path is absolute.
+ *
+ * If the path is relative, it is simply returned as the result of this function.
+ *
+ * The purpose of this function is to provide make the file reference actionable
+ * when it is printed in the console output associated with an error or warning message.
+ */
+private fun File.maybeUri(): String = if (isAbsolute) {
+    toURI().toString()
+} else {
+    path
 }

--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
@@ -102,9 +102,13 @@ public val FieldName.camelCase: String
 /**
  * Obtains the path to a Protobuf source file which declares
  * the message type to which this field belongs.
+ *
+ * @return The full path, if the declaring file is listed among [TypeSystem.compiledProtoFiles],
+ *  otherwise the path is relative.
  */
 public fun Field.declaringFile(typeSystem: TypeSystem): File {
     val messageType = declaringType.toMessageType(typeSystem)
     val file = messageType.file.toPath().toFile()
-    return file
+    val fullPath = typeSystem.compiledProtoFiles.find(file)
+    return fullPath ?: file
 }

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -111,13 +111,13 @@ internal class CompilationSpec {
     fun `use print file relative if it is not absolute`() {
         val file = File("not/absolute/file.proto")
         Compilation.errorMessage(file, 1, 2, "").let {
-            it shouldNotContain NO_HOSTNAME_PREFIX
             it shouldNotContain EMPTY_HOSTNAME_PREFIX
+            it shouldNotContain NO_HOSTNAME_PREFIX
             it shouldContain file.path
         }
         Compilation.warningMessage(file, 3, 4, "").let {
-            it shouldNotContain NO_HOSTNAME_PREFIX
             it shouldNotContain EMPTY_HOSTNAME_PREFIX
+            it shouldNotContain NO_HOSTNAME_PREFIX
             it shouldContain file.path
         }
     }

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -30,6 +30,8 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 import io.spine.logging.testing.tapConsole
+import io.spine.protodata.Compilation.ERROR_PREFIX
+import io.spine.protodata.Compilation.WARNING_PREFIX
 import java.io.File
 import java.nio.file.Paths
 import org.junit.jupiter.api.DisplayName
@@ -126,7 +128,7 @@ internal class CompilationSpec {
     fun `use the prefix for error messages`() {
         val file = File("with_error.proto")
         Compilation.errorMessage(file, 1, 2, "").let {
-            it shouldStartWith  "e:"
+            it shouldStartWith ERROR_PREFIX
         }
     }
 
@@ -134,7 +136,7 @@ internal class CompilationSpec {
     fun `use the prefix for warning messages`() {
         val file = File("with_warning.proto")
         Compilation.warningMessage(file, 3, 4, "").let {
-            it shouldStartWith  "w:"
+            it shouldStartWith WARNING_PREFIX
         }
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -51,8 +51,8 @@ internal class CompilationSpec {
             Compilation.error(file, lineNumber, columnNumber, errorMessage)
         }
         exception.message.let {
-            it shouldContain "file:/"
-            it shouldContain file.path
+            it shouldContain EMPTY_HOSTNAME_PREFIX
+            it shouldContain file.uriRef()
             it shouldContain "$lineNumber:$columnNumber"
             it shouldContain errorMessage
         }
@@ -71,7 +71,7 @@ internal class CompilationSpec {
         }
         consoleOutput.let {
             it shouldContain EMPTY_HOSTNAME_PREFIX // because the file path is absolute.
-            it shouldContain file.path
+            it shouldContain file.uriRef()
             it shouldContain "$lineNumber:$columnNumber"
             it shouldContain errorMessage
         }
@@ -90,7 +90,7 @@ internal class CompilationSpec {
         }
         consoleOutput.let {
             it shouldContain EMPTY_HOSTNAME_PREFIX // because the file path is absolute.
-            it shouldContain file.path
+            it shouldContain file.uriRef()
             it shouldContain "$lineNumber:$columnNumber"
             it shouldContain errorMessage
         }
@@ -101,11 +101,11 @@ internal class CompilationSpec {
         val file = File("/some/dir/file.proto").absoluteFile
         Compilation.errorMessage(file, 1, 2, "").let {
             it shouldContain EMPTY_HOSTNAME_PREFIX
-            it shouldContain file.path
+            it shouldContain file.uriRef()
         }
         Compilation.warningMessage(file, 3, 4, "").let {
             it shouldContain EMPTY_HOSTNAME_PREFIX
-            it shouldContain file.path
+            it shouldContain file.uriRef()
         }
     }
 
@@ -115,12 +115,12 @@ internal class CompilationSpec {
         Compilation.errorMessage(file, 1, 2, "").let {
             it shouldNotContain EMPTY_HOSTNAME_PREFIX
             it shouldNotContain NO_HOSTNAME_PREFIX
-            it shouldContain file.path
+            it shouldContain file.path // system-dependent file name.
         }
         Compilation.warningMessage(file, 3, 4, "").let {
             it shouldNotContain EMPTY_HOSTNAME_PREFIX
             it shouldNotContain NO_HOSTNAME_PREFIX
-            it shouldContain file.path
+            it shouldContain file.path // system-dependent file name.
         }
     }
 
@@ -138,5 +138,15 @@ internal class CompilationSpec {
         Compilation.warningMessage(file, 3, 4, "").let {
             it shouldStartWith WARNING_PREFIX
         }
+    }
+}
+
+private fun File.uriRef(): String {
+    val uriSeparator = "/"
+    val separator = File.pathSeparator
+    return if (separator == uriSeparator) {
+        path
+    } else {
+        path.replace(separator, uriSeparator)
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -143,7 +143,7 @@ internal class CompilationSpec {
 
 private fun File.uriRef(): String {
     val uriSeparator = "/"
-    val separator = File.pathSeparator
+    val separator = File.separator
     return if (separator == uriSeparator) {
         path
     } else {

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -68,7 +68,7 @@ internal class CompilationSpec {
             }
         }
         consoleOutput.let {
-            it shouldContain "file:/" // because the file path is absolute.
+            it shouldContain EMPTY_HOSTNAME_PREFIX // because the file path is absolute.
             it shouldContain file.path
             it shouldContain "$lineNumber:$columnNumber"
             it shouldContain errorMessage
@@ -87,7 +87,7 @@ internal class CompilationSpec {
             }
         }
         consoleOutput.let {
-            it shouldContain "file:/" // because the file path is absolute.
+            it shouldContain EMPTY_HOSTNAME_PREFIX // because the file path is absolute.
             it shouldContain file.path
             it shouldContain "$lineNumber:$columnNumber"
             it shouldContain errorMessage
@@ -98,11 +98,11 @@ internal class CompilationSpec {
     fun `use file URI for absolute paths`() {
         val file = File("/some/dir/file.proto").absoluteFile
         Compilation.errorMessage(file, 1, 2, "").let {
-            it shouldContain "file:/"
+            it shouldContain EMPTY_HOSTNAME_PREFIX
             it shouldContain file.path
         }
         Compilation.warningMessage(file, 3, 4, "").let {
-            it shouldContain "file:/"
+            it shouldContain EMPTY_HOSTNAME_PREFIX
             it shouldContain file.path
         }
     }
@@ -111,11 +111,13 @@ internal class CompilationSpec {
     fun `use print file relative if it is not absolute`() {
         val file = File("not/absolute/file.proto")
         Compilation.errorMessage(file, 1, 2, "").let {
-            it shouldNotContain "file:/"
+            it shouldNotContain NO_HOSTNAME_PREFIX
+            it shouldNotContain EMPTY_HOSTNAME_PREFIX
             it shouldContain file.path
         }
         Compilation.warningMessage(file, 3, 4, "").let {
-            it shouldNotContain "file:/"
+            it shouldNotContain NO_HOSTNAME_PREFIX
+            it shouldNotContain EMPTY_HOSTNAME_PREFIX
             it shouldContain file.path
         }
     }
@@ -131,7 +133,7 @@ internal class CompilationSpec {
     @Test
     fun `use the prefix for warning messages`() {
         val file = File("with_warning.proto")
-        Compilation.warningMessage(file, 1, 2, "").let {
+        Compilation.warningMessage(file, 3, 4, "").let {
             it shouldStartWith  "w:"
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.261"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.262"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.261"
+    const val version = "2.0.0-SNAPSHOT.262"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.90.0"
+    private const val fallbackVersion = "0.90.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.90.0"
+    private const val fallbackDfVersion = "0.90.1"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -105,6 +105,9 @@ object ProtoData {
 
     val backend
         get() = "$group:protodata-backend:$version"
+
+    val params
+        get() = "$group:protodata-params:$version"
 
     val protocPlugin
         get() = "$group:protodata-protoc:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,10 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Time {
-    const val version = "2.0.0-SNAPSHOT.135"
+    const val version = "2.0.0-SNAPSHOT.136"
     const val group = Spine.group
     const val artifact = "spine-time"
     const val lib = "$group:$artifact:$version"
 
-    //TODO:2024-11-29:alexander.yevsyukov: Change the artifact name to `spine-time-testlib`.
-    const val testLib = "${Spine.toolsGroup}:spine-testutil-time:$version"
+    const val testLib = "${Spine.toolsGroup}:spine-time-testlib:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.182"
+    const val version = "2.0.0-SNAPSHOT.183"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,9 @@ open class CheckVersionIncrement : DefaultTask() {
         val versions = metadata?.versioning?.versions
         val versionExists = versions?.contains(version) ?: false
         if (versionExists) {
-            throw GradleException("""
-                    Version `$version` is already published to maven repository `$repoUrl`.
+            throw GradleException(
+                    """
+                    The version `$version` is already published to the Maven repository `$repoUrl`.
                     Try incrementing the library version.
                     All available versions are: ${versions?.joinToString(separator = ", ")}. 
                     
@@ -88,12 +89,27 @@ open class CheckVersionIncrement : DefaultTask() {
 
     private fun Project.artifactPath(): String {
         val group = this.group as String
-        val name = "spine-${this.name}"
+        val name = "${artifactPrefix()}${this.name}"
 
         val pathElements = ArrayList(group.split('.'))
         pathElements.add(name)
         val path = pathElements.joinToString(separator = "/")
         return path
+    }
+
+    /**
+     * Returns the artifact prefix used for the publishing of this project.
+     *
+     * All current Spine modules should be using `SpinePublishing`.
+     * Therefore, the corresponding extension should be present in the root project.
+     * However, just in case, we define the "standard" prefix here as well.
+     *
+     * This value MUST be the same as defined by the defaults in `SpinePublishing`.
+     */
+    private fun Project.artifactPrefix(): String {
+        val ext = rootProject.extensions.findByType(SpinePublishing::class.java)
+        val result = ext?.artifactPrefix ?: SpinePublishing.DEFAULT_PREFIX
+        return result
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,6 +137,14 @@ fun Project.spinePublishing(block: SpinePublishing.() -> Unit) {
  */
 open class SpinePublishing(private val project: Project) {
 
+    companion object {
+
+        /**
+         * The default prefix added before a module name when publishing artifacts.
+         */
+        const val DEFAULT_PREFIX = "spine-"
+    }
+
     private val protoJar = ProtoJar()
     private val testJar = TestJar()
     private val dokkaJar = DokkaJar()
@@ -197,10 +205,8 @@ open class SpinePublishing(private val project: Project) {
 
     /**
      * A prefix to be added before the name of each artifact.
-     *
-     * The default value is "spine-".
      */
-    var artifactPrefix: String = "spine-"
+    var artifactPrefix: String = DEFAULT_PREFIX
 
     /**
      * Allows disabling publishing of [protoJar] artifact, containing all Proto sources

--- a/dependencies.md
+++ b/dependencies.md
@@ -1025,7 +1025,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:46 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1866,7 +1866,7 @@ This report was generated on **Sun Jan 05 17:13:46 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2892,7 +2892,7 @@ This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3973,7 +3973,7 @@ This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4985,7 +4985,7 @@ This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6153,7 +6153,7 @@ This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7179,7 +7179,7 @@ This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8212,7 +8212,7 @@ This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9050,7 +9050,7 @@ This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10091,7 +10091,7 @@ This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11215,4 +11215,4 @@ This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 05 17:13:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 20:24:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1025,12 +1025,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:46 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:46 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.90.2`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Sat Jan 04 15:44:46 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-backend:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3973,12 +3973,12 @@ This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4985,12 +4985,12 @@ This report was generated on **Sat Jan 04 15:44:47 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6153,12 +6153,12 @@ This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-java:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7179,12 +7179,12 @@ This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-params:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8212,12 +8212,12 @@ This report was generated on **Sat Jan 04 15:44:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.90.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10091,12 +10091,12 @@ This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.90.1`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.90.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11215,4 +11215,4 @@ This report was generated on **Sat Jan 04 15:44:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jan 04 15:44:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jan 05 17:13:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.90.1</version>
+<version>0.90.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.182</version>
+    <version>2.0.0-SNAPSHOT.183</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -217,8 +217,8 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-testutil-time</artifactId>
-    <version>2.0.0-SNAPSHOT.135</version>
+    <artifactId>spine-time-testlib</artifactId>
+    <version>2.0.0-SNAPSHOT.136</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -293,12 +293,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.90.0</version>
+    <version>0.90.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.90.0</version>
+    <version>0.90.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -308,13 +308,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.261</version>
+    <version>2.0.0-SNAPSHOT.262</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.261</version>
+    <version>2.0.0-SNAPSHOT.262</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.90.1")
+val protoDataVersion: String by extra("0.90.2")


### PR DESCRIPTION
This PR makes `Compilation.error()` and `warning()` functions use a file URI when an absolute file name is provided. IntelliJ IDEA recognises such a URI when printed in console, and the file could be opened right in the IDE.

### Build changes
 * Latest `config` was applied.
