### PR TITLE
Infix file pattern

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/FilePatternFactory.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilePatternFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,20 @@ public object FilePatternFactory {
     }
 
     /**
+     * Creates a new [FilePattern] with the [infix][FilePattern.getInfix] field filled.
+     */
+    public fun infix(value: String): FilePattern = filePattern {
+        value.checkNotBlank("infix")
+        infix = value
+    }
+
+    /**
      * Creates a new [FilePattern] with the [prefix][FilePattern.getPrefix] field filled.
      */
+    @Deprecated(message = "Please use `infix` instead.", ReplaceWith("infix(value)"))
     public fun prefix(value: String): FilePattern = filePattern {
         value.checkNotBlank("prefix")
+        @Suppress("DEPRECATION") // Supporting for backward compatibility.
         prefix = value
     }
 
@@ -59,7 +69,7 @@ public object FilePatternFactory {
 
     private fun String.checkNotBlank(name: String) {
         require(isNotBlank()) {
-            "File pattern $name cannot be empty or blank: `$this`."
+            "The file pattern `$name` cannot be empty or blank. Encountered: `$this`."
         }
     }
 }

--- a/api/src/main/kotlin/io/spine/protodata/ast/FilePatterns.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilePatterns.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@
 package io.spine.protodata.ast
 
 import io.spine.protodata.ast.FilePattern.KindCase.KIND_NOT_SET
-import io.spine.protodata.ast.FilePattern.KindCase.PREFIX
 import io.spine.protodata.ast.FilePattern.KindCase.REGEX
+import io.spine.protodata.ast.FilePattern.KindCase.INFIX
 import io.spine.protodata.ast.FilePattern.KindCase.SUFFIX
 
 /**
@@ -38,8 +38,10 @@ import io.spine.protodata.ast.FilePattern.KindCase.SUFFIX
  */
 public fun FilePattern.matches(file: File): Boolean {
     val path = file.path
+    @Suppress("DEPRECATION") // Support the `PREFIX` kind for backward compatibility.
     return when (kindCase) {
-        PREFIX -> path.startsWith(prefix)
+        io.spine.protodata.ast.FilePattern.KindCase.PREFIX -> path.startsWith(prefix)
+        INFIX -> path.contains(infix)
         SUFFIX -> path.endsWith(suffix)
         REGEX -> path.matches(Regex(regex))
         KIND_NOT_SET -> false

--- a/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
@@ -33,13 +33,19 @@ import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.name
 import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.pathString
 
 /**
  * Converts the given path to a [File] message containing an absolute version of this path.
  */
-public fun Path.toProto(): File = file {
+public fun Path.toAbsoluteFile(): File = file {
     path = absolutePathString().toUnix()
 }
+
+/**
+ * Converts this path to a [File] message with conversion to Unix path separators.
+ */
+public fun Path.toProto(): File = file { path = this@toProto.pathString.toUnix() }
 
 private fun String.toUnix(): String = replace('\\', '/')
 
@@ -55,6 +61,11 @@ public fun Path.toDirectory(): Directory = toFile().toDirectory()
 
 /**
  * Converts this instance of [java.io.File] to a [File] message with an absolute path.
+ */
+public fun java.io.File.toAbsoluteFile(): File = toPath().toAbsoluteFile()
+
+/**
+ * Converts this path to a [File] message with conversion to Unix path separators.
  */
 public fun java.io.File.toProto(): File = toPath().toProto()
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("TooManyFunctions") // ... we need for relative and absolute paths.
+
 package io.spine.protodata.ast
 
 import io.spine.protodata.util.Format

--- a/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FilesAndPaths.kt
@@ -62,6 +62,11 @@ public fun java.io.File.unixPath(): String = path.toUnix()
 public fun Path.toDirectory(): Directory = toFile().toDirectory()
 
 /**
+ * Converts this path to a [Directory] with the absolute path.
+ */
+public fun Path.toAbsoluteDirectory(): Directory = toAbsolutePath().toDirectory()
+
+/**
  * Converts this instance of [java.io.File] to a [File] message with an absolute path.
  */
 public fun java.io.File.toAbsoluteFile(): File = toPath().toAbsoluteFile()

--- a/api/src/main/kotlin/io/spine/protodata/render/InsertionPointPrinter.kt
+++ b/api/src/main/kotlin/io/spine/protodata/render/InsertionPointPrinter.kt
@@ -27,7 +27,8 @@
 package io.spine.protodata.render
 
 import io.spine.core.userId
-import io.spine.protodata.ast.file
+import io.spine.protodata.ast.toAbsoluteFile
+import io.spine.protodata.ast.toProto
 import io.spine.protodata.render.CoordinatesFactory.Companion.endOfFile
 import io.spine.protodata.render.event.insertionPointPrinted
 import io.spine.text.TextCoordinates
@@ -168,7 +169,7 @@ public abstract class InsertionPointPrinter<L: Language>(
 
     private fun reportPoint(sourceFile: SourceFile<*>, pointLabel: String, comment: String) {
         val event = insertionPointPrinted {
-            file = file { path = sourceFile.relativePath.toString() }
+            file = sourceFile.relativePath.toProto()
             label = pointLabel
             representationInCode = comment
         }

--- a/api/src/main/kotlin/io/spine/protodata/render/SourceFile.kt
+++ b/api/src/main/kotlin/io/spine/protodata/render/SourceFile.kt
@@ -32,6 +32,7 @@ import com.intellij.openapi.fileTypes.FileTypeRegistry
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import io.spine.protodata.ast.file
+import io.spine.protodata.ast.toProto
 import io.spine.protodata.util.Cache
 import io.spine.server.query.select
 import io.spine.text.Text
@@ -262,7 +263,7 @@ private constructor(
      */
     public fun atInline(insertionPoint: InsertionPoint): SourceAtPoint {
         val points = sources.querying.select<InsertedPoints>()
-            .findById(file { path = relativePath.toString() })
+            .findById(relativePath.toProto())
         val point = points?.pointList?.firstOrNull { it.label == insertionPoint.label }
         return if (point != null) {
             SpecificPoint(this@SourceFile, point)

--- a/api/src/main/kotlin/io/spine/protodata/settings/SettingsDirectory.kt
+++ b/api/src/main/kotlin/io/spine/protodata/settings/SettingsDirectory.kt
@@ -27,7 +27,7 @@
 package io.spine.protodata.settings
 
 import io.spine.protodata.util.ensureExistingDirectory
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.settings.event.SettingsFileDiscovered
 import io.spine.protodata.settings.event.settingsFileDiscovered
 import io.spine.protodata.util.Format
@@ -122,7 +122,7 @@ public class SettingsDirectory(
     public fun emitEvents(): List<SettingsFileDiscovered> =
         files().map {
             settingsFileDiscovered {
-                file = it.toProto()
+                file = it.toAbsoluteFile()
             }
         }
 

--- a/api/src/main/proto/spine/protodata/directory.proto
+++ b/api/src/main/proto/spine/protodata/directory.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,12 @@ option java_outer_classname = "DirectoryProto";
 option java_multiple_files = true;
 
 // A path to a directory in an arbitrary OS.
+//
+// The Protobuf compiler only works with the Unix-style file separator (`/`), regardless of
+// the current operating system. This value holds this exact format of the path.
+//
 message Directory {
 
-    // The path to the directory, could be relative or absolute.
-    string path = 1 [(required) = true];
+    // The path to the directory, could be relative or absolute, with the slash (`/`) separator.
+    string path = 1 [(required) = true, (pattern).regex = "^[^\\\\]*$"];
 }

--- a/api/src/main/proto/spine/protodata/file_pattern.proto
+++ b/api/src/main/proto/spine/protodata/file_pattern.proto
@@ -51,7 +51,7 @@ message FilePattern {
         //
         // Deprecated: File paths managed by Spine Compiler are primarily absolute.
         // That is why this kind of pattern would not work in most cases.
-        // Please use the `infix` kind instead.
+        // Please use the `infix` property instead.
         //
         string prefix = 2 [deprecated = true];
 

--- a/api/src/main/proto/spine/protodata/file_pattern.proto
+++ b/api/src/main/proto/spine/protodata/file_pattern.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,16 @@ message FilePattern {
         // The path must end with this string.
         string suffix = 1;
 
+        // The path must contain this infix.
+        string infix = 4;
+
         // The path must start with this string.
-        string prefix = 2;
+        //
+        // Deprecated: File paths managed by Spine Compiler are primarily absolute.
+        // That is why this kind of pattern would not work in most cases.
+        // Please use the `infix` kind instead.
+        //
+        string prefix = 2 [deprecated = true];
 
         // The path must match this regular expression.
         string regex = 3;

--- a/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/CompilationSpec.kt
@@ -33,7 +33,7 @@ import io.spine.logging.testing.tapConsole
 import io.spine.protodata.Compilation.ERROR_PREFIX
 import io.spine.protodata.Compilation.WARNING_PREFIX
 import io.spine.protodata.ast.Span
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.testing.TestValues
 import java.io.File
 import java.nio.file.Paths
@@ -146,7 +146,7 @@ internal class CompilationSpec {
 
     @Test
     fun `provide the 'check' utility function`() {
-        val file = File("some/path/goes/here.proto").toProto()
+        val file = File("some/path/goes/here.proto").toAbsoluteFile()
         val span = Span.getDefaultInstance()
         val msg = TestValues.randomString()
         val error = assertThrows<Compilation.Error> {

--- a/api/src/test/kotlin/io/spine/protodata/ast/FilePatternsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FilePatternsSpec.kt
@@ -33,6 +33,7 @@ import com.google.protobuf.Timestamp
 import io.kotest.matchers.shouldBe
 import io.spine.protodata.ast.FilePatternFactory.prefix
 import io.spine.protodata.ast.FilePatternFactory.regex
+import io.spine.protodata.ast.FilePatternFactory.infix
 import io.spine.protodata.ast.FilePatternFactory.suffix
 import io.spine.validate.ValidationError
 import org.junit.jupiter.api.DisplayName
@@ -52,6 +53,13 @@ internal class FilePatternsSpec {
             assertThrowing { suffix(" ") }
         }
 
+        @Test
+        fun infix() {
+            assertThrowing { infix("") }
+            assertThrowing { infix(" ") }
+        }
+
+        @Suppress("DEPRECATION") // Supporting for backward combability.
         @Test
         fun prefix() {
             assertThrowing { prefix("") }
@@ -76,9 +84,19 @@ internal class FilePatternsSpec {
 
         @Test
         fun prefix() {
+            @Suppress("DEPRECATION") // Supporting for backward compatibility.
             prefix("google/protobuf/any").run {
                 matches(messageTypeOf<Any>()) shouldBe true
                 matches(messageTypeOf<Timestamp>()) shouldBe false
+            }
+        }
+
+        @Test
+        fun infix() {
+            infix("protodata/file").run {
+                matches(messageTypeOf<FilePattern>()) shouldBe true
+                matches(messageTypeOf<File>()) shouldBe true
+                matches(messageTypeOf<Directory>()) shouldBe false
             }
         }
 

--- a/api/src/test/kotlin/io/spine/protodata/ast/FileSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FileSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,27 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-syntax = "proto3";
+package io.spine.protodata.ast
 
-package spine.protodata;
+import io.spine.validate.ValidationException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 
-import "spine/options.proto";
+@DisplayName("`File` should")
+internal class FileSpec {
 
-option (type_url_prefix) = "type.spine.io";
-option java_package = "io.spine.protodata.ast";
-option java_outer_classname = "FileProto";
-option java_multiple_files = true;
-
-// A path to a file in an arbitrary OS.
-//
-// In most cases it is going to be a relative path.
-// In some cases it may be an absolute path.
-//
-// The Protobuf compiler only works with the Unix-style file separator (`/`), regardless of
-// the current operating system. This value holds this exact format of the path.
-//
-message File {
-
-    // The path to the file, separating directories with the slash (`/`) symbol.
-    string path = 1 [(required) = true, (pattern).regex = "^[^\\\\]*$"];
+    @Test
+    fun `prohibit non-Unix path separators`() {
+        assertThrows<ValidationException> {
+            file { path = "foo\\bar.proto" }
+        }
+        assertDoesNotThrow {
+            file { path = "foo/bar.proto" }
+        }
+    }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
@@ -31,7 +31,6 @@ import io.spine.protodata.given.StubDeclaration
 import io.spine.protodata.given.copy
 import io.spine.protodata.given.stubDeclaration
 import kotlin.io.path.Path
-import kotlin.io.path.absolutePathString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -96,4 +95,4 @@ internal class ProtoDeclarationSpec {
 private fun StubDeclaration.withAbsoluteFile(path: File): StubDeclaration =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }
 
-private fun absoluteFile(path: String): File = Path(".").resolve(path).toAbsolutePath().toProto()
+private fun absoluteFile(path: String): File = Path(".").resolve(path).toAbsolutePath().toAbsoluteFile()

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
@@ -97,4 +97,4 @@ private fun StubDeclaration.withAbsoluteFile(path: File): StubDeclaration =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }
 
 private fun absoluteFile(path: String): File =
-    file { this.path = Path(".").resolve(path).absolutePathString() }
+    file { this.path = Path(".").resolve(path).absolutePathString().replace('\\', '/') }

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
@@ -96,5 +96,4 @@ internal class ProtoDeclarationSpec {
 private fun StubDeclaration.withAbsoluteFile(path: File): StubDeclaration =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }
 
-private fun absoluteFile(path: String): File =
-    file { this.path = Path(".").resolve(path).absolutePathString().replace('\\', '/') }
+private fun absoluteFile(path: String): File = Path(".").resolve(path).toAbsolutePath().toProto()

--- a/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/ProtoDeclarationSpec.kt
@@ -95,4 +95,5 @@ internal class ProtoDeclarationSpec {
 private fun StubDeclaration.withAbsoluteFile(path: File): StubDeclaration =
     replaceIfNotAbsoluteAlready(path) { copy { file = path } }
 
-private fun absoluteFile(path: String): File = Path(".").resolve(path).toAbsolutePath().toAbsoluteFile()
+private fun absoluteFile(path: String): File =
+    Path(".").resolve(path).toAbsolutePath().toAbsoluteFile()

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/CompilerEvents.kt
@@ -42,7 +42,7 @@ import io.spine.protodata.ast.event.fileOptionDiscovered
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.produceOptionEvents
 import io.spine.protodata.ast.toJava
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.backend.DescriptorFilter
 import io.spine.protodata.protobuf.file
 import io.spine.protodata.protobuf.toHeader
@@ -106,7 +106,7 @@ private class ProtoFileEvents(
         val relativePath = hdr.file.toJava()
         val fullPath = typeSystem.compiledProtoFiles.find(relativePath)
         if (fullPath != null) {
-            hdr.copy { file = fullPath.toProto() }
+            hdr.copy { file = fullPath.toAbsoluteFile() }
         } else {
             hdr
         }

--- a/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/CodeGenerationContextSpec.kt
@@ -51,7 +51,7 @@ import io.spine.protodata.ast.ProtobufSourceFile
 import io.spine.protodata.ast.doc
 import io.spine.protodata.ast.option
 import io.spine.protodata.ast.span
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.ast.toType
 import io.spine.protodata.backend.event.CompilerEvents
 import io.spine.protodata.context.CodegenContext
@@ -170,7 +170,7 @@ class CodeGenerationContextSpec {
         fun `with files marked for generation`() {
             val fullPath = typeSystem.findAbsolute(DoctorProto.getDescriptor())
             val assertSourceFile = ctx.assertEntity<ProtoSourceFileView, _>(
-                fullPath!!.toProto()
+                fullPath!!.toAbsoluteFile()
             )
             assertSourceFile.exists()
 
@@ -216,7 +216,7 @@ class CodeGenerationContextSpec {
         fun `with respect for custom options among the source files`() {
             val filePath = typeSystem.findAbsolute(PhDProto.getDescriptor())
             val phdFile = ctx.assertEntity<ProtoSourceFileView, _>(
-                filePath!!.toProto()
+                filePath!!.toAbsoluteFile()
             ).actual()!!.state() as ProtobufSourceFile
             val paperType = phdFile.typeMap.values.find { it.name.simpleName == "Paper" }!!
             val keywordsField = paperType.fieldList.find { it.name.value == "keywords" }!!

--- a/backend/src/test/kotlin/io/spine/protodata/backend/PipelineSpec.kt
+++ b/backend/src/test/kotlin/io/spine/protodata/backend/PipelineSpec.kt
@@ -33,7 +33,7 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.codeGeneratorRequest
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.context.CodegenContext
 import io.spine.protodata.params.PipelineParameters
 import io.spine.protodata.plugin.ConfigurationError
@@ -101,7 +101,7 @@ internal class PipelineSpec {
     private lateinit var sourceSet: SourceFileSet
 
     private fun PipelineParameters.Builder.addAbsoluteCompiledProtoPaths() {
-        addAllCompiledProto(typeSystem.compiledProtoFiles.files.map { it.toProto() })
+        addAllCompiledProto(typeSystem.compiledProtoFiles.files.map { it.toAbsoluteFile() })
     }
 
     @BeforeEach

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -179,16 +179,11 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains publishing tasks.
- *
- * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
- * the local testing workflow.
+ * Tells if this task belongs to the execution graph which contains the "publish" task.
  */
 fun AbstractDokkaTask.isInPublishingGraph(): Boolean =
     project.gradle.taskGraph.allTasks.any {
-        with(it.name) {
-            startsWith("publish") && !startsWith("publishToMavenLocal")
-        }
+        it.name == "publish"
     }
 
 /**

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -81,6 +81,7 @@ project.run {
     configureKotlin()
 
     setupTests()
+    configureDocTasks()
 
     applyGeneratedDirectories()
     configureTaskDependencies()
@@ -190,5 +191,18 @@ fun Module.configureKotlin() {
         setFreeCompilerArgs()
         // https://stackoverflow.com/questions/38298695/gradle-disable-all-incremental-compilation-and-parallel-builds
         incremental = false
+    }
+}
+
+fun Module.configureDocTasks() {
+    val dokkaJavadoc by tasks.getting(DokkaTask::class)
+    tasks.register("javadocJar", Jar::class) {
+        from(dokkaJavadoc.outputDirectory)
+        archiveClassifier.set("javadoc")
+        dependsOn(dokkaJavadoc)
+    }
+
+    tasks.withType<DokkaTaskPartial>().configureEach {
+        configureForKotlin()
     }
 }

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -49,6 +49,8 @@ plugins {
     kotlin("jvm")
     id("net.ltgt.errorprone")
     id("detekt-code-analysis")
+    id("dokka-for-java")
+    id("dokka-for-kotlin")
     jacoco
     idea
 }
@@ -79,7 +81,6 @@ project.run {
     configureKotlin()
 
     setupTests()
-    configureDocTasks()
 
     applyGeneratedDirectories()
     configureTaskDependencies()
@@ -189,18 +190,5 @@ fun Module.configureKotlin() {
         setFreeCompilerArgs()
         // https://stackoverflow.com/questions/38298695/gradle-disable-all-incremental-compilation-and-parallel-builds
         incremental = false
-    }
-}
-
-fun Module.configureDocTasks() {
-    val dokkaJavadoc by tasks.getting(DokkaTask::class)
-    tasks.register("javadocJar", Jar::class) {
-        from(dokkaJavadoc.outputDirectory)
-        archiveClassifier.set("javadoc")
-        dependsOn(dokkaJavadoc)
-    }
-
-    tasks.withType<DokkaTaskPartial>().configureEach {
-        configureForKotlin()
     }
 }

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
@@ -32,8 +32,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.spine.logging.Level
 import io.spine.logging.WithLogging
-import io.spine.protodata.ast.directory
 import io.spine.protodata.ast.file
+import io.spine.protodata.ast.toAbsoluteDirectory
 import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.cli.test.TestOptionsProto
 import io.spine.protodata.cli.test.TestProto
@@ -80,10 +80,10 @@ class LoggingLevelSpec {
 
         val params = pipelineParameters {
             compiledProto.addAll(absoluteFiles)
-            settings = directory { path = workingDir.settingsDirectory.path.absolutePathString() }
-            sourceRoot.add(directory { path = sandbox.resolve("src").absolutePathString() })
-            targetRoot.add(directory { path = sandbox.resolve("generated").absolutePathString() })
-            request = codegenRequestFile.toFile().toAbsoluteFile()
+            settings = workingDir.settingsDirectory.path.toAbsoluteDirectory()
+            sourceRoot.add(sandbox.resolve("src").toAbsoluteDirectory())
+            targetRoot.add(sandbox.resolve("generated").toAbsoluteDirectory())
+            request = codegenRequestFile.toAbsoluteFile()
             pluginClassName.add(LoggingLevelAsserterPlugin::class.jvmName)
         }
         parametersFile = workingDir.parametersDirectory.write(SourceSetName.main, params)

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
@@ -34,7 +34,7 @@ import io.spine.logging.Level
 import io.spine.logging.WithLogging
 import io.spine.protodata.ast.directory
 import io.spine.protodata.ast.file
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.cli.test.TestOptionsProto
 import io.spine.protodata.cli.test.TestProto
 import io.spine.protodata.params.WorkingDirectory
@@ -83,7 +83,7 @@ class LoggingLevelSpec {
             settings = directory { path = workingDir.settingsDirectory.path.absolutePathString() }
             sourceRoot.add(directory { path = sandbox.resolve("src").absolutePathString() })
             targetRoot.add(directory { path = sandbox.resolve("generated").absolutePathString() })
-            request = codegenRequestFile.toFile().toProto()
+            request = codegenRequestFile.toFile().toAbsoluteFile()
             pluginClassName.add(LoggingLevelAsserterPlugin::class.jvmName)
         }
         parametersFile = workingDir.parametersDirectory.write(SourceSetName.main, params)

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/LoggingLevelSpec.kt
@@ -35,6 +35,7 @@ import io.spine.logging.WithLogging
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.toAbsoluteDirectory
 import io.spine.protodata.ast.toAbsoluteFile
+import io.spine.protodata.ast.toProto
 import io.spine.protodata.cli.test.TestOptionsProto
 import io.spine.protodata.cli.test.TestProto
 import io.spine.protodata.params.WorkingDirectory
@@ -76,7 +77,7 @@ class LoggingLevelSpec {
         codegenRequestFile = sandbox.resolve("code-gen-request.bin")
 
         val compiledProtos = CompiledProtosFile(this::class.java.classLoader)
-        val absoluteFiles = compiledProtos.listFiles { file { path = it } }
+        val absoluteFiles = compiledProtos.listFiles { File(it).toProto() }
 
         val params = pipelineParameters {
             compiledProto.addAll(absoluteFiles)

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
@@ -37,7 +37,7 @@ import io.spine.protodata.ast.AstProto
 import io.spine.protodata.ast.FileProto
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.toDirectory
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.cli.given.DefaultOptionsCounterPlugin
 import io.spine.protodata.cli.given.DefaultOptionsCounterRenderer
 import io.spine.protodata.cli.given.DefaultOptionsCounterRendererPlugin
@@ -122,7 +122,7 @@ class MainSpec {
             settings = workingDir.settingsDirectory.path.toDirectory()
             sourceRoot.add(srcRoot.toDirectory())
             targetRoot.add(this@MainSpec.targetRoot.toDirectory())
-            request = codegenRequestFile.toFile().toProto()
+            request = codegenRequestFile.toFile().toAbsoluteFile()
         }
         parametersFile = workingDir.parametersDirectory.write(SourceSetName.test, params)
 

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
@@ -35,7 +35,7 @@ import io.spine.base.Time
 import io.spine.protobuf.pack
 import io.spine.protodata.ast.AstProto
 import io.spine.protodata.ast.FileProto
-import io.spine.protodata.ast.file
+import io.spine.protodata.ast.toProto
 import io.spine.protodata.ast.toDirectory
 import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.cli.given.DefaultOptionsCounterPlugin

--- a/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
+++ b/cli/src/test/kotlin/io/spine/protodata/cli/app/MainSpec.kt
@@ -111,11 +111,11 @@ class MainSpec {
         targetRoot.toFile().mkdirs()
 
         val compiledProtos = CompiledProtosFile(this::class.java.classLoader)
-        val thisModuleFiles = compiledProtos.listFiles { file { path = it } }
+        val thisModuleFiles = compiledProtos.listFiles { File(it).toProto() }
 
         val testEnvJar = ProjectProto::class.java.protectionDomain.codeSource.location
         val urlClassLoader = URLClassLoader(arrayOf(testEnvJar), null)
-        val testEnvJarFiles = CompiledProtosFile(urlClassLoader).listFiles { file { path = it } }
+        val testEnvJarFiles = CompiledProtosFile(urlClassLoader).listFiles { File(it).toProto() }
 
         val params = pipelineParameters {
             compiledProto.addAll(thisModuleFiles + testEnvJarFiles)

--- a/dependencies.md
+++ b/dependencies.md
@@ -1049,7 +1049,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1303,6 +1303,10 @@ This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-Lice
 1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 1.3.1.
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -1609,6 +1613,10 @@ This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1902,7 +1910,7 @@ This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2944,7 +2952,7 @@ This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4065,7 +4073,7 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4487,6 +4495,10 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4792,6 +4804,10 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5085,7 +5101,7 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5543,6 +5559,10 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5849,6 +5869,10 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -6277,7 +6301,7 @@ This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7319,7 +7343,7 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8368,7 +8392,7 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8627,6 +8651,10 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
 
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -8921,6 +8949,10 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -9210,7 +9242,7 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10267,7 +10299,7 @@ This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11411,4 +11443,4 @@ This report was generated on **Sat Feb 22 18:00:42 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:00:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1045,12 +1045,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.7`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1898,12 +1898,12 @@ This report was generated on **Fri Feb 21 14:57:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2936,12 +2936,12 @@ This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4053,12 +4053,12 @@ This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5069,12 +5069,12 @@ This report was generated on **Fri Feb 21 14:57:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6257,12 +6257,12 @@ This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7295,12 +7295,12 @@ This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8340,12 +8340,12 @@ This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.7`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9182,12 +9182,12 @@ This report was generated on **Fri Feb 21 14:57:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10235,12 +10235,12 @@ This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.92.6`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.7`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11371,4 +11371,4 @@ This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 14:57:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:28:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -150,7 +150,7 @@
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -836,7 +836,7 @@
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -853,6 +853,10 @@
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1045,7 +1049,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1299,10 +1303,6 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
 1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 1.3.1.
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -1609,10 +1609,6 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1657,6 +1653,10 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1693,7 +1693,7 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1710,6 +1710,10 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1898,7 +1902,7 @@ This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:39 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2053,7 +2057,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2731,7 +2735,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2748,6 +2752,10 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2936,7 +2944,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3099,7 +3107,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3848,7 +3856,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3865,6 +3873,10 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4053,7 +4065,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4208,7 +4220,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4474,10 +4486,6 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
 1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 1.3.1.
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -4784,10 +4792,6 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4832,6 +4836,10 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4868,6 +4876,10 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.0.0.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4881,6 +4893,10 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5069,7 +5085,7 @@ This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5244,7 +5260,7 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5526,10 +5542,6 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
 1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 1.3.1.
      * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
      * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -5840,10 +5852,6 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5956,6 +5964,10 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6012,6 +6024,10 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.0.0.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6029,6 +6045,10 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -6257,7 +6277,7 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6412,7 +6432,7 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -7090,7 +7110,7 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -7107,6 +7127,10 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -7295,7 +7319,7 @@ This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7450,7 +7474,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8135,7 +8159,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8152,6 +8176,10 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8340,7 +8368,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8394,11 +8422,11 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8599,10 +8627,6 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
 
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
      * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
@@ -8897,10 +8921,6 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8945,6 +8965,10 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8981,7 +9005,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8998,6 +9022,10 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -9182,7 +9210,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9337,7 +9365,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -10030,7 +10058,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -10047,6 +10075,10 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -10235,7 +10267,7 @@ This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10468,7 +10500,7 @@ This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -11130,6 +11162,10 @@ This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.24.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -11166,7 +11202,7 @@ This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-Lice
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -11183,6 +11219,10 @@ This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.24.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -11371,4 +11411,4 @@ This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 18:00:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1049,7 +1049,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:27:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1910,7 +1910,7 @@ This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2952,7 +2952,7 @@ This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4073,7 +4073,7 @@ This report was generated on **Sat Feb 22 18:36:18 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5101,7 +5101,7 @@ This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6301,7 +6301,7 @@ This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7343,7 +7343,7 @@ This report was generated on **Sat Feb 22 18:36:19 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8392,7 +8392,7 @@ This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9242,7 +9242,7 @@ This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10299,7 +10299,7 @@ This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11443,4 +11443,4 @@ This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 22 18:36:20 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 19:28:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1045,7 +1045,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:15 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1898,7 +1898,7 @@ This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2936,7 +2936,7 @@ This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4053,7 +4053,7 @@ This report was generated on **Fri Feb 21 19:28:05 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:16 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5069,7 +5069,7 @@ This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6257,7 +6257,7 @@ This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:17 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7295,7 +7295,7 @@ This report was generated on **Fri Feb 21 19:28:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8340,7 +8340,7 @@ This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9182,7 +9182,7 @@ This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:18 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10235,7 +10235,7 @@ This report was generated on **Fri Feb 21 19:28:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11371,4 +11371,4 @@ This report was generated on **Fri Feb 21 19:28:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 21 19:28:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 21 19:53:19 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -30,7 +30,7 @@ import com.google.protobuf.gradle.GenerateProtoTask
 import com.intellij.openapi.util.io.FileUtil
 import io.spine.protodata.Constants.CLI_APP_CLASS
 import io.spine.protodata.ast.toDirectory
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.gradle.Names.PROTO_DATA_RAW_ARTIFACT
 import io.spine.protodata.gradle.Names.USER_CLASSPATH_CONFIGURATION
 import io.spine.protodata.gradle.error
@@ -210,7 +210,7 @@ private fun LaunchProtoData.createParametersFile() {
     val params = pipelineParameters {
         val protoFiles = generateProtoTask.sourceDirs.asFileTree.files.toList().sorted()
             .map {
-                it.toProto()
+                it.toAbsoluteFile()
             }
         compiledProto.addAll(protoFiles)
         settings = workingDir.settingsDirectory.path.toAbsolutePath().toDirectory()
@@ -220,7 +220,7 @@ private fun LaunchProtoData.createParametersFile() {
         targetRoot.addAll(
             targets.absoluteDirs().map { it.toDirectory() }
         )
-        request = workingDir.requestDirectory.file(SourceSetName(sourceSetName.get())).toProto()
+        request = workingDir.requestDirectory.file(SourceSetName(sourceSetName.get())).toAbsoluteFile()
 
         pluginClassName.addAll(plugins.get())
 

--- a/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/protodata/gradle/plugin/LaunchProtoData.kt
@@ -220,7 +220,9 @@ private fun LaunchProtoData.createParametersFile() {
         targetRoot.addAll(
             targets.absoluteDirs().map { it.toDirectory() }
         )
-        request = workingDir.requestDirectory.file(SourceSetName(sourceSetName.get())).toAbsoluteFile()
+        request = workingDir.requestDirectory
+            .file(SourceSetName(sourceSetName.get()))
+            .toAbsoluteFile()
 
         pluginClassName.addAll(plugins.get())
 

--- a/pom.xml
+++ b/pom.xml
@@ -133,14 +133,8 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
-    <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.246</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -213,6 +207,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.246</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-testutil-server</artifactId>
+    <version>2.0.0-SNAPSHOT.206</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -303,7 +303,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>prototap-protoc-plugin</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-dokka-extensions</artifactId>
+    <version>2.0.0-SNAPSHOT.6</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -384,6 +389,11 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
     <artifactId>jekyll-template-processing-plugin</artifactId>
+    <version>1.9.20</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>kotlin-as-java-plugin</artifactId>
     <version>1.9.20</version>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.92.6</version>
+<version>0.92.7</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineParametersExts.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineParametersExts.kt
@@ -27,7 +27,7 @@
 package io.spine.protodata.testing
 
 import io.spine.protodata.ast.toDirectory
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.params.PipelineParameters
 import io.spine.protodata.params.WorkingDirectory
 import io.spine.tools.code.SourceSetName
@@ -50,7 +50,7 @@ public fun pipelineParams(
  * Assigns the given [file] as the reference to the request parameters file.
  */
 public fun PipelineParameters.Builder.withRequestFile(file: File): PipelineParameters.Builder  {
-    request = file.toProto()
+    request = file.toAbsoluteFile()
     return this
 }
 
@@ -108,7 +108,7 @@ public fun parametersForWorkingDir(
     val requestFile = wd.requestDirectory.file(SourceSetName("testFixtures"))
     val params = PipelineParameters.newBuilder()
         .setSettings(wd.settingsDirectory.path.toDirectory())
-        .setRequest(requestFile.toProto())
+        .setRequest(requestFile.toAbsoluteFile())
         .buildPartial()
     return params
 }

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
@@ -32,9 +32,8 @@ import io.spine.code.proto.parse
 import io.spine.io.Resource
 import io.spine.io.ResourceDirectory
 import io.spine.io.replaceExtension
-import io.spine.protodata.ast.file
 import io.spine.protodata.ast.toPath
-import io.spine.protodata.ast.toProto
+import io.spine.protodata.ast.toAbsoluteFile
 import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.backend.DescriptorFilter
 import io.spine.protodata.backend.Pipeline
@@ -351,7 +350,7 @@ public class PipelineSetup(
         ): @NonValidated PipelineParameters{
             return if (params.compiledProtoList.isEmpty()) {
                 val files = CompiledProtosFile(classLoader)
-                    .listFiles { Path(it).toProto() }
+                    .listFiles { Path(it).toAbsoluteFile() }
                 params.toBuilder()
                     .addAllCompiledProto(files)
                     .buildPartial()

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/PipelineSetup.kt
@@ -34,6 +34,7 @@ import io.spine.io.ResourceDirectory
 import io.spine.io.replaceExtension
 import io.spine.protodata.ast.file
 import io.spine.protodata.ast.toPath
+import io.spine.protodata.ast.toProto
 import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.backend.DescriptorFilter
 import io.spine.protodata.backend.Pipeline
@@ -60,6 +61,7 @@ import io.spine.validate.NonValidated
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.CREATE
 import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+import kotlin.io.path.Path
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
 import org.gradle.api.Project
@@ -349,7 +351,7 @@ public class PipelineSetup(
         ): @NonValidated PipelineParameters{
             return if (params.compiledProtoList.isEmpty()) {
                 val files = CompiledProtosFile(classLoader)
-                    .listFiles { file { path = it } }
+                    .listFiles { Path(it).toProto() }
                 params.toBuilder()
                     .addAllCompiledProto(files)
                     .buildPartial()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.92.6")
+val protoDataVersion: String by extra("0.92.7")


### PR DESCRIPTION
This PR introduces `FilePattern.infix` property which aims to replace the `prefix` property. 

ProtoData started using absolute file paths for types implementing `ProtoDeclaration`.  This is to allow navigatable full file paths when reporting compilation errors. Because of this `prefix` pattern makes little sense because figuring out absolute paths on developer workstations would be awkward and meaningless.

## Other notable changes
 * The `File` type got `(pattern).regex` option prohibiting Windows path separators.
 * Similarly to `File`, the `Directory` type also got validation option for requiring Unix path separators.
 * Functions converting `File`s and `Path`s got names clarifying where the output is definitely absolute.
