### PR TITLE
Supply `OneofOptionDiscrovered` with `subject` field

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protodata.ast
+
+/**
+ * Creates a new instance of [OneofRef] for this [OneofGroup].
+ */
+public val OneofGroup.ref: OneofRef
+    get() = oneofRef {
+        type = declaringType
+        name = this@ref.name
+    }

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -43,14 +43,16 @@ public fun OneofDescriptor.name(): OneofName = oneofName { value = name }
 /**
  * Converts this `oneof` descriptor to [OneofGroup].
  */
-public fun OneofDescriptor.toOneOfGroup(): OneofGroup =
-    oneofGroup {
-        val self = this@toOneOfGroup
-        val groupName = name()
-        name = groupName
+public fun OneofDescriptor.toOneOfGroup(): OneofGroup  {
+    val self = this@toOneOfGroup
+    val messageType = containingType
+    return oneofGroup {
+        name = name()
+        declaringType = messageType.name()
         field.addAll(fields.mapped())
         option.addAll(options())
-        val messageType = containingType
         doc = messageType.documentation().forOneof(self)
         span = messageType.coordinates().forOneof(self)
     }
+}
+

--- a/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/protobuf/OneofDescriptorExts.kt
@@ -55,4 +55,3 @@ public fun OneofDescriptor.toOneOfGroup(): OneofGroup  {
         span = messageType.coordinates().forOneof(self)
     }
 }
-

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -391,6 +391,16 @@ message OneofGroup {
     Span span = 5;
 }
 
+// Uniquely identifies a `oneof` group declaration within a compilation process.
+message OneofRef {
+
+    // The name of the declaring type.
+    TypeName type = 1;
+
+    // The name of the group.
+    OneofName name = 2;
+}
+
 // A name of a Protobuf service type.
 message ServiceName {
     option (is).java_type = "ServiceNameMixin";

--- a/api/src/main/proto/spine/protodata/ast.proto
+++ b/api/src/main/proto/spine/protodata/ast.proto
@@ -372,6 +372,9 @@ message OneofGroup {
 
     OneofName name = 1 [(required) = true];
 
+    // A type in which the `oneof` is declared.
+    TypeName declaring_type = 6 [(required) = true];
+
     // Fields declared in this group.
     //
     // The fields are ordered by their order of declaration in the group.

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -136,8 +136,8 @@ message OneofOptionDiscovered {
     // The file in which the `oneof` group is defined.
     File file = 1 [(required) = true];
 
-    // The type in which the `oneof` group is defined.
-    TypeName type = 2 [(required) = true];
+    // Deprecated: use `subject` instead.
+    TypeName type = 2 [(required) = true, deprecated = true];
 
     // Deprecated: please use `subject` instead.
     OneofName group = 3 [(required) = true, deprecated = true];

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -139,8 +139,11 @@ message OneofOptionDiscovered {
     // The type in which the `oneof` group is defined.
     TypeName type = 2 [(required) = true];
 
+    // Deprecated: please use `subject` instead.
+    OneofName group = 3 [(required) = true, deprecated = true];
+
     // The `oneof` group in which the option is discovered.
-    OneofName group = 3 [(required) = true];
+    OneofGroup subject = 5 [(required) = true];
 
     // The discovered option.
     Option option = 4 [(required) = true];

--- a/api/src/main/proto/spine/protodata/events.proto
+++ b/api/src/main/proto/spine/protodata/events.proto
@@ -137,10 +137,10 @@ message OneofOptionDiscovered {
     File file = 1 [(required) = true];
 
     // Deprecated: use `subject` instead.
-    TypeName type = 2 [(required) = true, deprecated = true];
+    TypeName type = 2 [deprecated = true];
 
     // Deprecated: please use `subject` instead.
-    OneofName group = 3 [(required) = true, deprecated = true];
+    OneofName group = 3 [deprecated = true];
 
     // The `oneof` group in which the option is discovered.
     OneofGroup subject = 5 [(required) = true];

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
@@ -140,6 +140,7 @@ internal class MessageEvents(header: ProtoFileHeader) : DeclarationEvents<Descri
         val oneofName = desc.name()
         val oneofGroup = oneofGroup {
             name = oneofName
+            declaringType = typeName
             doc = documentation.forOneof(desc)
         }
         val path = header.file
@@ -153,8 +154,7 @@ internal class MessageEvents(header: ProtoFileHeader) : DeclarationEvents<Descri
         produceOptionEvents(desc.options, desc) {
             oneofOptionDiscovered {
                 file = path
-                type = typeName
-                group = oneofName
+                subject = oneofGroup
                 option = it
             }
         }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-api:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1113,12 +1113,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:31 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.9`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1955,12 +1955,12 @@ This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:31 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-backend:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3069,12 +3069,12 @@ This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:32 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-cli:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4218,12 +4218,12 @@ This report was generated on **Mon Mar 31 16:14:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:32 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5259,12 +5259,12 @@ This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:32 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6388,12 +6388,12 @@ This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:33 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-java:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7502,12 +7502,12 @@ This report was generated on **Mon Mar 31 16:14:40 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:33 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-params:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8619,12 +8619,12 @@ This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:33 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.93.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9454,12 +9454,12 @@ This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:33 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10575,12 +10575,12 @@ This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:34 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.93.8`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.93.9`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11815,4 +11815,4 @@ This report was generated on **Mon Mar 31 16:14:41 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 31 16:14:42 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 14:56:34 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.93.8</version>
+<version>0.93.9</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.93.8")
+val protoDataVersion: String by extra("0.93.9")


### PR DESCRIPTION
This PR does the following:

1. Supplies `OneofOptionDiscovered` with the `subject` field similarly to `FieldOptionDiscovered` event.
2. Supplies `OneofGroup` with the `declaring_type` field similarly to the `Field` message.
3. Introduces `OneofRef` similarly to `FieldRef`.

The changeset brings more consistency within the API, allowing handling of `OneofOptionDiscovered` events in the same manner we do for `FieldOptionDiscovered`. 
