### PR TITLE
Fix full paths in `ProtoDeclaration` implementions

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
@@ -30,11 +30,10 @@ package io.spine.protodata.ast
  * Replaces the [file][EnumType.file] property of this enum type with
  * the specified absolute path.
  *
+ * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
  *  this enum type prior to the call of this function.
  */
-public fun EnumType.withAbsoluteFile(path: File): EnumType {
-    checkReplacingAbsoluteFile(path)
-    return copy { file = path }
-}
+public fun EnumType.withAbsoluteFile(path: File): EnumType =
+    replaceIfNotAbsoluteAlready(path) { copy { file = path } }

--- a/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+/**
+ * Replaces the [file][EnumType.file] property of this enum type with
+ * the specified absolute path.
+ *
+ * @throws IllegalArgumentException if the given path is not absolute, or
+ *  if the given path is not an absolute version of the relative file set in
+ *  this enum type prior to the call of this function.
+ */
+public fun EnumType.withAbsoluteFile(path: File): EnumType {
+    checkReplacingAbsoluteFile(path)
+    return copy { file = path }
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/EnumTypeExts.kt
@@ -33,7 +33,7 @@ package io.spine.protodata.ast
  * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
- *  this enum type prior to the call of this function.
+ *  this enum type before the call of this function.
  */
 public fun EnumType.withAbsoluteFile(path: File): EnumType =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,19 @@
 package io.spine.protodata.ast
 
 import io.spine.protodata.type.TypeSystem
+
+/**
+ * Replaces the [file][MessageType.file] property of this message type with
+ * the specified absolute path.
+ *
+ * @throws IllegalArgumentException if the given path is not absolute, or
+ *  if the given path is not an absolute version of the relative file set in
+ *  this message type prior to the call of this function.
+ */
+public fun MessageType.withAbsoluteFile(path: File): MessageType {
+    checkReplacingAbsoluteFile(path)
+    return copy { file = path }
+}
 
 /**
  * Obtains column fields of this message type.

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
@@ -34,14 +34,13 @@ import io.spine.protodata.type.TypeSystem
  * Replaces the [file][MessageType.file] property of this message type with
  * the specified absolute path.
  *
+ * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
  *  this message type prior to the call of this function.
  */
-public fun MessageType.withAbsoluteFile(path: File): MessageType {
-    checkReplacingAbsoluteFile(path)
-    return copy { file = path }
-}
+public fun MessageType.withAbsoluteFile(path: File): MessageType =
+    replaceIfNotAbsoluteAlready(path) { copy { file = path } }
 
 /**
  * Obtains column fields of this message type.

--- a/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/MessageTypeExts.kt
@@ -37,7 +37,7 @@ import io.spine.protodata.type.TypeSystem
  * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
- *  this message type prior to the call of this function.
+ *  this message type before the call of this function.
  */
 public fun MessageType.withAbsoluteFile(path: File): MessageType =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }

--- a/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
@@ -129,6 +129,9 @@ private fun ProtoDeclaration.checkReplacingAbsoluteFile(path: File) {
  * @param file The absolute path to be used instead of the relative one.
  * @param block The function creating a new instance with the full path.
  * @return a new instance with the full path or `this` if the file was already absolute.
+ * @throws IllegalArgumentException if the given path is not absolute, or
+ *  if the given path is not an absolute version of the relative file set in
+ *  this declaration before the call of this function.
  */
 internal fun <T : ProtoDeclaration> T.replaceIfNotAbsoluteAlready(
     file: File,

--- a/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
@@ -106,3 +106,18 @@ public inline fun <reified T : Message> ProtoDeclaration.option(): Option {
     findOption<T>()?.let { return it }
         ?: error("The declaration `${qualifiedName}` must have the `${simply<T>()}` option.")
 }
+
+/**
+ * Checks that the given path is absolute and is the absolute version of
+ * the relative file currently set in this declaration.
+ *
+ * @throws IllegalArgumentException if the above conditions are not met.
+ */
+internal fun ProtoDeclaration.checkReplacingAbsoluteFile(path: File) {
+    require(path.toJava().isAbsolute) {
+        "The path `${path.path} must be absolute."
+    }
+    require(path.path.endsWith(file.path)) {
+        "The path `${path.path}` is not the absolute version of `${file.path}`."
+    }
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
@@ -113,11 +113,31 @@ public inline fun <reified T : Message> ProtoDeclaration.option(): Option {
  *
  * @throws IllegalArgumentException if the above conditions are not met.
  */
-internal fun ProtoDeclaration.checkReplacingAbsoluteFile(path: File) {
+private fun ProtoDeclaration.checkReplacingAbsoluteFile(path: File) {
     require(path.toJava().isAbsolute) {
         "The path `${path.path} must be absolute."
     }
     require(path.path.endsWith(file.path)) {
         "The path `${path.path}` is not the absolute version of `${file.path}`."
+    }
+}
+
+/**
+ * Replaces the [ProtoDeclaration.file] property with the given absolute path.
+ *
+ * @param T The type implementing [ProtoDeclaration].
+ * @param file The absolute path to be used instead of the relative one.
+ * @param block The function creating a new instance with the full path.
+ * @return a new instance with the full path or `this` if the file was already absolute.
+ */
+internal fun <T : ProtoDeclaration> T.replaceIfNotAbsoluteAlready(
+    file: File,
+    block: (File) -> T
+): T {
+    checkReplacingAbsoluteFile(file)
+    return if (this.file.toJava().isAbsolute) {
+        this
+    } else {
+        block(file)
     }
 }

--- a/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+/**
+ * Replaces the [file][Service.file] property of this service with
+ * the specified absolute path.
+ *
+ * @throws IllegalArgumentException if the given path is not absolute, or
+ *  if the given path is not an absolute version of the relative file set in
+ *  this service to the call of this function.
+ */
+public fun Service.withAbsoluteFile(path: File): Service {
+    checkReplacingAbsoluteFile(path)
+    return copy { file = path }
+}

--- a/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
@@ -30,11 +30,10 @@ package io.spine.protodata.ast
  * Replaces the [file][Service.file] property of this service with
  * the specified absolute path.
  *
+ * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
  *  this service to the call of this function.
  */
-public fun Service.withAbsoluteFile(path: File): Service {
-    checkReplacingAbsoluteFile(path)
-    return copy { file = path }
-}
+public fun Service.withAbsoluteFile(path: File): Service =
+    replaceIfNotAbsoluteAlready(path) { copy { file = path } }

--- a/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ServiceExts.kt
@@ -33,7 +33,7 @@ package io.spine.protodata.ast
  * @return a new instance with the absolute path, or `this` if the file was already absolute.
  * @throws IllegalArgumentException if the given path is not absolute, or
  *  if the given path is not an absolute version of the relative file set in
- *  this service to the call of this function.
+ *  this service before the call of this function.
  */
 public fun Service.withAbsoluteFile(path: File): Service =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+import io.spine.protodata.given.stubDeclaration
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`ProtoDeclaration` should")
+internal class ProtoDeclarationSpec {
+
+    private val relativeFile: File = file { path = "foo/bar/baz.proto" }
+    private val absoluteFile: File = absoluteFile(relativeFile.path)
+
+    @Suppress("unused")
+    private lateinit var decl: ProtoDeclaration
+
+    @Nested inner class
+    `check the replacing absolute file` {
+
+        @Test
+        fun `is absolute`() {
+            decl = stubDeclaration { file = relativeFile }
+            assertThrows<IllegalArgumentException> {
+                decl.checkReplacingAbsoluteFile(relativeFile)
+            }
+            assertDoesNotThrow {
+                decl.checkReplacingAbsoluteFile(absoluteFile)
+            }
+        }
+
+        @Test
+        fun `is absolute version of the relative one`() {
+            decl = stubDeclaration { file = relativeFile }
+            val stranger = absoluteFile("stranger.proto")
+            assertThrows<IllegalArgumentException> {
+                decl.checkReplacingAbsoluteFile(stranger)
+            }
+            assertDoesNotThrow {
+                decl.checkReplacingAbsoluteFile(absoluteFile)
+            }
+        }
+
+        @Test
+        fun `accept the absolute path if the current is already absolute`() {
+            decl = stubDeclaration { file = absoluteFile }
+            assertDoesNotThrow {
+                decl.checkReplacingAbsoluteFile(absoluteFile)
+            }
+        }
+    }
+}
+
+private fun absoluteFile(path: String): File =
+    file { this.path = Path(".").resolve(path).absolutePathString() }

--- a/api/src/test/proto/protodata/given/stub_declaration.proto
+++ b/api/src/test/proto/protodata/given/stub_declaration.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/proto/protodata/given/stub_declaration.proto
+++ b/api/src/test/proto/protodata/given/stub_declaration.proto
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package spine.protodata.given;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.protodata.given";
+option java_outer_classname = "StubDeclarationProto";
+option java_multiple_files = true;
+
+import "spine/protodata/ast.proto";
+import "spine/protodata/file.proto";
+
+// A stub implementation of `ProtoDeclaration`.
+message StubDeclaration {
+    option (is).java_type = "io.spine.protodata.ast.ProtoDeclaration";
+
+    // This property is just to satisfy the `ProtoDeclaration` interface.
+    // We don't need it for tests.
+    TypeName name = 1;
+
+    File file = 2 [(required) = true];
+
+    // Another property to satisfy the interface.
+    repeated Option option = 4 [(distinct) = true];
+}

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/EnumEvents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import io.spine.protodata.ast.event.enumEntered
 import io.spine.protodata.ast.event.enumExited
 import io.spine.protodata.ast.event.enumOptionDiscovered
 import io.spine.protodata.ast.produceOptionEvents
+import io.spine.protodata.ast.withAbsoluteFile
 import io.spine.protodata.protobuf.buildConstant
 import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.toEnumType
@@ -57,9 +58,9 @@ internal class EnumEvents(header: ProtoFileHeader) : DeclarationEvents<EnumDescr
      * At last, closes with an [EnumExited][io.spine.protodata.ast.event.EnumExited] event.
      */
     override suspend fun SequenceScope<EventMessage>.produceEvents(desc: EnumDescriptor) {
-        val enumType = desc.toEnumType()
-        val typeName = desc.name()
         val path = header.file
+        val enumType = desc.toEnumType().withAbsoluteFile(path)
+        val typeName = desc.name()
         yield(
             enumDiscovered {
                 file = path

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
@@ -48,6 +48,7 @@ import io.spine.protodata.ast.event.typeExited
 import io.spine.protodata.ast.event.typeOptionDiscovered
 import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.produceOptionEvents
+import io.spine.protodata.ast.withAbsoluteFile
 import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.realNestedTypes
 import io.spine.protodata.protobuf.toField
@@ -74,7 +75,7 @@ internal class MessageEvents(header: ProtoFileHeader) : DeclarationEvents<Descri
     ) {
         val typeName = desc.name()
         val path = header.file
-        val messageType = desc.toMessageType()
+        val messageType = desc.toMessageType().withAbsoluteFile(path)
         yield(
             typeDiscovered {
                 file = path

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/ServiceEvents.kt
@@ -40,6 +40,7 @@ import io.spine.protodata.ast.event.serviceEntered
 import io.spine.protodata.ast.event.serviceExited
 import io.spine.protodata.ast.event.serviceOptionDiscovered
 import io.spine.protodata.ast.produceOptionEvents
+import io.spine.protodata.ast.withAbsoluteFile
 import io.spine.protodata.protobuf.buildRpc
 import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.toService
@@ -62,7 +63,7 @@ internal class ServiceEvents(header: ProtoFileHeader) :
         desc: ServiceDescriptor
     ) {
         val path = header.file
-        val serviceType = desc.toService()
+        val serviceType = desc.toService().withAbsoluteFile(path)
         yield(
             serviceDiscovered {
                 file = path

--- a/backend/src/test/kotlin/io/spine/protodata/backend/Fixtures.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/Fixtures.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.backend
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import io.spine.protodata.protobuf.ProtoFileList
+import io.spine.protodata.test.DoctorProto
+import io.spine.protodata.type.TypeSystem
+import io.spine.tools.prototap.CompiledProtosFile
+import java.io.File
+import java.net.URLClassLoader
+
+/**
+ * Creates a type system using the list of compiled proto files from the `test-env` module.
+ */
+internal fun createTypeSystem(request: CodeGeneratorRequest): TypeSystem {
+    val testEnvJar = DoctorProto::class.java.protectionDomain.codeSource.location
+    // Create the class loader without the parent because the parent is checked first.
+    // We only interested in that particular JAR.
+    val urlClassLoader = URLClassLoader(arrayOf(testEnvJar), null)
+    val protoFiles = CompiledProtosFile(urlClassLoader)
+        .listFiles { File(it) }
+    val typeSystem = request.toTypeSystem(
+        ProtoFileList(protoFiles)
+    )
+    return typeSystem
+}

--- a/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/event/CompilerEventsSpec.kt
@@ -62,19 +62,13 @@ import io.spine.protodata.ast.event.ServiceExited
 import io.spine.protodata.ast.event.TypeDiscovered
 import io.spine.protodata.ast.event.TypeEntered
 import io.spine.protodata.ast.event.TypeExited
-import io.spine.protodata.ast.file
 import io.spine.protodata.ast.messageType
 import io.spine.protodata.ast.toJava
 import io.spine.protodata.ast.typeName
-import io.spine.protodata.backend.toTypeSystem
-import io.spine.protodata.protobuf.ProtoFileList
+import io.spine.protodata.backend.createTypeSystem
 import io.spine.protodata.test.DoctorProto
-import io.spine.protodata.type.TypeSystem
 import io.spine.testing.Correspondences
-import io.spine.tools.prototap.CompiledProtosFile
 import io.spine.type.KnownTypes
-import java.io.File
-import java.net.URLClassLoader
 import kotlin.reflect.KClass
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
@@ -115,24 +109,6 @@ class CompilerEventsSpec {
                 protoFile.addAll(allDependencyFiles)
             }
             return request
-        }
-
-        /**
-         * Creates a type system using the list of compiled proto files
-         * from the `test-env` module, which provides the [DoctorProto] file used
-         * by this test suite.
-         */
-        private fun createTypeSystem(request: CodeGeneratorRequest): TypeSystem {
-            val testEnvJar = DoctorProto::class.java.protectionDomain.codeSource.location
-            // Create the class loader without the parent because the parent is checked first.
-            // We only interested in that particular JAR.
-            val urlClassLoader = URLClassLoader(arrayOf(testEnvJar), null)
-            val protoFiles = CompiledProtosFile(urlClassLoader)
-                .listFiles { File(it) }
-            val typeSystem = request.toTypeSystem(
-                ProtoFileList(protoFiles)
-            )
-            return typeSystem
         }
     }
 
@@ -279,7 +255,7 @@ class CompilerEventsSpec {
             .comparingExpectedFieldsOnly()
             .isEqualTo(messageType {
                 name = typeName { simpleName = "Journey" }
-                file = file { path = "spine/protodata/test/doctor.proto" }
+                file = typeEntered.type.file
             })
 
         val doc = typeEntered.type.doc

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName")
 object Base {
     const val version = "2.0.0-SNAPSHOT.242"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.241"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.242"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.204"
+    const val version = "2.0.0-SNAPSHOT.206"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.92.1"
+    private const val fallbackVersion = "0.92.6"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.91.4"
+    private const val fallbackDfVersion = "0.92.5"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.92.6"
+    private const val fallbackVersion = "0.92.5"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.192"
+    const val version = "2.0.0-SNAPSHOT.194"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     `write-manifest`
     `build-proto-model`
     `maven-publish`
+    prototap
     ksp
     id("com.github.johnrengelman.shadow")
 }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
@@ -42,11 +42,11 @@ import io.spine.protodata.params.pipelineParameters
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.render.SourceFileSet
 import io.spine.protodata.test.Project
-import io.spine.protodata.test.ProjectProto
 import io.spine.protodata.test.StubSoloRenderer
 import io.spine.protodata.testing.googleProtobufProtos
 import io.spine.protodata.testing.spineOptionProtos
 import io.spine.tools.code.SourceSetName
+import io.spine.tools.prototap.CompiledProtosFile
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
@@ -75,8 +75,11 @@ class LoggingLevelSpec {
 
         codegenRequestFile = sandbox.resolve("code-gen-request.bin")
 
+        val compiledProtos = CompiledProtosFile(this::class.java.classLoader)
+        val absoluteFiles = compiledProtos.listFiles { file { path = it } }
+
         val params = pipelineParameters {
-            compiledProto.add(file { path = "/given/proto/file/path.proto"})
+            compiledProto.addAll(absoluteFiles)
             settings = directory { path = workingDir.settingsDirectory.path.absolutePathString() }
             sourceRoot.add(directory { path = sandbox.resolve("src").absolutePathString() })
             targetRoot.add(directory { path = sandbox.resolve("generated").absolutePathString() })
@@ -97,19 +100,16 @@ class LoggingLevelSpec {
             ${Project::class.simpleName}.getUuid() 
         """.trimIndent())
 
-        val project = ProjectProto.getDescriptor()
         val testProto = TestProto.getDescriptor()
         val request = codeGeneratorRequest {
             protoFile.addAll(
                 listOf(
-                    project.toProto(),
                     testProto.toProto(),
                     TestOptionsProto.getDescriptor().toProto(),
                 ) + spineOptionProtos()
                         + googleProtobufProtos()
             )
             fileToGenerate.addAll(listOf(
-                project.name,
                 testProto.name
             ))
         }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
@@ -146,6 +146,7 @@ class MainSpec {
                         + googleProtobufProtos()
             )
             fileToGenerate.addAll(listOf(
+                project.name,
                 testProto.name
             ))
         }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,9 +68,11 @@ import io.spine.time.LocalDates
 import io.spine.time.Month.SEPTEMBER
 import io.spine.time.toInstant
 import io.spine.tools.code.SourceSetName
+import io.spine.tools.prototap.CompiledProtosFile
 import io.spine.type.toCompactJson
 import io.spine.type.toJson
 import java.io.File
+import java.net.URLClassLoader
 import java.nio.file.Path
 import kotlin.io.path.name
 import kotlin.io.path.readText
@@ -108,8 +110,15 @@ class MainSpec {
         targetRoot = sandbox.resolve("target")
         targetRoot.toFile().mkdirs()
 
+        val compiledProtos = CompiledProtosFile(this::class.java.classLoader)
+        val thisModuleFiles = compiledProtos.listFiles { file { path = it } }
+
+        val testEnvJar = ProjectProto::class.java.protectionDomain.codeSource.location
+        val urlClassLoader = URLClassLoader(arrayOf(testEnvJar), null)
+        val testEnvJarFiles = CompiledProtosFile(urlClassLoader).listFiles { file { path = it } }
+
         val params = pipelineParameters {
-            compiledProto.add(file { path = "/given/proto/file/path.proto"})
+            compiledProto.addAll(thisModuleFiles + testEnvJarFiles)
             settings = workingDir.settingsDirectory.path.toDirectory()
             sourceRoot.add(srcRoot.toDirectory())
             targetRoot.add(this@MainSpec.targetRoot.toDirectory())
@@ -137,7 +146,6 @@ class MainSpec {
                         + googleProtobufProtos()
             )
             fileToGenerate.addAll(listOf(
-                project.name,
                 testProto.name
             ))
         }

--- a/cli/src/test/proto/spine/protodata/cli/test/test.proto
+++ b/cli/src/test/proto/spine/protodata/cli/test/test.proto
@@ -14,10 +14,6 @@ option java_multiple_files = true;
 import "google/protobuf/timestamp.proto";
 import "spine/protodata/ast.proto";
 
-message Project {
-    string uuid = 1;
-}
-
 message Type {
 
     string custom_field_for_test = 1 [(.spine.protodata.cli.test.custom) = { bar: "yes" }];

--- a/cli/src/test/proto/spine/protodata/cli/test/test.proto
+++ b/cli/src/test/proto/spine/protodata/cli/test/test.proto
@@ -14,6 +14,10 @@ option java_multiple_files = true;
 import "google/protobuf/timestamp.proto";
 import "spine/protodata/ast.proto";
 
+message Project {
+    string uuid = 1;
+}
+
 message Type {
 
     string custom_field_for_test = 1 [(.spine.protodata.cli.test.custom) = { bar: "yes" }];

--- a/dependencies.md
+++ b/dependencies.md
@@ -1045,7 +1045,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 21:35:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1045,7 +1045,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 21:35:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1898,7 +1898,7 @@ This report was generated on **Thu Feb 20 21:35:40 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2936,7 +2936,7 @@ This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4053,7 +4053,7 @@ This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5069,7 +5069,7 @@ This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6257,7 +6257,7 @@ This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7295,7 +7295,7 @@ This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8340,7 +8340,7 @@ This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9182,7 +9182,7 @@ This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10235,7 +10235,7 @@ This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11371,4 +11371,4 @@ This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1045,12 +1045,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.6`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1898,12 +1898,12 @@ This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2936,12 +2936,12 @@ This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:48 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4053,12 +4053,12 @@ This report was generated on **Thu Feb 20 17:07:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:21 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5069,12 +5069,12 @@ This report was generated on **Thu Feb 20 17:07:21 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:21 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6257,12 +6257,12 @@ This report was generated on **Thu Feb 20 17:07:21 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7295,12 +7295,12 @@ This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:49 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8340,12 +8340,12 @@ This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9182,12 +9182,12 @@ This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10235,12 +10235,12 @@ This report was generated on **Thu Feb 20 17:07:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.92.5`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.6`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11371,4 +11371,4 @@ This report was generated on **Thu Feb 20 17:07:23 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:07:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 20:32:50 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -26,7 +26,7 @@
 
 import io.spine.dependency.lib.JavaPoet
 import io.spine.dependency.lib.JavaX
-import io.spine.dependency.local.Spine
+import io.spine.dependency.local.Base
 import io.spine.dependency.local.Time
 import io.spine.dependency.local.ToolBase
 import org.gradle.api.file.DuplicatesStrategy.INCLUDE
@@ -50,7 +50,7 @@ dependencies {
 configurations.all {
     if(name in arrayOf("testCompileClasspath", "testRuntimeClasspath")) {
         resolutionStrategy.force(
-            Spine.baseForBuildScript
+            Base.libForBuildScript
         )
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.92.5</version>
+<version>0.92.6</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -110,7 +110,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.204</version>
+    <version>2.0.0-SNAPSHOT.206</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -134,7 +134,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.204</version>
+    <version>2.0.0-SNAPSHOT.206</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -146,7 +146,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.192</version>
+    <version>2.0.0-SNAPSHOT.194</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.92.5")
+val protoDataVersion: String by extra("0.92.6")


### PR DESCRIPTION
This PR fixes setting absolute file paths in `MessageType`, `EnumType`, and `Service`. Previously, only events related to the declarations and file headers had full paths.