### PR TITLE
Add extensions to find a field option by its type

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
@@ -121,3 +121,9 @@ public val Field.ref: FieldRef
         type = declaringType
         name = this@ref.name
     }
+
+/**
+ * Looks up a field option by its [name].
+ */
+public fun Field.findOption(name: String): Option? =
+    optionList.find { it.name == name }

--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
@@ -28,8 +28,12 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.Message
+import io.spine.protobuf.defaultInstance
 import io.spine.protodata.type.TypeSystem
 import io.spine.string.camelCase
+import io.spine.string.simply
+import io.spine.type.typeName
 import java.io.File
 
 /**
@@ -123,7 +127,30 @@ public val Field.ref: FieldRef
     }
 
 /**
- * Looks up a field option by its [name].
+ * Finds the option with the given type [T] applied to this [Field].
+ *
+ * @param T The type of the option.
+ * @return the option or `null` if there is no option with such a type applied to the field.
+ * @see Field.option
  */
-public fun Field.findOption(name: String): Option? =
-    optionList.find { it.name == name }
+public inline fun <reified T : Message> Field.findOption(): T? {
+    val typeUrl = T::class.java.defaultInstance.typeName.toUrl().value()
+    val option = optionList.find { opt ->
+        opt.value.typeUrl == typeUrl
+    }
+    return option?.unpack()
+}
+
+/**
+ * Obtains the option with the given type [T] applied to this [Field].
+ *
+ * Invoke this function if you are sure the option with the type [T] is applied
+ * to the receiver field. Otherwise, please use [findOption].
+ *
+ * @param T The type of the option.
+ * @return the option.
+ * @throws IllegalStateException if the option is not found.
+ * @see Field.findOption
+ */
+public inline fun <reified T : Message> Field.option(): T = findOption<T>()
+    ?: error("The field `${qualifiedName}` must have the `${simply<T>()}` option.")

--- a/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/ProtoDeclaration.kt
@@ -102,10 +102,8 @@ public inline fun <reified T : Message> ProtoDeclaration.findOption(): Option? {
  * @throws IllegalStateException if the option is not found.
  * @see ProtoDeclaration.findOption
  */
-public inline fun <reified T : Message> ProtoDeclaration.option(): Option {
-    findOption<T>()?.let { return it }
-        ?: error("The declaration `${qualifiedName}` must have the `${simply<T>()}` option.")
-}
+public inline fun <reified T : Message> ProtoDeclaration.option(): Option = findOption<T>()
+    ?: error("The declaration `${qualifiedName}` must have the `${simply<T>()}` option.")
 
 /**
  * Checks that the given path is absolute and is the absolute version of

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/DescriptorExts.kt
@@ -26,11 +26,9 @@
 
 package io.spine.protodata.protobuf
 
-import com.google.common.annotations.VisibleForTesting
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FileDescriptor
-import com.google.protobuf.Descriptors.GenericDescriptor
 import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.MessageType
 import io.spine.protodata.ast.Type

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MessageClass.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MessageClass.kt
@@ -33,10 +33,11 @@ import kotlin.reflect.KClass
 /**
  * Returns a Protobuf descriptor for this message [Class].
  */
-public fun Class<out Message>.getDescriptor(): Descriptor =
-    getDeclaredMethod("getDescriptor").invoke(null) as Descriptor
+public val Class<out Message>.descriptor: Descriptor
+    get() = getDeclaredMethod("getDescriptor").invoke(null) as Descriptor
 
 /**
  * Returns a Protobuf descriptor for this message [KClass].
  */
-public fun KClass<out Message>.getDescriptor(): Descriptor = java.getDescriptor()
+public val KClass<out Message>.descriptor: Descriptor
+    get() = java.descriptor

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/MessageClass.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/MessageClass.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.protobuf
+
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Message
+import kotlin.reflect.KClass
+
+/**
+ * Returns a Protobuf descriptor for this message [Class].
+ */
+public fun Class<out Message>.getDescriptor(): Descriptor =
+    getDeclaredMethod("getDescriptor").invoke(null) as Descriptor
+
+/**
+ * Returns a Protobuf descriptor for this message [KClass].
+ */
+public fun KClass<out Message>.getDescriptor(): Descriptor = java.getDescriptor()

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-api:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1049,12 +1049,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:02 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.92.10`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1918,12 +1918,12 @@ This report was generated on **Tue Feb 25 17:01:02 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-backend:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2968,12 +2968,12 @@ This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-cli:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4097,12 +4097,12 @@ This report was generated on **Tue Feb 25 17:01:03 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5125,12 +5125,12 @@ This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6325,12 +6325,12 @@ This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-java:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7375,12 +7375,12 @@ This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:14 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-params:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8424,12 +8424,12 @@ This report was generated on **Tue Feb 25 17:01:04 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:14 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.92.10`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9274,12 +9274,12 @@ This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:14 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10331,12 +10331,12 @@ This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:15 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.92.9`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.92.10`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11491,4 +11491,4 @@ This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 25 17:01:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 27 16:24:15 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.92.9</version>
+<version>0.92.10</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.92.9")
+val protoDataVersion: String by extra("0.92.10")


### PR DESCRIPTION
This PR adds two extensions to find a field option by its type:

1. `Field.findOption()`, which returns a nullable result.
2. `Field.option()`, which throws ISE if the option not found.

Additionally, it adds extensions to get a message `Descriptor` from the message `Class`:

1. `Class<out Message>.descriptor: Descriptor`  – for Java classes.
2. `KClass<out Message>.descriptor: Descriptor` - for Kotlin classes.