### PR TITLE
Full file paths

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -128,7 +128,7 @@ public object Compilation {
      * If the code is run [under tests][Tests] the method throws [Compilation.Error].
      *
      * @param file The file in which the error occurred.
-     * @param span The span of Protobuf declaration which caused the error.
+     * @param span The span of the Protobuf declaration which caused the error.
      * @param message The function calculating the description of what went wrong.
      * @throws Compilation.Error exception when called under tests.
      */

--- a/api/src/main/kotlin/io/spine/protodata/Compilation.kt
+++ b/api/src/main/kotlin/io/spine/protodata/Compilation.kt
@@ -31,7 +31,8 @@ import io.spine.base.Mistake
 import io.spine.environment.Tests
 import io.spine.protodata.Compilation.ERROR_EXIT_CODE
 import io.spine.protodata.Compilation.error
-import io.spine.protodata.ast.toPath
+import io.spine.protodata.ast.Span
+import io.spine.protodata.ast.toJava
 import java.io.File
 import kotlin.system.exitProcess
 import io.spine.protodata.ast.File as PFile
@@ -116,7 +117,23 @@ public object Compilation {
      * @throws Compilation.Error exception when called under tests.
      */
     public fun error(file: PFile, line: Int, column: Int, message: String): Nothing =
-        error(file.toPath().toFile(), line, column, message)
+        error(file.toJava(), line, column, message)
+
+    /**
+     * Prints the error diagnostics to [System.err] and terminates the compilation.
+     *
+     * The termination of the compilation in the production mode is done by
+     * exiting the process with [ERROR_EXIT_CODE].
+     *
+     * If the code is run [under tests][Tests] the method throws [Compilation.Error].
+     *
+     * @param file The file in which the error occurred.
+     * @param span The span of Protobuf declaration which caused the error.
+     * @param message The function calculating the description of what went wrong.
+     * @throws Compilation.Error exception when called under tests.
+     */
+    public fun error(file: PFile, span: Span, message: () -> String): Nothing =
+        error(file, span.startLine, span.startColumn, message())
 
     @VisibleForTesting
     internal fun errorMessage(file: File, line: Int, column: Int, message: String) =

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
@@ -31,12 +31,6 @@ package io.spine.protodata.ast
 import io.spine.protodata.type.TypeSystem
 
 /**
- * Obtains the package and the name of the type.
- */
-public val MessageType.qualifiedName: String
-    get() = name.qualifiedName
-
-/**
  * Obtains column fields of this message type.
  *
  * @return the list if the column fields, or

--- a/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
+++ b/api/src/main/kotlin/io/spine/protodata/type/TypeSystem.kt
@@ -103,6 +103,7 @@ public class TypeSystem(
  * @return the file with the declaration, or `null` if the file is not among
  *  the [compiled proto files][TypeSystem.compiledProtoFiles] known to this type system.
  */
+@Deprecated(message = "Please use `file` properties of `ProtoDeclaration`s with `toJava()`")
 public fun TypeSystem.fileOf(d: ProtoDeclaration): File? {
     val file = d.file.toJava()
     return compiledProtoFiles.find(file)

--- a/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/Pipeline.kt
@@ -295,7 +295,7 @@ public class Pipeline(
         settings.emitEvents().forEach {
             configuration.emitted(it)
         }
-        val events = CompilerEvents.parse(request, descriptorFilter)
+        val events = CompilerEvents.parse(request, typeSystem, descriptorFilter)
         compiler.emitted(events)
     }
 
@@ -326,7 +326,8 @@ private fun printError(message: String?) {
 /**
  * Converts this code generation request into [TypeSystem] taking all the proto files.
  */
-private fun CodeGeneratorRequest.toTypeSystem(compiledProtoFiles: ProtoFileList): TypeSystem {
+@VisibleForTesting
+internal fun CodeGeneratorRequest.toTypeSystem(compiledProtoFiles: ProtoFileList): TypeSystem {
     val fileDescriptors = FileSet.of(protoFileList).files()
     val protoFiles = fileDescriptors.map { it.toPbSourceFile() }
     return TypeSystem(compiledProtoFiles, protoFiles.toSet())

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -92,10 +92,14 @@ private class ProtoFileEvents(
     private val descriptorFilter: DescriptorFilter
 ) {
     /**
-     * Obtains the header of the proto [file] replacing its path
-     * the [TypeSystem] passed to the constructor parameter.
+     * The header of the proto [file] passed to the constructor.
      *
-     * If the full path is not available, the original header with the relative path is used.
+     * During the lazy evaluation, the [ProtoFileHeader.file][ProtoFileHeader.getFile] property,
+     * which is relative by default, is replaced with the absolute version using
+     * the [TypeSystem] passed to the constructor.
+     *
+     * If the full path of the proto file is not available via the [TypeSystem],
+     * the header with the relative path is used.
      */
     private val header: ProtoFileHeader by lazy {
         val hdr = file.toHeader()

--- a/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -54,11 +54,13 @@ import io.spine.protodata.ast.span
 import io.spine.protodata.ast.toType
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.context.CodegenContext
+import io.spine.protodata.protobuf.ProtoFileList
 import io.spine.protodata.protobuf.file
 import io.spine.protodata.protobuf.toFile
 import io.spine.protodata.test.DoctorProto
 import io.spine.protodata.test.PhDProto
 import io.spine.protodata.test.XtraOptsProto
+import io.spine.protodata.type.TypeSystem
 import io.spine.testing.server.blackbox.BlackBox
 import io.spine.testing.server.blackbox.assertEntity
 import io.spine.time.TimeProto
@@ -125,6 +127,10 @@ class CodeGenerationContextSpec {
             fileToGenerate.addAll(filesToGenerate)
         }
 
+        private val typeSystem = codeGeneratorRequest.toTypeSystem(
+            ProtoFileList(listOf())
+        )
+
         fun createCodegenBlackBox(pipelineId: String): Pair<CodegenContext, BlackBox> {
             val context = CodeGenerationContext(pipelineId)
             val blackBox = BlackBox.from(context.context)
@@ -132,7 +138,7 @@ class CodeGenerationContextSpec {
         }
 
         fun emitCompilerEvents(pipelineId: String) {
-            val events = CompilerEvents.parse(codeGeneratorRequest, { true })
+            val events = CompilerEvents.parse(codeGeneratorRequest, typeSystem, { true })
             ProtobufCompilerContext(pipelineId).use {
                 it.emitted(events)
             }
@@ -272,7 +278,7 @@ class CodeGenerationContextSpec {
                 protoFile.addAll(dependencies)
                 fileToGenerate.addAll(dependencies.map { it.name })
             }
-            val events = CompilerEvents.parse(set, { true })
+            val events = CompilerEvents.parse(set, Fixtures.typeSystem, { true })
 
             val eventList = events.toList()
             eventList.distinct() shouldContainExactly eventList

--- a/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
@@ -64,6 +64,8 @@ import io.spine.protodata.ast.event.TypeExited
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.messageType
 import io.spine.protodata.ast.typeName
+import io.spine.protodata.backend.toTypeSystem
+import io.spine.protodata.protobuf.ProtoFileList
 import io.spine.protodata.test.DoctorProto
 import io.spine.testing.Correspondences
 import io.spine.type.KnownTypes
@@ -97,7 +99,10 @@ class CompilerEventsSpec {
             fileToGenerate += DoctorProto.getDescriptor().fullName
             protoFile.addAll(allDependencyFiles)
         }
-        events = CompilerEvents.parse(request, { true }).toList()
+        val typeSystem = request.toTypeSystem(
+            ProtoFileList(listOf())
+        )
+        events = CompilerEvents.parse(request, typeSystem, { true }).toList()
     }
 
     @Test

--- a/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
@@ -33,6 +33,7 @@ import com.google.protobuf.DescriptorProtos.MethodOptions.IdempotencyLevel.NO_SI
 import com.google.protobuf.DescriptorProtos.MethodOptions.IdempotencyLevel.NO_SIDE_EFFECTS_VALUE
 import com.google.protobuf.Message
 import com.google.protobuf.StringValue
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.codeGeneratorRequest
 import com.google.protobuf.enumValue
 import io.kotest.matchers.collections.shouldContainExactly
@@ -63,14 +64,19 @@ import io.spine.protodata.ast.event.TypeEntered
 import io.spine.protodata.ast.event.TypeExited
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.messageType
+import io.spine.protodata.ast.toJava
 import io.spine.protodata.ast.typeName
 import io.spine.protodata.backend.toTypeSystem
 import io.spine.protodata.protobuf.ProtoFileList
 import io.spine.protodata.test.DoctorProto
+import io.spine.protodata.type.TypeSystem
 import io.spine.testing.Correspondences
+import io.spine.tools.prototap.CompiledProtosFile
 import io.spine.type.KnownTypes
+import java.io.File
+import java.net.URLClassLoader
 import kotlin.reflect.KClass
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -83,26 +89,51 @@ import org.junit.jupiter.api.Test
 @DisplayName("`CompilerEvents` should")
 class CompilerEventsSpec {
 
-    private val nl: String = System.lineSeparator()
+    companion object {
 
-    private lateinit var events: List<EventMessage>
+        private val nl: String = System.lineSeparator()
 
-    @BeforeEach
-    fun parseEvents() {
-        // Gather files of all known types to simplify resolving dependencies.
-        val allDependencyFiles = KnownTypes.instance()
-            .asTypeSet()
-            .messageTypes()
-            .map { it.descriptor().file.toProto() }
+        private lateinit var events: List<EventMessage>
 
-        val request = codeGeneratorRequest {
-            fileToGenerate += DoctorProto.getDescriptor().fullName
-            protoFile.addAll(allDependencyFiles)
+        @BeforeAll
+        @JvmStatic
+        fun parseEvents() {
+            val request = createRequest()
+            val typeSystem = createTypeSystem(request)
+            events = CompilerEvents.parse(request, typeSystem, { true }).toList()
         }
-        val typeSystem = request.toTypeSystem(
-            ProtoFileList(listOf())
-        )
-        events = CompilerEvents.parse(request, typeSystem, { true }).toList()
+
+        private fun createRequest(): CodeGeneratorRequest {
+            // Gather files of all known types to simplify resolving dependencies.
+            val allDependencyFiles = KnownTypes.instance()
+                .asTypeSet()
+                .messageTypes()
+                .map { it.descriptor().file.toProto() }
+
+            val request = codeGeneratorRequest {
+                fileToGenerate += DoctorProto.getDescriptor().fullName
+                protoFile.addAll(allDependencyFiles)
+            }
+            return request
+        }
+
+        /**
+         * Creates a type system using the list of compiled proto files
+         * from the `test-env` module, which provides the [DoctorProto] file used
+         * by this test suite.
+         */
+        private fun createTypeSystem(request: CodeGeneratorRequest): TypeSystem {
+            val testEnvJar = DoctorProto::class.java.protectionDomain.codeSource.location
+            // Create the class loader without the parent because the parent is checked first.
+            // We only interested in that particular JAR.
+            val urlClassLoader = URLClassLoader(arrayOf(testEnvJar), null)
+            val protoFiles = CompiledProtosFile(urlClassLoader)
+                .listFiles { File(it) }
+            val typeSystem = request.toTypeSystem(
+                ProtoFileList(protoFiles)
+            )
+            return typeSystem
+        }
     }
 
     @Test
@@ -136,6 +167,13 @@ class CompilerEventsSpec {
 
             event shouldNotBe null
             event.option<StringValue>().value shouldBe "type.spine.io"
+        }
+
+        @Test
+        fun `with full file path`() {
+            events.first { it is FileEntered }.let { event ->
+                (event as FileEntered).file.toJava().isAbsolute shouldBe true
+            }
         }
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.240"
+    const val version = "2.0.0-SNAPSHOT.241"
     const val versionForBuildScript = "2.0.0-SNAPSHOT.241"
     const val group = Spine.group
     const val artifact = "spine-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.91.4"
+    private const val fallbackVersion = "0.91.8"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -38,7 +38,7 @@ package io.spine.dependency.local
 )
 object ProtoTap {
     const val group = "io.spine.tools"
-    const val version = "0.9.0"
+    const val version = "0.9.1"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1041,7 +1041,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1894,7 +1894,7 @@ This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2928,7 +2928,7 @@ This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4045,7 +4045,7 @@ This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5061,7 +5061,7 @@ This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6249,7 +6249,7 @@ This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7283,7 +7283,7 @@ This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8324,7 +8324,7 @@ This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9166,7 +9166,7 @@ This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10215,7 +10215,7 @@ This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11351,4 +11351,4 @@ This report was generated on **Sun Feb 16 17:35:54 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 17:35:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1041,7 +1041,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1894,7 +1894,7 @@ This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2928,7 +2928,7 @@ This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:51 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4045,7 +4045,7 @@ This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5061,7 +5061,7 @@ This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6249,7 +6249,7 @@ This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:52 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7042,10 +7042,6 @@ This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7287,7 +7283,7 @@ This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8328,7 +8324,7 @@ This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9170,7 +9166,7 @@ This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:53 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10219,7 +10215,7 @@ This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11355,4 +11351,4 @@ This report was generated on **Sat Feb 15 19:41:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 15 19:41:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 17:35:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1041,12 +1041,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.0`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1894,12 +1894,12 @@ This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2928,12 +2928,12 @@ This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4045,12 +4045,12 @@ This report was generated on **Fri Feb 14 21:40:35 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5061,12 +5061,12 @@ This report was generated on **Fri Feb 14 21:40:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:35 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6249,12 +6249,12 @@ This report was generated on **Fri Feb 14 21:40:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7042,6 +7042,10 @@ This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7283,12 +7287,12 @@ This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8324,12 +8328,12 @@ This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.0`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9166,12 +9170,12 @@ This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10215,12 +10219,12 @@ This report was generated on **Fri Feb 14 21:40:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:38 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.91.7`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.0`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11351,4 +11355,4 @@ This report was generated on **Fri Feb 14 21:40:38 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 21:40:38 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 15 19:41:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1041,7 +1041,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1894,7 +1894,7 @@ This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2928,7 +2928,7 @@ This report was generated on **Sun Feb 16 18:02:14 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:55 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4045,7 +4045,7 @@ This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:55 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5061,7 +5061,7 @@ This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:56 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6249,7 +6249,7 @@ This report was generated on **Sun Feb 16 18:02:15 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:56 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7283,7 +7283,7 @@ This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:56 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8324,7 +8324,7 @@ This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:56 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9166,7 +9166,7 @@ This report was generated on **Sun Feb 16 18:02:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:57 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10215,7 +10215,7 @@ This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:57 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11351,4 +11351,4 @@ This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 16 18:02:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 16 18:33:57 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.91.7</version>
+<version>0.92.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -212,7 +212,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.201</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.241</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -110,7 +110,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.201</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -122,7 +122,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>prototap-api</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/test-env/build.gradle.kts
+++ b/test-env/build.gradle.kts
@@ -29,6 +29,7 @@ import io.spine.dependency.lib.Grpc
 
 plugins {
     `build-proto-model`
+    prototap
 }
 
 dependencies {
@@ -50,6 +51,15 @@ protobuf {
             }
         }
     }
+}
+
+prototap {
+    sourceSet.set(sourceSets.main.get())
+}
+
+// Add resources placed by ProtoTap so that we can use them from tests in other modules.
+tasks.processResources {
+    from(tasks.processTestResources)
 }
 
 /**

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
@@ -51,6 +51,7 @@ import io.spine.tools.code.Kotlin
 import io.spine.tools.code.Language
 import io.spine.tools.code.Protobuf
 import io.spine.tools.code.TypeScript
+import io.spine.tools.prototap.CompiledProtosFile
 import io.spine.tools.prototap.Names.PROTOC_PLUGIN_NAME
 import io.spine.tools.prototap.Paths.CODE_GENERATOR_REQUEST_FILE
 import io.spine.tools.prototap.Paths.COMPILED_PROTOS_FILE
@@ -346,16 +347,11 @@ public class PipelineSetup(
             params: @NonValidated PipelineParameters,
             classLoader: ClassLoader
         ): @NonValidated PipelineParameters{
-            val listFile = Resource.file(
-                "$PROTOC_PLUGIN_NAME/$COMPILED_PROTOS_FILE",
-                classLoader
-            )
             return if (params.compiledProtoList.isEmpty()) {
-                val fileNames = listFile.read().lines()
-                    .filter { it.isNotBlank() }
-                    .map { file { path = it } }
+                val files = CompiledProtosFile(classLoader)
+                    .listFiles { file { path = it } }
                 params.toBuilder()
-                    .addAllCompiledProto(fileNames)
+                    .addAllCompiledProto(files)
                     .buildPartial()
             } else {
                 params

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.91.7")
+val protoDataVersion: String by extra("0.92.0")


### PR DESCRIPTION
This PR makes the `Pipeline` pick up full proto file paths when generating events and `ast` types. This will simplify reporting errors because the full path would be available from a class implementing `ProtoDeclaration` interface.

## Changes in details

The `ProtoFileEvents ` was updated to replace the `file` property of `ProtoFileHeader` obtained from a file descriptor (which gave a relative path) to the absolute path obtained via `TypeSystem.compiledProtoFiles`.
After that the generated events obtain the full path from the transformed header.

### Other notable changes
 * Added overload of `Compilation.error()` function which accepts `Span` and a function for calculating an error message.
 * `TypeSystem.fileOf()` was deprecated because now `file` properties give full paths.
 * The extension property `MessageType.qualifiedName` was removed because the property is available via the `ProtoDeclaration` interface.
