### PR TITLE
Take the latest `tool-base` and bring a handful of improvements

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -71,26 +71,24 @@ protected constructor(
     /**
      * A code generation context associated with this instance.
      *
-     * Is `null` before the call to [registerWith].
-     *
-     * @see registerWith
+     * @throws IllegalStateException if accessed before `Code Generation` context
+     *  is [injected][registerWith].
      */
-    protected open val context: CodegenContext?
-        get() = if (this::_context.isInitialized) {
-            _context
-        } else {
-            null
-        }
+    protected open val context: CodegenContext by lazy {
+        checkContext(this::context.name)
+        _context
+    }
 
     /**
      * A type system with the Protobuf types defined in the current code generation pipeline.
      *
-     * Is `null` if the type system is not yet available to this renderer.
-     *
-     * This property is guaranteed to be non-`null` after [registerWith].
+     * @throws IllegalStateException if accessed before `Code Generation` context
+     *  is [injected][registerWith].
      */
-    protected open val typeSystem: TypeSystem?
-        get() = context?.typeSystem
+    protected open val typeSystem: TypeSystem by lazy {
+        checkContext(this::typeSystem.name)
+        context.typeSystem
+    }
 
     /**
      * Creates a [QueryingClient] for obtaining entity states of the given type.
@@ -152,6 +150,12 @@ protected constructor(
     @Internal
     override fun isRegistered(): Boolean {
         return this::_context.isInitialized
+    }
+
+    private fun checkContext(property: String) = check(this::_context.isInitialized) {
+        "Access to `${this::class.simpleName}.$property` property is not allowed until " +
+                "the `Code Generation` context has been injected. Please invoke " +
+                "`registerWith(CodegenContext)` method first."
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/render/InsertionPointPrinter.kt
+++ b/api/src/main/kotlin/io/spine/protodata/render/InsertionPointPrinter.kt
@@ -139,7 +139,7 @@ public abstract class InsertionPointPrinter<L: Language>(
         val cursors = coordinates.map { it.inline }
         val cursorsByLine = cursors.groupBy({ it.line }, { it.column })
         val comment = target.comment(point.codeLine)
-        cursorsByLine.forEach { lineNumber, columns ->
+        cursorsByLine.forEach { (lineNumber, columns) ->
             lines.checkLineNumber(lineNumber)
             val line = lines[lineNumber]
             columns.forEach {
@@ -172,10 +172,7 @@ public abstract class InsertionPointPrinter<L: Language>(
             label = pointLabel
             representationInCode = comment
         }
-        check(context != null) {
-            "Insertion point printer `$this` is not registered with a `CodegenContext`."
-        }
-        context!!.insertionPointsContext.emittedEvent(event, actorId)
+        context.insertionPointsContext.emittedEvent(event, actorId)
     }
 
     private companion object {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.240"
+    const val version = "2.0.0-SNAPSHOT.241"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/cli/src/main/kotlin/io/spine/protodata/cli/app/Main.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/app/Main.kt
@@ -53,7 +53,7 @@ import kotlin.system.exitProcess
  * Launches the CLI application.
  *
  * When the application is done exists the process with the code `0`.
- * If an unhandled error occurs, exits the process with the code `1`.
+ * If an unhandled error occurs, exits the process with the code `-1`.
  */
 @Suppress(
     "TooGenericExceptionCaught", // We do want the most generic type thrown.
@@ -72,7 +72,7 @@ public fun main(args: Array<String>) {
             e.printStackTrace(this)
             println("```")
         }
-        exitProcess(1)
+        exitProcess(-1)
     }
 }
 

--- a/cli/src/main/kotlin/io/spine/protodata/cli/app/Main.kt
+++ b/cli/src/main/kotlin/io/spine/protodata/cli/app/Main.kt
@@ -53,7 +53,7 @@ import kotlin.system.exitProcess
  * Launches the CLI application.
  *
  * When the application is done exists the process with the code `0`.
- * If an unhandled error occurs, exits the process with the code `-1`.
+ * If an unhandled error occurs, exits the process with the code `1`.
  */
 @Suppress(
     "TooGenericExceptionCaught", // We do want the most generic type thrown.
@@ -72,7 +72,7 @@ public fun main(args: Array<String>) {
             e.printStackTrace(this)
             println("```")
         }
-        exitProcess(-1)
+        exitProcess(1)
     }
 }
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1025,12 +1025,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.91.2`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1866,12 +1866,12 @@ This report was generated on **Sun Jan 12 19:36:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-backend:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2892,12 +2892,12 @@ This report was generated on **Sun Jan 12 19:36:30 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3973,12 +3973,12 @@ This report was generated on **Sun Jan 12 19:36:30 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4985,12 +4985,12 @@ This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6153,12 +6153,12 @@ This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-java:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7179,12 +7179,12 @@ This report was generated on **Sun Jan 12 19:36:31 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-params:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8212,12 +8212,12 @@ This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.91.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9050,12 +9050,12 @@ This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10091,12 +10091,12 @@ This report was generated on **Sun Jan 12 19:36:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:33 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.91.1`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.91.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11215,4 +11215,4 @@ This report was generated on **Sun Jan 12 19:36:33 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jan 12 19:36:33 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 16 14:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/Expression.kt
@@ -52,4 +52,4 @@ package io.spine.protodata.java
  * @param T The type of the returned value.
  * @param code The Java code denoting the expression.
  */
-public open class Expression<T>(code: String) : AnElement(code)
+public open class Expression<out T>(code: String) : AnElement(code)

--- a/java/src/main/kotlin/io/spine/protodata/java/FieldAccess.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/FieldAccess.kt
@@ -39,7 +39,7 @@ import io.spine.protodata.ast.fieldName
  */
 public class FieldAccess
 internal constructor(
-    public val message: Expression<out Message>,
+    public val message: Expression<Message>,
     name: FieldName,
     kind: Cardinality,
 ) : FieldConventions(name, kind) {
@@ -48,7 +48,7 @@ internal constructor(
      * Constructs field access for the given [message] and [name].
      */
     internal constructor(
-        message: Expression<out Message>,
+        message: Expression<Message>,
         name: String,
         kind: Cardinality = CARDINALITY_SINGLE
     ) : this(message, fieldName { value = name }, kind)

--- a/java/src/main/kotlin/io/spine/protodata/java/Fields.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/Fields.kt
@@ -29,7 +29,6 @@ package io.spine.protodata.java
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
 import io.spine.tools.psi.java.Environment.elementFactory
-import org.jaxen.expr.Expr
 
 /**
  * A declaration of a Java field.
@@ -37,7 +36,7 @@ import org.jaxen.expr.Expr
  * The declared field may OR may not be initialized,
  * depending on a specific implementation.
  */
-public sealed class FieldDeclaration<T>(public val name: String, code: String) : AnElement(code) {
+public sealed class FieldDeclaration<T>(public val name: String, code: String) : Statement(code) {
 
     /**
      * Returns an expression that reads the value of this field.

--- a/java/src/main/kotlin/io/spine/protodata/java/JavaElement.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/JavaElement.kt
@@ -51,5 +51,4 @@ public open class AnElement(public val code: String) : JavaElement  {
     override fun hashCode(): Int = code.hashCode()
 
     override fun toString(): String = code
-
 }

--- a/java/src/main/kotlin/io/spine/protodata/java/ProtobufExpressions.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ProtobufExpressions.kt
@@ -58,11 +58,11 @@ public fun Expression<*>.packToAny(): Expression<ProtoAny> {
 /**
  * Obtains a [FieldAccess] to the [field] of this message.
  */
-public fun Expression<out Message>.field(field: Field): FieldAccess =
+public fun Expression<Message>.field(field: Field): FieldAccess =
     FieldAccess(this, field.name, field.type.cardinality)
 
 /**
  * Obtains a [FieldAccess] to the field of this message with the given [name].
  */
-public fun Expression<out Message>.field(name: String, cardinality: Cardinality): FieldAccess =
+public fun Expression<Message>.field(name: String, cardinality: Cardinality): FieldAccess =
     FieldAccess(this, name, cardinality)

--- a/java/src/main/kotlin/io/spine/protodata/java/render/TypeRenderer.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/render/TypeRenderer.kt
@@ -55,7 +55,7 @@ public abstract class TypeRenderer<V>  : BaseRenderer<V>()
     }
 
     private fun doRender(view: V, type: MessageType, sourceFile: SourceFile<Java>) {
-        val actions = RenderActions(type, sourceFile, view.getActions(), context!!)
+        val actions = RenderActions(type, sourceFile, view.getActions(), context)
         actions.apply()
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.91.1</version>
+<version>0.91.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -128,13 +128,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.241</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.241</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -206,7 +206,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.241</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -319,7 +319,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.241</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/recorder/RecordingPlugin.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/recorder/RecordingPlugin.kt
@@ -81,7 +81,7 @@ public class RecordingPlugin : Plugin(
  */
 private class ContextAccess: Renderer<Java>(Java) {
 
-    fun context(): CodegenContext = context!!
+    fun context(): CodegenContext = context
 
     override fun render(sources: SourceFileSet) {
         // Do nothing.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.91.1")
+val protoDataVersion: String by extra("0.91.2")


### PR DESCRIPTION
This PR does the following:

1. Takes the latest `tool-base` to pick up [tool-base #111](https://github.com/SpineEventEngine/tool-base/pull/111).
2. Makes the whole `Expression` hierarchy covariant. Previously, only some child members declared it.
3. `FieldDeclaration` is actually `Statement`.

### Remove nullability of `Member` properties

I'm not 100% sure about this change, but personally don't foresee any problems.

I suggest moving null safety checks from the usage site to the declaration site of `Member.context` and `typeSystem` properties. Making them non-nullable is desired for the following reasons:

1. I have already met the third `JavaRenderer` that has such a line `public fun typeSystem(): TypeSystem = typeSystem!!`.
2. `!!` leads to a naked NPE while ISE from the declaration site would bring an error message.
3. Anyway, each line of code within renderers (and, probably, members) is meant to be executed during the codegen. 
4. We have `select()` method in `Member`, and it just throws when used without the injected codegen context, but could have returned `null` as properties do.