### PR TITLE
Fill in the `span` property of `OneofGroup`

### DIFF
--- a/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/Coordinates.kt
@@ -161,7 +161,7 @@ private fun Location.toSpan(): Span {
 }
 
 /**
- * Obtains coordinates for the file this [GenericDescriptor].
+ * Obtains coordinates for this [GenericDescriptor].
  */
 internal fun GenericDescriptor.coordinates(): Coordinates {
     val fromResources = withSourceLines()

--- a/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
@@ -36,7 +36,7 @@ public val OneofGroup.ref: OneofRef
     }
 
 /**
- * The field name containing a qualified name of the declaring type.
+ * The qualified name of this [OneofGroup].
  */
 public val OneofGroup.qualifiedName: String
     get() = "${declaringType.qualifiedName}.${name.value}"

--- a/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
+++ b/api/src/main/kotlin/io/spine/protodata/ast/OneofGroupExts.kt
@@ -34,3 +34,9 @@ public val OneofGroup.ref: OneofRef
         type = declaringType
         name = this@ref.name
     }
+
+/**
+ * The field name containing a qualified name of the declaring type.
+ */
+public val OneofGroup.qualifiedName: String
+    get() = "${declaringType.qualifiedName}.${name.value}"

--- a/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
+++ b/backend/src/main/kotlin/io/spine/protodata/backend/event/MessageEvents.kt
@@ -30,7 +30,6 @@ import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.OneofDescriptor
 import io.spine.base.EventMessage
-import io.spine.protodata.ast.Documentation
 import io.spine.protodata.ast.ProtoFileHeader
 import io.spine.protodata.ast.event.FieldEntered
 import io.spine.protodata.ast.event.FieldExited
@@ -46,13 +45,13 @@ import io.spine.protodata.ast.event.typeDiscovered
 import io.spine.protodata.ast.event.typeEntered
 import io.spine.protodata.ast.event.typeExited
 import io.spine.protodata.ast.event.typeOptionDiscovered
-import io.spine.protodata.ast.oneofGroup
 import io.spine.protodata.ast.produceOptionEvents
 import io.spine.protodata.ast.withAbsoluteFile
 import io.spine.protodata.protobuf.name
 import io.spine.protodata.protobuf.realNestedTypes
 import io.spine.protodata.protobuf.toField
 import io.spine.protodata.protobuf.toMessageType
+import io.spine.protodata.protobuf.toOneOfGroup
 
 /**
  * Produces events for a message.
@@ -135,19 +134,14 @@ internal class MessageEvents(header: ProtoFileHeader) : DeclarationEvents<Descri
     private suspend fun SequenceScope<EventMessage>.produceOneofEvents(
         desc: OneofDescriptor
     ) {
-        val typeName = desc.containingType.name()
-        val documentation = Documentation.of(desc.containingType.file)
+        val containingType = desc.containingType.name()
         val oneofName = desc.name()
-        val oneofGroup = oneofGroup {
-            name = oneofName
-            declaringType = typeName
-            doc = documentation.forOneof(desc)
-        }
+        val oneofGroup = desc.toOneOfGroup()
         val path = header.file
         yield(
             oneofGroupEntered {
                 file = path
-                type = typeName
+                type = containingType
                 group = oneofGroup
             }
         )
@@ -164,7 +158,7 @@ internal class MessageEvents(header: ProtoFileHeader) : DeclarationEvents<Descri
         yield(
             oneofGroupExited {
                 file = path
-                type = typeName
+                type = containingType
                 group = oneofName
             }
         )

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.300"
+    const val version = "2.0.0-SNAPSHOT.301"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Time {
-    const val version = "2.0.0-SNAPSHOT.200"
+    const val version = "2.0.0-SNAPSHOT.202"
     const val group = Spine.group
     const val artifact = "spine-time"
     const val lib = "$group:$artifact:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.protodata:protodata-api:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-api:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1113,12 +1113,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:36 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:09 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-api-tests:0.93.11`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1955,12 +1955,12 @@ This report was generated on **Fri Apr 04 17:20:36 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:37 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:09 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-backend:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-backend:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3069,12 +3069,12 @@ This report was generated on **Fri Apr 04 17:20:37 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:37 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:09 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-cli:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-cli:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4218,12 +4218,12 @@ This report was generated on **Fri Apr 04 17:20:37 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:10 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-gradle-api:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5259,12 +5259,12 @@ This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:10 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-gradle-plugin:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6388,12 +6388,12 @@ This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:10 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-java:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-java:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7502,12 +7502,12 @@ This report was generated on **Fri Apr 04 17:20:38 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:11 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-params:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-params:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8619,12 +8619,12 @@ This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:11 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-protoc:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-protoc:0.93.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9454,12 +9454,12 @@ This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:11 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-test-env:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-test-env:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10575,12 +10575,12 @@ This report was generated on **Fri Apr 04 17:20:39 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:11 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.protodata:protodata-testlib:0.93.10`
+# Dependencies of `io.spine.protodata:protodata-testlib:0.93.11`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11815,4 +11815,4 @@ This report was generated on **Fri Apr 04 17:20:40 CEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 04 17:20:40 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 14 13:39:12 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
@@ -73,10 +73,19 @@ public fun TypeName.javaClassName(accordingTo: ProtoFileHeader): ClassName =
  * @param typeSystem The type system to be used for obtaining the header for the proto
  *   file in which this message type is declared.
  */
-public fun TypeName.javaClassName(typeSystem: TypeSystem): ClassName {
-    val header = typeSystem.findMessageOrEnum(this)?.second
+public fun TypeName.javaClassName(typeSystem: TypeSystem): ClassName =
+    findJavaClassName(typeSystem)
         ?: error("Cannot find Java `${simply<ClassName>()}` for the Protobuf `${qualifiedName}`.")
-    val className = javaClassName(header)
+
+/**
+ * Finds a fully qualified Java class name, generated for the Protobuf type with this name.
+ *
+ * @param typeSystem The type system to be used for obtaining the header for the proto
+ *   file in which this message type is declared.
+ */
+public fun TypeName.findJavaClassName(typeSystem: TypeSystem): ClassName? {
+    val header = typeSystem.findMessageOrEnum(this)?.second
+    val className = header?.let { javaClassName(it) }
     return className
 }
 

--- a/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
+++ b/java/src/main/kotlin/io/spine/protodata/java/TypeNameExts.kt
@@ -55,7 +55,7 @@ public fun TypeName.javaFile(accordingTo: ProtoFileHeader): Path {
 }
 
 /**
- * Obtains a fully qualified Java class name, generated for the Protobuf type with this name.
+ * Obtains a Java class name, generated for the Protobuf type with this name.
  *
  * @param accordingTo The header of the proto file in which the type is declared.
  */
@@ -68,7 +68,7 @@ public fun TypeName.javaClassName(accordingTo: ProtoFileHeader): ClassName =
     })
 
 /**
- * Obtains a fully qualified Java class name, generated for the Protobuf type with this name.
+ * Obtains a Java class name, generated for the Protobuf type with this name.
  *
  * @param typeSystem The type system to be used for obtaining the header for the proto
  *   file in which this message type is declared.
@@ -78,7 +78,7 @@ public fun TypeName.javaClassName(typeSystem: TypeSystem): ClassName =
         ?: error("Cannot find Java `${simply<ClassName>()}` for the Protobuf `${qualifiedName}`.")
 
 /**
- * Finds a fully qualified Java class name, generated for the Protobuf type with this name.
+ * Finds a Java class name, generated for the Protobuf type with this name.
  *
  * @param typeSystem The type system to be used for obtaining the header for the proto
  *   file in which this message type is declared.
@@ -90,7 +90,7 @@ public fun TypeName.findJavaClassName(typeSystem: TypeSystem): ClassName? {
 }
 
 /**
- * Obtains a fully qualified Java enum type name, generated for the Protobuf enum with this name.
+ * Obtains a Java enum type name, generated for the Protobuf enum with this name.
  */
 public fun TypeName.javaEnumName(accordingTo: ProtoFileHeader): EnumName =
     composeJavaTypeName(accordingTo, {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.protodata</groupId>
 <artifactId>ProtoData</artifactId>
-<version>0.93.10</version>
+<version>0.93.11</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -110,7 +110,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.300</version>
+    <version>2.0.0-SNAPSHOT.301</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -206,13 +206,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.300</version>
+    <version>2.0.0-SNAPSHOT.301</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-time-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.200</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val protoDataVersion: String by extra("0.93.10")
+val protoDataVersion: String by extra("0.93.11")


### PR DESCRIPTION
This PR re-uses the `OneofDescriptor.toOneOfGroup()` method to create `OneofGroup` instance. Created this way, the `OneofGroup.span` field will be correctly populated. Thus, emitted compilation errors will point to the correct file and position.

Other changes are the following:

1. Added `OneofGroup.qualifiedName` extension, as we have for `Field`.
2. Added `TypeName.findJavaClassName()` counterpart that returns a nullable result instead of throwing.
3. Took the latest `core-java` to pick up the latest changes in `spine-time`.