### PR TITLE
Exclude files by filter

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -29,8 +29,12 @@ package io.spine.protodata
 import com.google.common.annotations.VisibleForTesting
 import io.spine.base.Mistake
 import io.spine.environment.Tests
+import io.spine.protodata.Compilation.ERROR_EXIT_CODE
+import io.spine.protodata.Compilation.error
+import io.spine.protodata.ast.toPath
 import java.io.File
 import kotlin.system.exitProcess
+import io.spine.protodata.ast.File as PFile
 
 
 /**
@@ -96,6 +100,23 @@ public object Compilation {
             exitProcess(ERROR_EXIT_CODE)
         }
     }
+
+    /**
+     * Prints the error diagnostics to [System.err] and terminates the compilation.
+     *
+     * The termination of the compilation in the production mode is done by
+     * exiting the process with [ERROR_EXIT_CODE].
+     *
+     * If the code is run [under tests][Tests] the method throws [Compilation.Error].
+     *
+     * @param file The file in which the error occurred.
+     * @param line The one-based number of the line with the error.
+     * @param column The one-based number of the column with the error.
+     * @param message The description of what went wrong.
+     * @throws Compilation.Error exception when called under tests.
+     */
+    public fun error(file: PFile, line: Int, column: Int, message: String): Nothing =
+        error(file.toPath().toFile(), line, column, message)
 
     @VisibleForTesting
     internal fun errorMessage(file: File, line: Int, column: Int, message: String) =

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -62,11 +62,12 @@ internal object CompilerEvents {
         val allFiles = request.protoFileList.toDescriptors()
         val filesToGenerate = request.fileToGenerateList.toSet()
         return sequence {
-            val (ownFiles, dependencies) = allFiles.partition {
+            val (compiledFiles, dependencies) = allFiles.partition {
                 it.name in filesToGenerate
             }
             yieldAll(dependencies.map { it.toDependencyEvent() })
-            ownFiles
+            compiledFiles
+                .filter(descriptorFilter)
                 .map { ProtoFileEvents(it, descriptorFilter) }
                 .forEach {
                     it.apply { produceEvents() }

--- a/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
@@ -119,7 +119,7 @@ class CompilerEventsSpec {
         )
 
         @Test
-        fun `for standard file option`() = with(events) {
+        fun `for standard file option`(): Unit = with(events) {
             findJavaPackageEvent().option<StringValue>().value shouldBe "io.spine.protodata.test"
             findOuterClassNameEvent().option<StringValue>().value shouldBe "DoctorProto"
             findMultipleFilesEvent().option<BoolValue>().value shouldBe true

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-api:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1041,12 +1041,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:13 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.91.6`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1894,12 +1894,12 @@ This report was generated on **Wed Feb 12 19:41:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:13 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-backend:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2928,12 +2928,12 @@ This report was generated on **Wed Feb 12 19:41:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:13 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-cli:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4045,12 +4045,12 @@ This report was generated on **Wed Feb 12 19:41:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5061,12 +5061,12 @@ This report was generated on **Wed Feb 12 19:41:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6249,12 +6249,12 @@ This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-java:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7283,12 +7283,12 @@ This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-params:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8324,12 +8324,12 @@ This report was generated on **Wed Feb 12 19:41:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.91.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9166,12 +9166,12 @@ This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10215,12 +10215,12 @@ This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.91.5`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.91.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11351,4 +11351,4 @@ This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 12 19:41:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 13 18:05:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.91.5</version>
+<version>0.91.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.91.5")
+val protoDataVersion: String by extra("0.91.6")


### PR DESCRIPTION
This PR adds the ability to filter proto files by `descriptorFilter` passed to a `Pipeline`.

Also, an overload method `error()` accepting `io.spine.protodata.ast.File` added to `Compilation`.