### PR TITLE
Finding via absolute and relative paths

### DIFF
--- a/api-tests/src/test/kotlin/io/spine/protodata/context/MemberSpec.kt
+++ b/api-tests/src/test/kotlin/io/spine/protodata/context/MemberSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,11 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldEndWith
 import io.spine.protodata.ast.EnumInFile
 import io.spine.protodata.ast.MessageInFile
+import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.ServiceInFile
+import io.spine.protodata.given.members.Person
 import io.spine.protodata.params.WorkingDirectory
+import io.spine.protodata.protobuf.toMessageType
 import io.spine.protodata.render.Renderer
 import io.spine.protodata.render.SourceFileSet
 import io.spine.protodata.testing.PipelineSetup
@@ -52,6 +55,12 @@ internal class MemberSpec {
 
     companion object {
 
+        /**
+         * This is the subject of testing.
+         *
+         * This renderer invokes the extension functions under the test in
+         * its [ProbeRenderer.render] method.
+         */
         val probe = ProbeRenderer()
 
         /**
@@ -80,6 +89,10 @@ internal class MemberSpec {
         }
     }
 
+    /**
+     * Tests under this class inspect sets collected by [ProbeRenderer]
+     * when its [ProbeRenderer.render] function is called.
+     */
     @Nested inner class
     `provide extensions for` {
 
@@ -128,6 +141,20 @@ internal class MemberSpec {
             }
         }
     }
+
+    @Nested inner class
+    `find a header via` {
+
+        @Test
+        fun `relative path`() {
+            probe.headerViaRelativePath shouldNotBe null
+        }
+
+        @Test
+        fun `absolute path`() {
+            probe.headerViaAbsolutePath shouldNotBe null
+        }
+    }
 }
 
 /**
@@ -140,10 +167,20 @@ class ProbeRenderer : Renderer<Java>(Java) {
     lateinit var enumTypes: Set<EnumInFile>
     lateinit var services: Set<ServiceInFile>
 
+    var headerViaRelativePath: ProtoFileHeader? = null
+    var headerViaAbsolutePath: ProtoFileHeader? = null
+
     override fun render(sources: SourceFileSet) {
         messageTypes = findMessageTypes()
         enumTypes = findEnumTypes()
         services = findServices()
+
+        val relativeFile = Person.getDescriptor().toMessageType().file
+        headerViaRelativePath = findHeader(relativeFile)
+
+        val personMessage = messageTypes.find("Person")!!.message
+        val absoluteFile = personMessage.file
+        headerViaAbsolutePath = findHeader(absoluteFile)
     }
 }
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
@@ -38,8 +38,15 @@ import kotlin.io.path.nameWithoutExtension
  * Converts the given path to a [File] message containing an absolute version of this path.
  */
 public fun Path.toProto(): File = file {
-    path = absolutePathString()
+    path = absolutePathString().toUnix()
 }
+
+private fun String.toUnix(): String = replace('\\', '/')
+
+/**
+ * Obtains the path to this file with Unix separators.
+ */
+public fun java.io.File.unixPath(): String = path.toUnix()
 
 /**
  * Converts this path to a [Directory] message.
@@ -55,7 +62,7 @@ public fun java.io.File.toProto(): File = toPath().toProto()
  * Converts this instance of [java.io.File] to a [Directory] message.
  */
 public fun java.io.File.toDirectory(): Directory =
-    directory { this@directory.path = this@toDirectory.path }
+    directory { this@directory.path = this@toDirectory.path.toUnix() }
 
 /**
  * Converts this [File] message to a [Path].

--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -160,10 +160,23 @@ protected constructor(
 }
 
 /**
- * Obtains the header of the proto file with the given [path].
+ * Obtains the proto source file with the given [path].
+ *
+ * @param path The path to the source file which could be relative or absolute.
  */
-public fun Member<*>.findHeader(path: File): ProtoFileHeader? =
-    (this as Querying).select<ProtobufSourceFile>().findById(path)?.header
+public fun Member<*>.findSource(path: File): ProtobufSourceFile? {
+    return (this as Querying).select<ProtobufSourceFile>().findById(path)
+        ?: run {
+            findAllFiles().firstOrNull { it.file.path.endsWith(path.path) }
+        }
+}
+
+/**
+ * Obtains the header of the proto file with the given [path].
+ *
+ * @param path The path to the source file which could be relative or absolute.
+ */
+public fun Member<*>.findHeader(path: File): ProtoFileHeader? = findSource(path)?.header
 
 /**
  * Obtains all Protobuf source code files passed to the current compilation process.

--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -35,6 +35,7 @@ import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.ProtobufSourceFile
 import io.spine.protodata.ast.ServiceInFile
 import io.spine.protodata.ast.enums
+import io.spine.protodata.ast.unixPath
 import io.spine.protodata.ast.messages
 import io.spine.protodata.ast.services
 import io.spine.protodata.settings.LoadsSettings
@@ -167,7 +168,9 @@ protected constructor(
  */
 public fun Member<*>.findSource(path: File): ProtobufSourceFile? {
     return (this as Querying).select<ProtobufSourceFile>().findById(path)
-        ?: findAllFiles().firstOrNull { it.file.path.endsWith(path.path) }
+        ?: findAllFiles().firstOrNull {
+            it.file.path.endsWith(path.path)
+        }
 }
 
 /**

--- a/api/src/main/kotlin/io/spine/protodata/context/Member.kt
+++ b/api/src/main/kotlin/io/spine/protodata/context/Member.kt
@@ -163,18 +163,18 @@ protected constructor(
  * Obtains the proto source file with the given [path].
  *
  * @param path The path to the source file which could be relative or absolute.
+ * @return the found source file message, or `null` if the file was not found.
  */
 public fun Member<*>.findSource(path: File): ProtobufSourceFile? {
     return (this as Querying).select<ProtobufSourceFile>().findById(path)
-        ?: run {
-            findAllFiles().firstOrNull { it.file.path.endsWith(path.path) }
-        }
+        ?: findAllFiles().firstOrNull { it.file.path.endsWith(path.path) }
 }
 
 /**
  * Obtains the header of the proto file with the given [path].
  *
  * @param path The path to the source file which could be relative or absolute.
+ * @return the found header, or `null` if the file was not found.
  */
 public fun Member<*>.findHeader(path: File): ProtoFileHeader? = findSource(path)?.header
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.202"
+    const val version = "2.0.0-SNAPSHOT.203"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.91.8"
+    private const val fallbackVersion = "0.92.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1041,7 +1041,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1894,7 +1894,7 @@ This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:14 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2928,7 +2928,7 @@ This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4045,7 +4045,7 @@ This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5061,7 +5061,7 @@ This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6249,7 +6249,7 @@ This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7283,7 +7283,7 @@ This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8324,7 +8324,7 @@ This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9166,7 +9166,7 @@ This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10215,7 +10215,7 @@ This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:03 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11351,4 +11351,4 @@ This report was generated on **Mon Feb 17 14:38:03 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 14:38:03 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:54:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1041,12 +1041,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.2`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1894,12 +1894,12 @@ This report was generated on **Mon Feb 17 12:57:57 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2928,12 +2928,12 @@ This report was generated on **Mon Feb 17 12:57:57 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4045,12 +4045,12 @@ This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5061,12 +5061,12 @@ This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6249,12 +6249,12 @@ This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7283,12 +7283,12 @@ This report was generated on **Mon Feb 17 12:57:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8324,12 +8324,12 @@ This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9166,12 +9166,12 @@ This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10215,12 +10215,12 @@ This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:03 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.92.1`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.2`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11351,4 +11351,4 @@ This report was generated on **Mon Feb 17 12:57:59 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 12:58:00 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 14:38:03 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.202</version>
+    <version>2.0.0-SNAPSHOT.203</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -129,6 +129,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java</artifactId>
     <version>2.0.0-SNAPSHOT.244</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-testutil-server</artifactId>
+    <version>2.0.0-SNAPSHOT.203</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -207,12 +213,6 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.244</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.202</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.92.1</version>
+<version>0.92.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -133,12 +133,6 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.202</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
     <version>2.0.0-SNAPSHOT.244</version>
     <scope>compile</scope>
@@ -213,6 +207,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.244</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-testutil-server</artifactId>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -303,7 +303,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>prototap-protoc-plugin</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/test-env/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
+++ b/test-env/src/main/kotlin/io/spine/protodata/test/DeletingRenderer.kt
@@ -27,13 +27,13 @@
 package io.spine.protodata.test
 
 import com.google.protobuf.StringValue
-import io.spine.protodata.ast.ProtobufSourceFile
 import io.spine.protodata.ast.find
+import io.spine.protodata.context.findSource
 import io.spine.protodata.render.Renderer
 import io.spine.protodata.render.SourceFileSet
 import io.spine.server.query.Querying
-import io.spine.tools.code.Java
 import io.spine.server.query.select
+import io.spine.tools.code.Java
 import kotlin.io.path.Path
 import kotlin.io.path.div
 
@@ -45,7 +45,7 @@ public class DeletingRenderer : Renderer<Java>(Java) {
     override fun render(sources: SourceFileSet) {
         val types = (this as Querying).select<DeletedType>().all()
         types.forEach {
-            val source = (this as Querying).select<ProtobufSourceFile>().findById(it.type.file)
+            val source = findSource(it.type.file)
             val javaPackage = source!!.header.optionList
                 .find("java_package", StringValue::class.java)!!.value
             val simpleName = it.type.name.simpleName

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.92.1")
+val protoDataVersion: String by extra("0.92.2")


### PR DESCRIPTION
This PR adds the `Member.findSource()` extension which allows to find an instance of `ProtobufSourceFile` via relative or full file path. This, in turn, fixes the issue `Member.findHeader()` extension function which used to find the header only via a relative path, which used to be an ID of corresponding entity states. Now both absolute and relative paths work.
