### PR TITLE
Introduce `AnnotatedClassName`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-api:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1117,12 +1117,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:17 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.5`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1963,12 +1963,12 @@ This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:17 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-backend:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3081,12 +3081,12 @@ This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:18 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-cli:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4230,12 +4230,12 @@ This report was generated on **Sun Mar 23 16:44:32 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:33 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:18 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5271,12 +5271,12 @@ This report was generated on **Sun Mar 23 16:44:33 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:33 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:18 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6428,12 +6428,12 @@ This report was generated on **Sun Mar 23 16:44:33 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:19 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-java:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7546,12 +7546,12 @@ This report was generated on **Sun Mar 23 16:44:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:19 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-params:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8667,12 +8667,12 @@ This report was generated on **Sun Mar 23 16:44:36 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:19 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.93.5`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9506,12 +9506,12 @@ This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:19 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10631,12 +10631,12 @@ This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:20 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.93.4`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.93.5`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11875,4 +11875,4 @@ This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 23 16:44:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 25 14:18:20 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
@@ -29,6 +29,25 @@ package io.spine.protodata.java
 /**
  * An annotated [ClassName].
  *
+ * For simple names, this class just prepends the annotation before the simple name:
+ *
+ * ```
+ * val string = ClassName(packageName = "", "String")
+ * val nullable = ClassName(Nullable::class)
+ * val annotatedString = AnnotatedClassName(string, nullable)
+ * println(annotatedString) // @org.checkerframework.checker.nullness.qual.Nullable String
+ * ```
+ *
+ * For fully-qualified classes and for classes with multiple simple names, the annotation
+ * prepended before the last simple name:
+ *
+ * ```
+ * val entry = ClassName(Map.Entry::class)
+ * val nullable = ClassName(Nullable::class)
+ * val annotatedEntry = AnnotatedClassName(entry, nullable)
+ * println(annotatedString) // java.util.Map.@org.checkerframework.checker.nullness.qual.Nullable Entry
+ * ```
+ *
  * @param [className] The class name to annotate.
  * @param [annotation] The class name of the annotation to apply.
  */

--- a/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.java
+
+/**
+ * An annotated [ClassName].
+ *
+ * @param [className] The class name to annotate.
+ * @param [annotation] The class name of the annotation to apply.
+ */
+public class AnnotatedClassName(
+    className: ClassName,
+    annotation: ClassName
+) : JavaTypeName() {
+
+    override val canonical: String = className.canonical.replaceAfterLast(
+        delimiter = ".",
+        replacement = "@${annotation.canonical} ${className.simpleName}",
+        missingDelimiterValue = "@${annotation.canonical} ${className.canonical}"
+    )
+}

--- a/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/AnnotatedClassName.kt
@@ -29,7 +29,7 @@ package io.spine.protodata.java
 /**
  * An annotated [ClassName].
  *
- * For simple names, this class just prepends the annotation before the simple name:
+ * For simple names, this class places the annotation before the simple name:
  *
  * ```
  * val string = ClassName(packageName = "", "String")
@@ -38,8 +38,8 @@ package io.spine.protodata.java
  * println(annotatedString) // @org.checkerframework.checker.nullness.qual.Nullable String
  * ```
  *
- * For fully-qualified classes and for classes with multiple simple names, the annotation
- * prepended before the last simple name:
+ * For fully qualified class names and classes with multiple simple names, the annotation
+ * is placed before the last simple name:
  *
  * ```
  * val entry = ClassName(Map.Entry::class)

--- a/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
@@ -27,9 +27,9 @@
 package io.spine.protodata.java
 
 /**
- * A parameterized class name.
+ * A parameterized Java type name.
  *
- * The class can be parameterized with any [JavaTypeName]. Usually, it is
+ * The type name can be parameterized with any [JavaTypeName]. Usually, it is
  * another class or a generic type variable (like `T` or `E`).
  *
  * Example usages:
@@ -52,11 +52,11 @@ package io.spine.protodata.java
  * println(comparatorOfGenericMaps) // java.util.Comparator<java.util.Map<T, E>>
  * ```
  *
- * @param base The parameterized class.
- * @param parameters The type parameters of the class.
+ * @param base The type name to parametrize.
+ * @param parameters The type parameters to use.
  */
-public class ParameterizedClassName(
-    base: ClassName,
+public class ParameterizedTypeName(
+    base: JavaTypeName,
     parameters: List<JavaTypeName>
 ) : JavaTypeName() {
 

--- a/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
@@ -69,7 +69,7 @@ public class ParameterizedTypeName(
         }
     }
 
-    public constructor(base: ClassName, vararg parameter: JavaTypeName) : this(
+    public constructor(base: JavaTypeName, vararg parameter: JavaTypeName) : this(
         base,
         parameter.toList()
     )

--- a/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/ParameterizedTypeName.kt
@@ -29,8 +29,8 @@ package io.spine.protodata.java
 /**
  * A parameterized Java type name.
  *
- * The type name can be parameterized with any [JavaTypeName]. Usually, it is
- * another class or a generic type variable (like `T` or `E`).
+ * The type name can be parameterized with any other [JavaTypeName].
+ * Usually, it is class or a generic type variable (like `T` or `E`).
  *
  * Example usages:
  *

--- a/java/src/test/kotlin/io/spine/protodata/java/AnnotatedClassNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/AnnotatedClassNameSpec.kt
@@ -40,22 +40,22 @@ internal class AnnotatedClassNameSpec {
     @Test
     fun `simple class name`() {
         val simpleName = "String"
-        val simpleClass = ClassName(packageName = "", simpleName)
-        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
-        annotatedClass.canonical shouldBe "$annotation $simpleName"
+        val string = ClassName(packageName = "", simpleName)
+        val nullableString =  AnnotatedClassName(string, annotationClass)
+        nullableString.canonical shouldBe "$annotation $simpleName"
     }
 
     @Test
     fun `fully-qualified class name`() {
-        val simpleClass = ClassName(String::class)
-        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
-        annotatedClass.canonical shouldBe "java.lang.$annotation String"
+        val string = ClassName(String::class)
+        val nullableString =  AnnotatedClassName(string, annotationClass)
+        nullableString.canonical shouldBe "java.lang.$annotation String"
     }
 
     @Test
     fun `class name with multiple simple names`() {
-        val simpleClass = ClassName(Map.Entry::class)
-        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
-        annotatedClass.canonical shouldBe "java.util.Map.$annotation Entry"
+        val entry = ClassName(Map.Entry::class)
+        val nullableEntry =  AnnotatedClassName(entry, annotationClass)
+        nullableEntry.canonical shouldBe "java.util.Map.$annotation Entry"
     }
 }

--- a/java/src/test/kotlin/io/spine/protodata/java/AnnotatedClassNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/AnnotatedClassNameSpec.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.java
+
+import io.kotest.matchers.shouldBe
+import org.checkerframework.checker.nullness.qual.Nullable
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`AnnotatedClassName` should annotate")
+internal class AnnotatedClassNameSpec {
+
+    private val annotationClass = ClassName(Nullable::class)
+    private val annotation = "@org.checkerframework.checker.nullness.qual.Nullable"
+
+    @Test
+    fun `simple class name`() {
+        val simpleName = "String"
+        val simpleClass = ClassName(packageName = "", simpleName)
+        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
+        annotatedClass.canonical shouldBe "$annotation $simpleName"
+    }
+
+    @Test
+    fun `fully-qualified class name`() {
+        val simpleClass = ClassName(String::class)
+        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
+        annotatedClass.canonical shouldBe "java.lang.$annotation String"
+    }
+
+    @Test
+    fun `class name with multiple simple names`() {
+        val simpleClass = ClassName(Map.Entry::class)
+        val annotatedClass =  AnnotatedClassName(simpleClass, annotationClass)
+        annotatedClass.canonical shouldBe "java.util.Map.$annotation Entry"
+    }
+}

--- a/java/src/test/kotlin/io/spine/protodata/java/ArrayTypeNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/ArrayTypeNameSpec.kt
@@ -70,7 +70,7 @@ internal class ArrayTypeNameSpec {
     fun `of parameterized types`() {
         val timestamp = ClassName(Timestamp::class)
         val comparator = ClassName(Comparator::class)
-        val timestampComparator = ParameterizedClassName(comparator, timestamp)
+        val timestampComparator = ParameterizedTypeName(comparator, timestamp)
         assertArrayName(
             timestampComparator,
             "java.util.Comparator<com.google.protobuf.Timestamp>[]"

--- a/java/src/test/kotlin/io/spine/protodata/java/ParameterizedTypeNameSpec.kt
+++ b/java/src/test/kotlin/io/spine/protodata/java/ParameterizedTypeNameSpec.kt
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-@DisplayName("`ParameterizedClassName` should")
-internal class ParameterizedClassNameSpec {
+@DisplayName("`ParameterizedTypeName` should")
+internal class ParameterizedTypeNameSpec {
 
     private val list = ClassName(List::class)
 
@@ -43,7 +43,7 @@ internal class ParameterizedClassNameSpec {
     inner class Accept {
 
         private val string = ClassName(String::class)
-        private val listOfStrings = ParameterizedClassName(list, string)
+        private val listOfStrings = ParameterizedTypeName(list, string)
 
         @Test
         fun `a class name as a parameter`() =
@@ -52,14 +52,14 @@ internal class ParameterizedClassNameSpec {
         @Test
         fun `generic variables as parameters`() {
             val map = ClassName(Map::class)
-            val genericMap = ParameterizedClassName(map, T, E)
+            val genericMap = ParameterizedTypeName(map, T, E)
             assertCode(genericMap, "java.util.Map<T, E>")
         }
 
         @Test
         fun `other parameterized classes`() {
             val comparator = ClassName(Comparator::class)
-            val comparatorOfLists = ParameterizedClassName(comparator, listOfStrings)
+            val comparatorOfLists = ParameterizedTypeName(comparator, listOfStrings)
             assertCode(comparatorOfLists, "java.util.Comparator<java.util.List<java.lang.String>>")
         }
 
@@ -70,7 +70,7 @@ internal class ParameterizedClassNameSpec {
                 override val canonical: String = arbitraryType
 
             }
-            val comparatorOfLists = ParameterizedClassName(list, typeName)
+            val comparatorOfLists = ParameterizedTypeName(list, typeName)
             assertCode(comparatorOfLists, "java.util.List<C super java.util.Collection>")
         }
     }
@@ -81,7 +81,7 @@ internal class ParameterizedClassNameSpec {
         @Test
         fun `throw if not given any parameters`() {
             assertThrows<IllegalArgumentException> {
-                ParameterizedClassName(list, emptyList())
+                ParameterizedTypeName(list, emptyList())
             }
         }
 
@@ -89,7 +89,7 @@ internal class ParameterizedClassNameSpec {
         fun `throw if given a primitive type as a parameter`() {
             JavaTypeName.KnownPrimitives.forEach { primitive ->
                 assertThrows<IllegalArgumentException> {
-                    ParameterizedClassName(list, primitive)
+                    ParameterizedTypeName(list, primitive)
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.93.4</version>
+<version>0.93.5</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.93.4")
+val protoDataVersion: String by extra("0.93.5")


### PR DESCRIPTION
This PR introduces `AnnotatedClassName` to hold a `ClassName` along with its annotation represented also by `ClassName`.

I've also renamed `ParametrizedClassName` to `ParametrizedTypeName`. Now it accepts `JavaTypeName` for a base. So, it is possible to annotate a class, and pass it to `ParametrizedTypeName` either as a base or as a parameter.

Now, the hierarchy of `JavaTypeName` looks like the following.

```
JavaTypeName
    AnnotatedClassName
    ParametrizedTypeName
    ClassName
    ArrayTypeName
    TypeVariableName
```

Needed for [validation #203](https://github.com/SpineEventEngine/validation/pull/203).