### PR TITLE
Implement `AbstractCompilationErrorTest`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1049,12 +1049,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:02 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.9`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1524,6 +1524,14 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
      * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1910,12 +1918,12 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2558,6 +2566,14 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2952,12 +2968,12 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3671,6 +3687,14 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4073,12 +4097,12 @@ This report was generated on **Tue Feb 25 13:20:56 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5101,12 +5125,12 @@ This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6301,12 +6325,12 @@ This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6949,6 +6973,14 @@ This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7343,12 +7375,12 @@ This report was generated on **Tue Feb 25 13:20:57 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8392,12 +8424,12 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9242,12 +9274,12 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10299,12 +10331,12 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.92.8`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10499,6 +10531,14 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
 1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
      * **Project URL:** [http://junit.org](http://junit.org)
      * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
@@ -11049,6 +11089,14 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
 1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.1.0.**No license information found**
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -11443,4 +11491,4 @@ This report was generated on **Tue Feb 25 13:20:58 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 13:20:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.92.8</version>
+<version>0.92.9</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/build.gradle.kts
+++ b/testlib/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.dependency.local.CoreJava
+import io.spine.dependency.local.Logging
 import io.spine.dependency.local.ProtoTap
 import io.spine.dependency.local.Reflect
 import io.spine.dependency.local.TestLib
@@ -46,4 +47,5 @@ dependencies {
     api(project(":backend"))
 
     implementation(Reflect.lib)
+    implementation(Logging.testLib)?.because("We need `tapConsole`.")
 }

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationErrorTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationErrorTest.kt
@@ -40,8 +40,21 @@ import org.junit.jupiter.api.io.TempDir
 
 /**
  * An abstract base for classes that test compilation errors.
+ *
+ * Note that there is no `assertCompilationPasses()` counterpart in this class
+ * because we avoid creation of [PipelineSetup] for positive assertions.
+ * Initialization and running of a pipeline is time-consuming. We do it here
+ * for each assertion just because ProtoData is expected to fail anyway.
+ *
+ * For tests, where compilation is expected to pass, a single run of a pipeline
+ * should be used for all sources. Positive tests usually have way more assertions.
+ *
+ * Another alternative is to create a standalone module just for tests, where all
+ * messages-under-test are compiled at once by `launchTestProtoData` task without
+ * a pipeline at all. Though, assertion of the generated source code is impossible
+ * with this approach.
  */
-public abstract class AbstractCompilationTest {
+public abstract class AbstractCompilationErrorTest {
 
     /**
      * A directory to be used by the compilation process.

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
@@ -51,8 +51,10 @@ public abstract class AbstractCompilationTest {
 
     /**
      * The name of a source set under which the tested Proto declarations reside.
+     *
+     * By default, it is `testFixtures`.
      */
-    protected open val protoSourceSet: SourceSetName = SourceSetName("testFixtures")
+    protected open val protoSources: SourceSetName = SourceSetName("testFixtures")
 
     /**
      * List of ProtoData plugins to use in the compilation.
@@ -85,7 +87,7 @@ public abstract class AbstractCompilationTest {
         val outputDir = workingDir.resolve("output")
             .also { it.toFile().mkdirs() }
         val params = pipelineParams {
-            withRequestFile(wd.requestDirectory.file(protoSourceSet))
+            withRequestFile(wd.requestDirectory.file(protoSources))
             withSettingsDir(wd.settingsDirectory.path)
         }
         return byResources(

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
@@ -55,14 +55,14 @@ public abstract class AbstractCompilationTest {
     protected open val protoSourceSet: SourceSetName = SourceSetName("testFixtures")
 
     /**
-     * Writes plugin settings before the pipeline is created.
-     */
-    protected abstract fun writeSettings(settings: SettingsDirectory)
-
-    /**
      * List of ProtoData plugins to use in the compilation.
      */
     protected abstract fun plugins(): List<Plugin>
+
+    /**
+     * Writes plugin settings before the pipeline is created.
+     */
+    protected abstract fun writeSettings(settings: SettingsDirectory)
 
     /**
      * Asserts that the messages represented by the given [descriptor]

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.testing
+
+import com.google.protobuf.Descriptors.Descriptor
+import io.spine.logging.testing.tapConsole
+import io.spine.protodata.Compilation
+import io.spine.protodata.params.WorkingDirectory
+import io.spine.protodata.plugin.Plugin
+import io.spine.protodata.settings.SettingsDirectory
+import io.spine.protodata.testing.PipelineSetup.Companion.byResources
+import io.spine.tools.code.SourceSetName
+import java.nio.file.Path
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * An abstract base for classes that test compilation errors.
+ */
+public abstract class AbstractCompilationTest {
+
+    /**
+     * A directory to be used by the compilation process.
+     */
+    @TempDir
+    protected lateinit var workingDir: Path
+
+    /**
+     * Writes plugin settings before the pipeline is created.
+     */
+    protected abstract fun writeSettings(settings: SettingsDirectory)
+
+    /**
+     * List of ProtoData plugins to use in the compilation.
+     */
+    protected abstract fun plugins(): List<Plugin>
+
+    /**
+     * Asserts that the messages represented by the given [descriptor]
+     * fails the compilation process.
+     */
+    public fun assertCompilationFails(descriptor: Descriptor): Compilation.Error {
+        val setup = createSetup(descriptor)
+        val pipeline = setup.createPipeline()
+        val error = assertThrows<Compilation.Error> {
+            // Redirect console output so that we don't print errors during the build.
+            tapConsole {
+                pipeline()
+            }
+        }
+        return error
+    }
+
+    private fun createSetup(descriptor: Descriptor): PipelineSetup {
+        val wd = WorkingDirectory(workingDir)
+        val outputDir = workingDir.resolve("output")
+            .also { it.toFile().mkdirs() }
+        val params = pipelineParams {
+            withRequestFile(wd.requestDirectory.file(SourceSetName("testFixtures")))
+            withSettingsDir(wd.settingsDirectory.path)
+        }
+        return byResources(
+            params,
+            plugins(),
+            outputDir,
+            acceptingOnly(descriptor),
+            ::writeSettings
+        )
+    }
+}

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
@@ -50,6 +50,11 @@ public abstract class AbstractCompilationTest {
     protected lateinit var workingDir: Path
 
     /**
+     * The name of a source set under which the tested Proto declarations reside.
+     */
+    protected open val protoSourceSet: SourceSetName = SourceSetName("testFixtures")
+
+    /**
      * Writes plugin settings before the pipeline is created.
      */
     protected abstract fun writeSettings(settings: SettingsDirectory)
@@ -80,7 +85,7 @@ public abstract class AbstractCompilationTest {
         val outputDir = workingDir.resolve("output")
             .also { it.toFile().mkdirs() }
         val params = pipelineParams {
-            withRequestFile(wd.requestDirectory.file(SourceSetName("testFixtures")))
+            withRequestFile(wd.requestDirectory.file(protoSourceSet))
             withSettingsDir(wd.settingsDirectory.path)
         }
         return byResources(

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/AbstractCompilationTest.kt
@@ -63,8 +63,12 @@ public abstract class AbstractCompilationTest {
 
     /**
      * Writes plugin settings before the pipeline is created.
+     *
+     * The default implementation of this method does nothing.
      */
-    protected abstract fun writeSettings(settings: SettingsDirectory)
+    protected open fun writeSettings(settings: SettingsDirectory) {
+        // No settings by default.
+    }
 
     /**
      * Asserts that the messages represented by the given [descriptor]

--- a/testlib/src/main/kotlin/io/spine/protodata/testing/DescriptorFilters.kt
+++ b/testlib/src/main/kotlin/io/spine/protodata/testing/DescriptorFilters.kt
@@ -39,8 +39,8 @@ import io.spine.protodata.backend.DescriptorFilter
  * If the given [descriptor] is [FileDescriptor] the predicate accepts
  * the file itself, all the declarations made in this file.
  */
-public fun acceptingOnly(descriptor: GenericDescriptor): DescriptorFilter {
-    return if (descriptor is FileDescriptor) {
+public fun acceptingOnly(descriptor: GenericDescriptor): DescriptorFilter =
+    if (descriptor is FileDescriptor) {
         /* The descriptor tested by the predicate */ d ->
         if (d is FileDescriptor) {
             descriptor.fullName == d.fullName
@@ -55,7 +55,6 @@ public fun acceptingOnly(descriptor: GenericDescriptor): DescriptorFilter {
             descriptor.fullName == d.fullName
         }
     }
-}
 
 /**
  * Creates a predicate that accepts descriptors that are not present in the given list.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.92.8")
+val protoDataVersion: String by extra("0.92.9")


### PR DESCRIPTION
This PR moves implementation of `AbstractCompilationErrorTest` from `validation` to ProtoData.

ProtoData clients still need to define their own `abstract CompilationTest` to declare the used plugin and settings, though with less code. 

Here's an example of such a class in `validation`:

```kotlin
internal abstract class CompilationErrorTest : AbstractCompilationErrorTest() {

    override fun plugins(): List<Plugin> = listOf(
        object : ValidationPlugin() {}
    )

    override fun writeSettings(settings: SettingsDirectory) {
        val config = validationConfig {
            messageMarkers = messageMarkers {
                commandPattern.add(filePattern { suffix = "commands.proto" })
                eventPattern.add(filePattern { suffix = "events.proto" })
                rejectionPattern.add(filePattern { suffix = "rejections.proto" })
                entityOptionName.add(OptionsProto.entity.descriptor.name)
            }
        }
        settings.write(
            ValidationPlugin::class.java.defaultConsumerId,
            Format.PROTO_JSON,
            config.toByteArray()
        )
    }
}
```