### PR TITLE
Add more `Option` extensions

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
@@ -157,24 +157,24 @@ public inline fun <reified T : Message> Field.option(): T = findOption<T>()
     ?: error("The field `${qualifiedName}` must have the `${simply<T>()}` option.")
 
 /**
- * Finds the option with the given generated type applied to this [Field].
+ * Finds the option applied to this [Field] by its generated extension type.
  *
- * @param [generated] The generated type used to represent the option.
+ * @param [extension] The extension type used to represent the option.
  * @return the option or `null` if there is no option with such a type applied to the field.
  * @see [option]
  */
-public fun Field.findOption(generated: GeneratedExtension<*, *>): Option? =
-    optionList.find { it.name == generated.descriptor.name && it.number == generated.number }
+public fun Field.findOption(extension: GeneratedExtension<*, *>): Option? =
+    optionList.find { it.name == extension.descriptor.name && it.number == extension.number }
 
 /**
- * Obtains the option with the given generated type applied to this [Field].
+ * Obtains the option applied to this [Field] by its generated extension type.
  *
- * Invoke this function if you are sure the option with the [generated] type is applied
- * to the receiver field. Otherwise, please use [findOption].
+ * Invoke this function if you are sure the option with the [extension] type
+ * is applied to the receiver field. Otherwise, please use [findOption].
  *
- * @param [generated] The generated type used to represent the option.
+ * @param [extension] The extension type used to represent the option.
  * @throws IllegalStateException if the option is not found.
  * @see [findOption]
  */
-public fun Field.option(generated: GeneratedExtension<*, *>): Option = findOption(generated)
-    ?: error("The field `${qualifiedName}` must have the `${generated.descriptor.name}` option.")
+public fun Field.option(extension: GeneratedExtension<*, *>): Option = findOption(extension)
+    ?: error("The field `${qualifiedName}` must have the `${extension.descriptor.name}` option.")

--- a/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/FieldExts.kt
@@ -28,6 +28,7 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.GeneratedMessage.GeneratedExtension
 import com.google.protobuf.Message
 import io.spine.protobuf.defaultInstance
 import io.spine.protodata.type.TypeSystem
@@ -154,3 +155,26 @@ public inline fun <reified T : Message> Field.findOption(): T? {
  */
 public inline fun <reified T : Message> Field.option(): T = findOption<T>()
     ?: error("The field `${qualifiedName}` must have the `${simply<T>()}` option.")
+
+/**
+ * Finds the option with the given generated type applied to this [Field].
+ *
+ * @param [generated] The generated type used to represent the option.
+ * @return the option or `null` if there is no option with such a type applied to the field.
+ * @see [option]
+ */
+public fun Field.findOption(generated: GeneratedExtension<*, *>): Option? =
+    optionList.find { it.name == generated.descriptor.name && it.number == generated.number }
+
+/**
+ * Obtains the option with the given generated type applied to this [Field].
+ *
+ * Invoke this function if you are sure the option with the [generated] type is applied
+ * to the receiver field. Otherwise, please use [findOption].
+ *
+ * @param [generated] The generated type used to represent the option.
+ * @throws IllegalStateException if the option is not found.
+ * @see [findOption]
+ */
+public fun Field.option(generated: GeneratedExtension<*, *>): Option = findOption(generated)
+    ?: error("The field `${qualifiedName}` must have the `${generated.descriptor.name}` option.")

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -63,9 +63,9 @@ public inline fun <reified T : Message> Option.unpack(): T =
     try {
         value.unpack<T>()
     } catch (e: UnexpectedTypeException) {
-        error(
+        throw IllegalStateException(
             "Cannot unpack the `($name)` option to `${T::class.simpleName}`. " +
-                    "The actual option type: `${type.name}`."
+                    "The actual option type: `${type.name}`.", e
         )
     }
 

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -28,6 +28,7 @@
 
 package io.spine.protodata.ast
 
+import com.google.protobuf.BoolValue
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.EnumValueDescriptor
@@ -38,6 +39,7 @@ import com.google.protobuf.Descriptors.GenericDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import com.google.protobuf.Descriptors.ServiceDescriptor
+import com.google.protobuf.GeneratedMessage.GeneratedExtension
 import com.google.protobuf.GeneratedMessageV3.ExtendableMessage
 import com.google.protobuf.Message
 import io.spine.base.EventMessage
@@ -61,6 +63,14 @@ public inline fun <reified T : Message> Option.unpack(): T =
  */
 public val Option.isColumn: Boolean
     get() = name == OptionsProto.column.descriptor.name
+
+/**
+ * Unpacks a [BoolValue] from this option.
+ *
+ * @throws io.spine.type.UnexpectedTypeException If the option stores a value of another type.
+ */
+public val Option.boolValue: Boolean
+    get() = value.unpack<BoolValue>().value
 
 /**
  * Looks up an option value by the [optionName].

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -75,7 +75,7 @@ public val Option.boolValue: Boolean
         value.unpack<BoolValue>().value
     } catch (e: UnexpectedTypeException) {
         error(
-            "Cannot unpack the `(${name})` option value to a boolean. " +
+            "Cannot unpack the `($name)` option to `${BoolValue::class.simpleName}`. " +
                     "The actual option type: `${type.name}`."
         )
     }

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -50,6 +50,7 @@ import io.spine.protobuf.pack
 import io.spine.protobuf.unpack
 import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.type
+import io.spine.type.UnexpectedTypeException
 import com.google.protobuf.Any as ProtoAny
 
 /**
@@ -67,10 +68,17 @@ public val Option.isColumn: Boolean
 /**
  * Unpacks a [BoolValue] from this option.
  *
- * @throws io.spine.type.UnexpectedTypeException If the option stores a value of another type.
+ * @throws IllegalStateException If the option stores a value of another type.
  */
 public val Option.boolValue: Boolean
-    get() = value.unpack<BoolValue>().value
+    get() = try {
+        value.unpack<BoolValue>().value
+    } catch (e: UnexpectedTypeException) {
+        error(
+            "Cannot unpack the `(${name})` option value to a boolean. " +
+                    "The actual option type: `${type.name}`."
+        )
+    }
 
 /**
  * Looks up an option value by the [optionName].

--- a/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OptionExts.kt
@@ -55,9 +55,20 @@ import com.google.protobuf.Any as ProtoAny
 
 /**
  * Unpacks the value of this option using the specified generic type.
+ *
+ * @throws IllegalArgumentException if the specified [T] does not denote a message class.
+ * @throws IllegalStateException If the option stores a value of another type.
  */
 public inline fun <reified T : Message> Option.unpack(): T =
-    value.unpack<T>()
+    try {
+        value.unpack<T>()
+    } catch (e: UnexpectedTypeException) {
+        error(
+            "Cannot unpack the `($name)` option to `${T::class.simpleName}`. " +
+                    "The actual option type: `${type.name}`."
+        )
+    }
+
 
 /**
  * Tells if this is a column option.
@@ -71,14 +82,7 @@ public val Option.isColumn: Boolean
  * @throws IllegalStateException If the option stores a value of another type.
  */
 public val Option.boolValue: Boolean
-    get() = try {
-        value.unpack<BoolValue>().value
-    } catch (e: UnexpectedTypeException) {
-        error(
-            "Cannot unpack the `($name)` option to `${BoolValue::class.simpleName}`. " +
-                    "The actual option type: `${type.name}`."
-        )
-    }
+    get() = value.unpack<BoolValue>().value
 
 /**
  * Looks up an option value by the [optionName].

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
@@ -109,7 +109,7 @@ internal class FieldExtsSpec {
     }
 
     @Test
-    fun `find the option by its generated type`() {
+    fun `find the option by its generated extension type`() {
         val field = Student.getDescriptor().field("id")
         field.findOption(OptionsProto.setOnce) shouldNotBe null
     }

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
@@ -29,9 +29,12 @@ package io.spine.protodata.ast
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.spine.option.OptionsProto
 import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
 import io.spine.protodata.ast.given.Driver
 import io.spine.protodata.ast.given.Tractor
+import io.spine.protodata.given.value.Student
+import io.spine.protodata.protobuf.field
 import io.spine.protodata.protobuf.toMessageType
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -103,5 +106,11 @@ internal class FieldExtsSpec {
             endLine shouldBe 69
             endColumn shouldBe 51
         }
+    }
+
+    @Test
+    fun `find the option by its generated type`() {
+        val field = Student.getDescriptor().field("id")
+        field.findOption(OptionsProto.setOnce) shouldNotBe null
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/FieldExtsSpec.kt
@@ -30,11 +30,14 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.spine.option.OptionsProto
+import io.spine.protobuf.field
 import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
+import io.spine.protodata.ast.given.Citizen
 import io.spine.protodata.ast.given.Driver
 import io.spine.protodata.ast.given.Tractor
 import io.spine.protodata.given.value.Student
 import io.spine.protodata.protobuf.field
+import io.spine.protodata.protobuf.toField
 import io.spine.protodata.protobuf.toMessageType
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -110,7 +113,9 @@ internal class FieldExtsSpec {
 
     @Test
     fun `find the option by its generated extension type`() {
-        val field = Student.getDescriptor().field("id")
+        val field = Student.getDescriptor()
+            .field(Student.ID_FIELD_NUMBER)!!
+            .toField()
         field.findOption(OptionsProto.setOnce) shouldNotBe null
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -34,6 +34,7 @@ import io.spine.protodata.ast.given.NotificationRequest
 import io.spine.protodata.ast.given.NotificationService
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
+import io.spine.protodata.given.value.Citizen
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -204,6 +205,13 @@ internal class OptionExtsSpec {
                 }
             }
         }
+    }
+
+    @Test
+    fun `return value of a boolean option`() {
+        val option = Citizen.getDescriptor().options()
+            .first()
+        option.boolValue shouldBe true
     }
 }
 

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -30,11 +30,11 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
 import io.spine.protobuf.field
+import io.spine.protodata.ast.given.Citizen
 import io.spine.protodata.ast.given.NotificationRequest
 import io.spine.protodata.ast.given.NotificationService
 import io.spine.protodata.ast.given.OptionExtsSpecProto
 import io.spine.protodata.ast.given.Selector
-import io.spine.protodata.given.value.Citizen
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -209,8 +209,7 @@ internal class OptionExtsSpec {
 
     @Test
     fun `return value of a boolean option`() {
-        val option = Citizen.getDescriptor().options()
-            .first()
+        val option = Citizen.getDescriptor().options().first()
         option.boolValue shouldBe true
     }
 }

--- a/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
+++ b/api/src/test/kotlin/io/spine/protodata/ast/OptionExtsSpec.kt
@@ -29,6 +29,7 @@ package io.spine.protodata.ast
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
+import io.spine.option.OptionsProto
 import io.spine.protobuf.field
 import io.spine.protodata.ast.given.Citizen
 import io.spine.protodata.ast.given.NotificationRequest
@@ -209,7 +210,10 @@ internal class OptionExtsSpec {
 
     @Test
     fun `return value of a boolean option`() {
-        val option = Citizen.getDescriptor().options().first()
+        val option = Citizen.getDescriptor()
+            .field(Citizen.TAX_CODE_FIELD_NUMBER)!!
+            .options().first()
+        option.name shouldBe OptionsProto.required.descriptor.name
         option.boolValue shouldBe true
     }
 }

--- a/api/src/test/proto/protodata/ast/option_exts_spec.proto
+++ b/api/src/test/proto/protodata/ast/option_exts_spec.proto
@@ -153,3 +153,8 @@ message PushNotification {
     string title = 2;
     string body = 3;
 }
+
+// The message with a boolean option.
+message Citizen {
+    string tax_code = 1 [(required) = true];
+}

--- a/api/src/test/proto/protodata/given/field_option_samples.proto
+++ b/api/src/test/proto/protodata/given/field_option_samples.proto
@@ -88,3 +88,8 @@ message Misreferences {
     // The field for checking nested paths.
     Range range = 10 [(required) = true];
 }
+
+// The message with a boolean option.
+message Student {
+    string id = 1 [(set_once) = true];
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-api:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1113,12 +1113,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.8`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1955,12 +1955,12 @@ This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-backend:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3069,12 +3069,12 @@ This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-cli:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4218,12 +4218,12 @@ This report was generated on **Fri Mar 28 15:50:22 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5259,12 +5259,12 @@ This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6388,12 +6388,12 @@ This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-java:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7502,12 +7502,12 @@ This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-params:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8619,12 +8619,12 @@ This report was generated on **Fri Mar 28 15:50:23 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.93.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9454,12 +9454,12 @@ This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10575,12 +10575,12 @@ This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.93.7`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.93.8`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11815,4 +11815,4 @@ This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 15:50:24 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 31 16:14:42 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.93.7</version>
+<version>0.93.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.93.7")
+val protoDataVersion: String by extra("0.93.8")


### PR DESCRIPTION
This PR adds the following options:

1. `fun Field.findOption(extension: GeneratedExtension<*, *>): Option?` – finds the option by its extension type descriptor.
2. `val Option.boolValue: Boolean` – unpacks this `Option` as `BoolValue`, and returns the value.

The `fun Option.unpack<>()` has been wrapped into try-catch, so that `IllegalStateException` is thrown with a more specific message.